### PR TITLE
Fixed #21: Fixed incorrect Anaconda detection in install and uninstall scripts.

### DIFF
--- a/install
+++ b/install
@@ -7,7 +7,7 @@ if [ "${CONDA_EXE} " == " " ]; then
     CONDA_EXE=$((find /opt/conda/bin/conda || find ~/anaconda3/bin/conda) 2>/dev/null)
 fi
 
-if ! ${CONDA_EXE} info > /dev/null 2>&1; then
+if [ "${CONDA_EXE}_" == "_" ]; then
     echo "Please install Anaconda w/ Python 3.7+ first"
     echo "See: https://www.anaconda.com/distribution/"
     exit 1

--- a/uninstall
+++ b/uninstall
@@ -7,7 +7,7 @@ if [ "${CONDA_EXE} " == " " ]; then
     CONDA_EXE=$((find /opt/conda/bin/conda || find ~/anaconda3/bin/conda) 2>/dev/null)
 fi
 
-if ! ${CONDA_EXE} info > /dev/null 2>&1; then
+if [ "${CONDA_EXE}_" == "_" ]; then
     echo "Please install Anaconda w/ Python 3.7+ first"
     echo "See: https://www.continuum.io/downloads"
     exit 1


### PR DESCRIPTION
As title.

The old `${CONDA_EXE} info` detection method would always succeed, even without Anaconda installed, because `info` is a valid shell command by itself. The fix is to test whether the detected Anaconda path to be empty or not.