### PR TITLE
(fix) anaconda version for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: ~/hummingbot
     docker:
       # Specify base image: using Anaconda
-      - image: continuumio/anaconda
+      - image: continuumio/anaconda3:2018.12
     steps:
       - checkout
 


### PR DESCRIPTION
The continuumio/anaconda3 package on docker hub was updated to a version that did not have certificates.  This resulted in an error that prevented circleci from running the container:

`x509: certificate signed by unknown authority`.

This fix specifies the anaconda3 tag, using the previous version `2018.12`, allowing circleci to run the container and perform its tests