### PR TITLE
Quick fix for duplicate orders during stop and start.

### DIFF
--- a/hummingbot/cli/hummingbot_application.py
+++ b/hummingbot/cli/hummingbot_application.py
@@ -592,6 +592,10 @@ class HummingbotApplication:
     async def stop(self, skip_order_cancellation: bool = False):
         self.app.log("\nWinding down...")
         if not skip_order_cancellation:
+            # Remove the strategy from clock before cancelling orders, to
+            # prevent race condition where the strategy tries to create more
+            # ordres during cancellation.
+            self.clock.remove_iterator(self.strategy)
             success = await self._cancel_outstanding_orders()
             if success:
                 # Only erase markets when cancellation has been successful


### PR DESCRIPTION
This is a quick fix which fixes a race condition between cancel orders and the running strategy during the `stop` command - an issue which ultimately caused duplicate orders to be issued and are left not cancelled.