### PR TITLE
(fix) Ignore market order done messages for Coinbase websocket

### DIFF
--- a/wings/data_source/coinbase_pro_api_order_book_data_source.py
+++ b/wings/data_source/coinbase_pro_api_order_book_data_source.py
@@ -205,8 +205,8 @@ class CoinbaseProAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         elif msg_type == "error":
                             raise ValueError(f"Coinbase Pro Websocket received error message - {msg['message']}")
                         elif msg_type in ["open", "match", "change", "done"]:
-                            if msg_type == "match" and "price" not in msg:
-                                # match messages with no price are completed market orders which can be ignored
+                            if msg_type == "done" and "price" not in msg:
+                                # done messages with no price are completed market orders which can be ignored
                                 continue
                             order_book_message: OrderBookMessage = self.order_book_class.diff_message_from_exchange(msg)
                             output.put_nowait(order_book_message)

--- a/wings/data_source/coinbase_pro_api_order_book_data_source.py
+++ b/wings/data_source/coinbase_pro_api_order_book_data_source.py
@@ -205,11 +205,14 @@ class CoinbaseProAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         elif msg_type == "error":
                             raise ValueError(f"Coinbase Pro Websocket received error message - {msg['message']}")
                         elif msg_type in ["open", "match", "change", "done"]:
+                            if msg_type == "match" and "price" not in msg:
+                                # match messages with no price are completed market orders which can be ignored
+                                continue
                             order_book_message: OrderBookMessage = self.order_book_class.diff_message_from_exchange(msg)
                             output.put_nowait(order_book_message)
                         elif msg_type in ["received", "activate", "subscriptions"]:
                             # these messages are not needed to track the order book
-                            pass
+                            continue
                         else:
                             raise ValueError(f"Unrecognized Coinbase Pro Websocket message received - {msg}")
             except asyncio.CancelledError:


### PR DESCRIPTION
Order book does not need to consume market order done messages.