### PR TITLE
Added logic to autoincrement debug console port, to allow multiple instances to run in debug mode.

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -16,6 +16,8 @@ else:
     sys.path.insert(0, realpath(join(__file__, "../../")))
 
 import asyncio
+import errno
+import socket
 from typing import (
     List,
     Coroutine
@@ -35,6 +37,20 @@ from hummingbot.cli.ui.stdout_redirection import patch_stdout
 from hummingbot.management.console import start_management_console
 
 
+def detect_available_port(starting_port: int) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        current_port: int = starting_port
+        while current_port < 65535:
+            try:
+                s.bind(("127.0.0.1", current_port))
+                break
+            except OSError as e:
+                if e.errno == errno.EADDRINUSE:
+                    current_port += 1
+                    continue
+        return current_port
+
+
 async def main():
     await create_yml_files()
     read_configs_from_yml()
@@ -47,7 +63,8 @@ async def main():
                      override_log_level=global_config_map.get("log_level").value)
         tasks: List[Coroutine] = [hb.run()]
         if global_config_map.get("debug_console").value:
-            tasks.append(start_management_console(locals(), host="localhost", port=8211))
+            management_port: int = detect_available_port(8211)
+            tasks.append(start_management_console(locals(), host="localhost", port=management_port))
         await asyncio.gather(*tasks)
 
 if __name__ == "__main__":

--- a/hummingbot/management/console.py
+++ b/hummingbot/management/console.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import aioconsole
+import logging
 from typing import Dict
 
 
@@ -15,4 +16,5 @@ async def start_management_console(local_vars: Dict = locals(),
 
     retval = await aioconsole.start_interactive_server(host=host, port=port, banner=banner,
                                                        factory=factory_method)
+    logging.getLogger(__name__).info(f"Started debug console at {host}:{port}.")
     return retval


### PR DESCRIPTION


**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This patch adds auto-increment logic to the debug console's TCP port. This allows multiple hummingbot instances to run with debug console turned on.