### PR TITLE
fix / fix duplicate log bug

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -55,8 +55,6 @@ async def main():
     await create_yml_files()
     read_configs_from_yml()
 
-    init_logging("hummingbot_logs.yml")
-
     hb = HummingbotApplication()
     with patch_stdout(log_field=hb.app.log_field):
         init_logging("hummingbot_logs.yml",

--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -55,6 +55,7 @@ async def main():
     await create_yml_files()
     read_configs_from_yml()
 
+    init_logging("hummingbot_logs.yml")
     hb = HummingbotApplication()
     with patch_stdout(log_field=hb.app.log_field):
         init_logging("hummingbot_logs.yml",

--- a/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
+++ b/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
@@ -40,52 +40,52 @@ handlers:
 loggers:
     hummingbot.public_eth_address:
         level: INFO
-        propagate: no
+        propagate: false
         handlers: [report_proxy_handler]
     hummingbot.command_history:
         level: INFO
-        propagate: no
+        propagate: false
         handlers: ["null"]
     hummingbot.logger.report_aggregator:
         level: METRIC_LOG
         handlers: [report_proxy_handler, console_warning]
-        propagate: no
+        propagate: false
     hummingbot.logger.log_server_client:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, file_handler]
     hummingbot.logger.reporting_proxy_handler:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, file_handler]
     hummingbot.strategy:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     wings.event_reporter:
         level: EVENT_LOG
         handlers: [file_handler]
-        propagate: no
+        propagate: false
     wings.tracker:
         level: WARNING
         handlers: [console_warning, file_handler]
-        propagate: no
+        propagate: false
     wings.data_source:
         level: WARNING
         handlers: [console_warning, file_handler]
-        propagate: no
+        propagate: false
     wings.wallet:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     wings.market:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     conf:
         level: INFO
         handlers: ["null"]
-        propagate: no
+        propagate: false
 
 root:
     level: INFO

--- a/hummingbot/templates/log_templates/hummingbot_logs_full_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_full_TEMPLATE.yml
@@ -40,52 +40,52 @@ handlers:
 loggers:
     hummingbot.public_eth_address:
         level: INFO
-        propagate: no
+        propagate: false
         handlers: [report_proxy_handler]
     hummingbot.command_history:
         level: INFO
-        propagate: no
+        propagate: false
         handlers: [report_proxy_handler]
     hummingbot.logger.report_aggregator:
         level: METRIC_LOG
         handlers: [report_proxy_handler, console_warning]
-        propagate: no
+        propagate: false
     hummingbot.logger.log_server_client:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, report_proxy_handler, file_handler]
     hummingbot.logger.reporting_proxy_handler:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, report_proxy_handler, file_handler]
     hummingbot.strategy:
         level: INFO
         handlers: [console, report_proxy_handler, file_handler]
-        propagate: no
+        propagate: false
     wings.event_reporter:
         level: EVENT_LOG
         handlers: [report_proxy_handler, file_handler]
-        propagate: no
+        propagate: false
     wings.tracker:
         level: WARNING
         handlers: [console_warning, report_proxy_handler, file_handler]
-        propagate: no
+        propagate: false
     wings.data_source:
         level: WARNING
         handlers: [console_warning, report_proxy_handler, file_handler]
-        propagate: no
+        propagate: false
     wings.wallet:
         level: INFO
         handlers: [console, report_proxy_handler, file_handler]
-        propagate: no
+        propagate: false
     wings.market:
         level: INFO
         handlers: [console, report_proxy_handler, file_handler]
-        propagate: no
+        propagate: false
     conf:
         level: INFO
         handlers: ["null", report_proxy_handler]
-        propagate: no
+        propagate: false
 
 root:
     level: INFO

--- a/hummingbot/templates/log_templates/hummingbot_logs_none_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_none_TEMPLATE.yml
@@ -49,43 +49,43 @@ loggers:
     hummingbot.logger.report_aggregator:
         level: METRIC_LOG
         handlers: [console_warning]
-        propagate: no
+        propagate: false
     hummingbot.logger.log_server_client:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, file_handler]
     hummingbot.logger.reporting_proxy_handler:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, file_handler]
     hummingbot.strategy:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     wings.event_reporter:
         level: EVENT_LOG
         handlers: [file_handler]
-        propagate: no
+        propagate: false
     wings.tracker:
         level: WARNING
         handlers: [console_warning, file_handler]
-        propagate: no
+        propagate: false
     wings.data_source:
         level: WARNING
         handlers: [console_warning, file_handler]
-        propagate: no
+        propagate: false
     wings.wallet:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     wings.market:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     conf:
         level: INFO
         handlers: ["null"]
-        propagate: no
+        propagate: false
 
 root:
     level: INFO

--- a/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
@@ -40,52 +40,52 @@ handlers:
 loggers:
     hummingbot.public_eth_address:
         level: INFO
-        propagate: no
+        propagate: false
         handlers: [report_proxy_handler]
     hummingbot.command_history:
         level: INFO
-        propagate: no
+        propagate: false
         handlers: ["null"]
     hummingbot.logger.report_aggregator:
         level: METRIC_LOG
         handlers: [report_proxy_handler, console_warning]
-        propagate: no
+        propagate: false
     hummingbot.logger.log_server_client:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, file_handler]
     hummingbot.logger.reporting_proxy_handler:
         level: WARNING
-        propagate: no
+        propagate: false
         handlers: [console, file_handler]
     hummingbot.strategy:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     wings.event_reporter:
         level: EVENT_LOG
         handlers: [file_handler]
-        propagate: no
+        propagate: false
     wings.tracker:
         level: WARNING
         handlers: [console_warning, file_handler]
-        propagate: no
+        propagate: false
     wings.data_source:
         level: WARNING
         handlers: [console_warning, file_handler]
-        propagate: no
+        propagate: false
     wings.wallet:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     wings.market:
         level: INFO
         handlers: [console, file_handler]
-        propagate: no
+        propagate: false
     conf:
         level: INFO
         handlers: ["null"]
-        propagate: no
+        propagate: false
 
 root:
     level: INFO


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story: https://app.clubhouse.io/coinalpha/story/3643/duplicate-log-messages-bug


**A description of the changes proposed in the pull request**:
@martinkou After the change in `hummingbot/__init_-.py`, we are now using ruamel.yaml to load logging configs. The issue is that ruamel.yaml loads "no" in "propagate: no" as a string, which then evaluates to `True` when turned into a boolean. This causes duplicate logs. Changing "propagate: no" to "propagate: false" solves the problem.
