### PR TITLE
Treat "unknown order" error from cancelling Binance order as successful.

### DIFF
--- a/wings/market/ddex_market.pyx
+++ b/wings/market/ddex_market.pyx
@@ -202,7 +202,7 @@ cdef class DDEXMarket(MarketBase):
     API_CALL_TIMEOUT = 10.0
     DDEX_REST_ENDPOINT = "https://api.ddex.io/v3"
 
-    ORDER_EXPIRY_TIME = 3600.0
+    ORDER_EXPIRY_TIME = 15 * 60.0
 
     @classmethod
     def logger(cls) -> logging.Logger:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:

This partially fixes https://app.clubhouse.io/coinalpha/story/3510/binance-error-when-running-xemm

**A description of the changes proposed in the pull request**:
- Treat the "unknown order" error from Binance cancel order as successful - since the order isn't there.
- Shortened the cancelled order polling duration from 60 minutes to 15 minutes for DDEX, to reduce the order polling load.