### PR TITLE
If an order has failed at creation, then it should not be tracked.

### DIFF
--- a/wings/market/binance_market.pyx
+++ b/wings/market/binance_market.pyx
@@ -871,6 +871,7 @@ cdef class BinanceMarket(MarketBase):
         except asyncio.CancelledError:
             raise
         except Exception:
+            self.c_stop_tracking_order(order_id)
             order_type_str = 'MARKET' if order_type == OrderType.MARKET else 'LIMIT'
             self.logger().error(f"Error submitting buy {order_type_str} order to Binance for "
                                 f"{decimal_amount} {symbol} {price}.",
@@ -935,6 +936,7 @@ cdef class BinanceMarket(MarketBase):
         except asyncio.CancelledError:
             raise
         except Exception:
+            self.c_stop_tracking_order(order_id)
             order_type_str = 'MARKET' if order_type == OrderType.MARKET else 'LIMIT'
             self.logger().error(f"Error submitting sell {order_type_str} order to Binance for "
                                 f"{decimal_amount} {symbol} {price}.",

--- a/wings/market/coinbase_pro_market.pyx
+++ b/wings/market/coinbase_pro_market.pyx
@@ -625,6 +625,7 @@ cdef class CoinbaseProMarket(MarketBase):
         except asyncio.CancelledError:
             raise
         except Exception:
+            self.c_stop_tracking_order(order_id)
             order_type_str = "MARKET" if order_type == OrderType.MARKET else "LIMIT"
             self.logger().error(f"Error submitting buy {order_type_str} order to Coinbase Pro for "
                                 f"{decimal_amount} {symbol} {price}.", exc_info=True)
@@ -669,6 +670,7 @@ cdef class CoinbaseProMarket(MarketBase):
         except asyncio.CancelledError:
             raise
         except Exception:
+            self.c_stop_tracking_order(order_id)
             order_type_str = "MARKET" if order_type == OrderType.MARKET else "LIMIT"
             self.logger().error(f"Error submitting sell {order_type_str} order to Coinbase Pro for "
                                 f"{decimal_amount} {symbol} {price}.", exc_info=True)

--- a/wings/market/radar_relay_market.pyx
+++ b/wings/market/radar_relay_market.pyx
@@ -799,6 +799,7 @@ cdef class RadarRelayMarket(MarketBase):
 
             return order_id
         except Exception:
+            self.c_stop_tracking_order(order_id)
             self.logger().error(f"Error submitting trade order to Radar Relay for {str(q_amt)} {symbol}.", exc_info=True)
             self.c_trigger_event(
                 self.MARKET_TRANSACTION_FAILURE_EVENT_TAG,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
This is a partial fix to https://app.clubhouse.io/coinalpha/story/3510/binance-error-when-running-xemm

**A description of the changes proposed in the pull request**:
- If an order has failed to be created, then it should not be tracked in the future. This prevents further error messages about failing to poll the order or failing the cancel the non-existent order.