### PR TITLE
Fixed an issue in Binance market cancel_all() where non-existent orders can stll block.

### DIFF
--- a/wings/market/binance_market.pyx
+++ b/wings/market/binance_market.pyx
@@ -963,7 +963,10 @@ cdef class BinanceMarket(MarketBase):
                 self.logger().info(f"The order {order_id} does not exist on Binance. No cancellation needed.")
                 self.c_trigger_event(self.MARKET_ORDER_CANCELLED_EVENT_TAG,
                                      OrderCancelledEvent(self._current_timestamp, order_id))
-                return {}
+                return {
+                    # Required by cancel_all() below.
+                    "origClientOrderId": order_id
+                }
 
         if isinstance(cancel_result, dict) and cancel_result.get("status") == "CANCELED":
             self.logger().info(f"Successfully cancelled order {order_id}.")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/3510/binance-error-when-running-xemm

**A description of the changes proposed in the pull request**:
This is a continuation from #81. I need to add an "origClientOrderId" key in `execute_cancel()`'s return value to satisfy `cancel_all()` below. Otherwise, `cancel_all()` would still block forever even though `execute_cancel()` reported success.