### PR TITLE
Fixed XEMM emitting orders at incorrect prices after exchange rate conversion

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -23,9 +23,9 @@ from typing import (
     Coroutine
 )
 
-from hummingbot import (
-    init_logging
-)
+# This init_logging() call is important, to skip over the missing config
+# warnings.
+from hummingbot import init_logging; init_logging("hummingbot_logs.yml")
 
 from hummingbot.cli.hummingbot_application import HummingbotApplication
 from hummingbot.cli.settings import (
@@ -55,7 +55,6 @@ async def main():
     await create_yml_files()
     read_configs_from_yml()
 
-    init_logging("hummingbot_logs.yml")
     hb = HummingbotApplication()
     with patch_stdout(log_field=hb.app.log_field):
         init_logging("hummingbot_logs.yml",

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pxd
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pxd
@@ -42,7 +42,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
         EventListener _order_cancelled_listener
         EventListener _order_expired_listener
         int64_t _logging_options
-        object exchange_rate_conversion
+        object _exchange_rate_conversion
 
     cdef c_buy_with_specific_market(self, MarketBase market, str symbol, double amount,
                                     object order_type = *, double price = *, double expiration_seconds = *)

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -305,9 +305,49 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
 
         return "\n".join(lines)
 
+    # The following exposed Python functions are meant for unit tests
+    # ---------------------------------------------------------------
     def get_market_making_price_and_size_limit(self, market_pair: CrossExchangeMarketPair, is_bid: bool,
                                                own_order_depth: float = 0.0) -> Tuple[Decimal, Decimal]:
         return self.c_get_market_making_price_and_size_limit(market_pair, is_bid, own_order_depth=own_order_depth)
+
+    def get_order_size_after_portfolio_ratio_limit(self, market_pair: CrossExchangeMarketPair,
+                                                   original_order_size: float) -> float:
+        return self.c_get_order_size_after_portfolio_ratio_limit(market_pair, original_order_size)
+
+    def get_adjusted_limit_order_size(self, market_pair: CrossExchangeMarketPair, price: float,
+                                      original_order_size: float) -> float:
+        return self.c_get_adjusted_limit_order_size(market_pair, price, original_order_size)
+
+    def has_market_making_profit_potential(self, market_pair: CrossExchangeMarketPair,
+                                           OrderBook maker_order_book,
+                                           OrderBook taker_order_book) -> Tuple[bool, bool]:
+        return self.c_has_market_making_profit_potential(market_pair, maker_order_book, taker_order_book)
+
+    def get_market_making_price_and_size_limit(self, market_pair: CrossExchangeMarketPair,
+                                               is_bid: bool,
+                                               own_order_depth: float = 0) -> Tuple[Decimal, Decimal]:
+        return self.c_get_market_making_price_and_size_limit(market_pair, is_bid, own_order_depth=own_order_depth)
+
+    def calculate_effective_hedging_price(self, OrderBook taker_order_book,
+                                          is_maker_bid: bool,
+                                          maker_order_size: float) -> float:
+        return self.c_calculate_effective_hedging_price(taker_order_book, is_maker_bid, maker_order_size)
+
+    def check_if_still_profitable(self, market_pair: CrossExchangeMarketPair,
+                                  LimitOrder active_order,
+                                  double current_hedging_price) -> bool:
+        return self.c_check_if_still_profitable(market_pair, active_order, current_hedging_price)
+
+    def check_if_sufficient_balance(self, market_pair: CrossExchangeMarketPair,
+                                    LimitOrder active_order) -> bool:
+        return self.c_check_if_sufficient_balance(market_pair, active_order)
+
+    def check_if_price_correct(self, market_pair: CrossExchangeMarketPair,
+                               LimitOrder active_order,
+                               double current_hedging_price) -> bool:
+        return self.c_check_if_price_correct(market_pair, active_order, current_hedging_price)
+    # ---------------------------------------------------------------
 
     cdef c_buy_with_specific_market(self, MarketBase market, str symbol, double amount,
                                     object order_type = OrderType.MARKET,

--- a/test/test_cross_exchange_market_making.py
+++ b/test/test_cross_exchange_market_making.py
@@ -4,11 +4,12 @@ from os.path import join, realpath
 import sys; sys.path.insert(0, realpath(join(__file__, "../../")))
 
 from decimal import Decimal
-import logging
+import logging; logging.basicConfig(level=logging.ERROR)
 import pandas as pd
 from typing import List
 import unittest
 
+from hummingbot.cli.utils.exchange_rate_conversion import ExchangeRateConversion
 from hummingsim.backtest.backtest_market import BacktestMarket
 from hummingsim.backtest.market import (
     AssetType,
@@ -46,6 +47,13 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
     maker_symbols: List[str] = ["COINALPHA-WETH", "COINALPHA", "WETH"]
     taker_symbols: List[str] = ["coinalpha/eth", "COINALPHA", "ETH"]
 
+    @classmethod
+    def setUpClass(cls):
+        ExchangeRateConversion.set_global_exchange_rate_config([
+            ("WETH", 1.0, "None"),
+            ("QETH", 0.95, "None"),
+        ])
+
     def setUp(self):
         self.clock: Clock = Clock(ClockMode.BACKTEST, 1.0, self.start_timestamp, self.end_timestamp)
         self.maker_market: BacktestMarket = BacktestMarket()
@@ -58,6 +66,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         self.taker_market.add_data(self.taker_data)
         self.maker_market.set_balance("COINALPHA", 5)
         self.maker_market.set_balance("WETH", 5)
+        self.maker_market.set_balance("QETH", 5)
         self.taker_market.set_balance("COINALPHA", 5)
         self.taker_market.set_balance("ETH", 5)
         self.maker_market.set_quantization_param(
@@ -336,7 +345,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
             10
         )
 
-    def test_profitability_estimates(self):
+    def test_profitability_without_conversion(self):
         self.clock.remove_iterator(self.strategy)
         self.strategy: CrossExchangeMarketMakingStrategy = CrossExchangeMarketMakingStrategy(
             [self.market_pair],
@@ -372,10 +381,53 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
             self.taker_data.order_book
         ))
 
+    def test_profitability_with_conversion(self):
+        self.clock.remove_iterator(self.strategy)
+        self.market_pair: CrossExchangeMarketPair = CrossExchangeMarketPair(
+            *(
+                [self.maker_market] + ["COINALPHA-QETH", "COINALPHA", "QETH"] +
+                [self.taker_market] + self.taker_symbols +
+                [2]
+            )
+        )
+        self.maker_data: MockOrderBookLoader = MockOrderBookLoader("COINALPHA-QETH", "COINALPHA", "QETH")
+        self.maker_data.set_balanced_order_book(1.05263, 0.55, 1.55, 0.01, 10)
+        self.maker_market.add_data(self.maker_data)
+        self.strategy: CrossExchangeMarketMakingStrategy = CrossExchangeMarketMakingStrategy(
+            [self.market_pair],
+            0.01,
+            order_size_portfolio_ratio_limit=0.3,
+            logging_options=self.logging_options
+        )
+        self.clock.add_iterator(self.strategy)
+        self.clock.backtest_til(self.start_timestamp + 5)
+        self.assertEqual(0, len(self.strategy.active_bids))
+        self.assertEqual(0, len(self.strategy.active_asks))
+        self.assertEqual((False, False), self.strategy.has_market_making_profit_potential(
+            self.market_pair,
+            self.maker_data.order_book,
+            self.taker_data.order_book
+        ))
+
+        self.clock.remove_iterator(self.strategy)
+        self.strategy: CrossExchangeMarketMakingStrategy = CrossExchangeMarketMakingStrategy(
+            [self.market_pair],
+            0.003,
+            order_size_portfolio_ratio_limit=0.3,
+            logging_options=self.logging_options
+        )
+        self.clock.add_iterator(self.strategy)
+        self.clock.backtest_til(self.start_timestamp + 10)
+        self.assertEqual(1, len(self.strategy.active_bids))
+        self.assertEqual(1, len(self.strategy.active_asks))
+        self.assertEqual((True, True), self.strategy.has_market_making_profit_potential(
+            self.market_pair,
+            self.maker_data.order_book,
+            self.taker_data.order_book
+        ))
+
 
 def main():
-    logging.basicConfig(level=logging.ERROR)
-    # logging.basicConfig(level=logging.DEBUG)
     unittest.main()
 
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/3656/check-xemm-logic

**A description of the changes proposed in the pull request**:
- Fixed a typo in `c_has_market_making_profit_potential()` which causes taker market prices to be converted incorrectly
- Fixed missing price conversion logic in `c_get_market_making_price_and_size_limit()` when querying taker order book vs. maker market prices
- Added unit test case