### PR TITLE
Fix/get logs

### DIFF
--- a/hummingbot/cli/ui/hummingbot_cli.py
+++ b/hummingbot/cli/ui/hummingbot_cli.py
@@ -66,7 +66,7 @@ class HummingbotCLI:
         self.pending_input = None
 
     def log(self, text: str):
-        self.log_lines.extend(text.split('\n'))
+        self.log_lines.extend(str(text).split('\n'))
         while len(self.log_lines) > MAXIMUM_OUTPUT_PANE_LINE_COUNT:
             self.log_lines.popleft()
         new_text: str = "\n".join(self.log_lines)

--- a/wings/watcher/contract_event_logs.py
+++ b/wings/watcher/contract_event_logs.py
@@ -118,9 +118,9 @@ class ContractEventLogger:
             except Exception as e:
                 # This exception will never be resolve as the block here will not be found
                 # Alchemy nodes return a different error message
-                # if "message" in e and e["message"] == "unknown block":
-                #     break
-                # else:
-                self.logger().debug(f"Block not found with filters: '{event_filter_params}'. Retrying...")
-                await asyncio.sleep(0.5)
+                if "message" in e and e["message"] == "unknown block":
+                    break
+                else:
+                    self.logger().debug(f"Block not found with filters: '{event_filter_params}'. Retrying...")
+                    await asyncio.sleep(0.5)
         return logs

--- a/wings/watcher/contract_event_logs.py
+++ b/wings/watcher/contract_event_logs.py
@@ -54,8 +54,8 @@ class ContractEventLogger:
         return self._contract_abi
 
     async def get_new_entries_from_logs(self,
-                                  event_name: str,
-                                  block_hashes: List[HexBytes]) -> List[AttributeDict]:
+                                        event_name: str,
+                                        block_hashes: List[HexBytes]) -> List[AttributeDict]:
         event_abi: Dict[str, any] = self._event_abi_map.get(event_name, None)
         if event_abi is None:
             event_abi = find_matching_event_abi(self._contract_abi, event_name=event_name)
@@ -115,9 +115,12 @@ class ContractEventLogger:
                 break
             except asyncio.CancelledError:
                 raise
-            except Exception:
-                self.logger().debug(
-                    f"Block not found with filters: '{event_filter_params}'. Retrying..."
-                )
+            except Exception as e:
+                # This exception will never be resolve as the block here will not be found
+                # Alchemy nodes return a different error message
+                # if "message" in e and e["message"] == "unknown block":
+                #     break
+                # else:
+                self.logger().debug(f"Block not found with filters: '{event_filter_params}'. Retrying...")
                 await asyncio.sleep(0.5)
         return logs

--- a/wings/watcher/contract_event_logs.py
+++ b/wings/watcher/contract_event_logs.py
@@ -116,8 +116,7 @@ class ContractEventLogger:
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                # This exception will never be resolve as the block here will not be found
-                # Alchemy nodes return a different error message
+                # The "unknown block" exception will never be resolved -- the block hash is not found
                 if "unknown block" in str(e):
                     break
                 else:

--- a/wings/watcher/contract_event_logs.py
+++ b/wings/watcher/contract_event_logs.py
@@ -95,7 +95,7 @@ class ContractEventLogger:
 
     async def _get_logs(self,
                         event_filter_params: Dict[str, any],
-                        max_tries: Optional[int] = 100) -> List[Dict[str, any]]:
+                        max_tries: Optional[int] = 30) -> List[Dict[str, any]]:
         ev_loop: asyncio.BaseEventLoop = self._ev_loop
         count: int = 0
         logs = []
@@ -103,7 +103,7 @@ class ContractEventLogger:
             try:
                 count += 1
                 if count > max_tries:
-                    self.logger().error(
+                    self.logger().debug(
                         f"Error fetching logs from block with filters: '{event_filter_params}'."
                     )
                     break
@@ -116,10 +116,6 @@ class ContractEventLogger:
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                # The "unknown block" exception will never be resolved -- the block hash is not found
-                if "unknown block" in str(e):
-                    break
-                else:
-                    self.logger().debug(f"Block not found with filters: '{event_filter_params}'. Retrying...")
-                    await asyncio.sleep(0.5)
+                self.logger().debug(f"Block not found with filters: '{event_filter_params}'. Retrying...")
+                await asyncio.sleep(0.5)
         return logs

--- a/wings/watcher/contract_event_logs.py
+++ b/wings/watcher/contract_event_logs.py
@@ -118,7 +118,7 @@ class ContractEventLogger:
             except Exception as e:
                 # This exception will never be resolve as the block here will not be found
                 # Alchemy nodes return a different error message
-                if "message" in e and e["message"] == "unknown block":
+                if "unknown block" in str(e):
                     break
                 else:
                     self.logger().debug(f"Block not found with filters: '{event_filter_params}'. Retrying...")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

- Related Clubhouse Story: https://app.clubhouse.io/coinalpha/story/3592/error-fetching-logs-from-block-with-filters

@chowryan Please take a look at this fix. 
When the node return `{'code': -32000, 'message': 'unknown block'}`, it is never resolved and it logs an error message after 100 tries (I've seen this with Infura and our test node). 

I tested the same logic with an Alchemy node, and I got a different exception `{'code': -32000, 'message': 'The fromBlock or blockhash cannot be found...'}`. The error message is different although the error codes are the same. This one resolves itself after 3-5 tries and does not trigger the final error (Maybe Alchemy added some additional logic to prevent the failure?)

So I think if we check the error message, we can prevent the bot from making 100 of the same unnecessary calls.
