### PR TITLE
docs/ fix wording of trade override config prompt

### DIFF
--- a/hummingbot/cli/settings.py
+++ b/hummingbot/cli/settings.py
@@ -257,8 +257,8 @@ cross_exchange_market_making_config_map = {
                                                   default=0.003,
                                                   type_str="float"),
     "trade_size_override":              ConfigVar(key="trade_size_override",
-                                                  prompt="What is your preferred trade size? (Enter 0.15 to indicate "
-                                                         "15%) >>> ",
+                                                  prompt="What is your preferred trade size? (denominated in "
+                                                         "the quote asset) >>> ",
                                                   required_if=lambda: False,
                                                   default=0.0,
                                                   type_str="float"),
@@ -312,8 +312,8 @@ arbitrage_config_map = {
                                                   default=0.003,
                                                   type_str="float"),
     "trade_size_override":              ConfigVar(key="trade_size_override",
-                                                  prompt="What is your preferred trade size? (Enter 0.15 to indicate "
-                                                         "15%) >>> ",
+                                                  prompt="What is your preferred trade size? (denominated in "
+                                                         "the quote asset) >>> ",
                                                   required_if=lambda: False,
                                                   default=0.0,
                                                   type_str="float"),


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
Fix the wording of the `config` question to set `trade_size_override` to reflect how it is applied in the code currently.