### PR TITLE
fix / show low balance warnings when balances are tiny

### DIFF
--- a/hummingbot/strategy/arbitrage/arbitrage.pyx
+++ b/hummingbot/strategy/arbitrage/arbitrage.pyx
@@ -202,13 +202,15 @@ cdef class ArbitrageStrategy(StrategyBase):
                 lines.extend(["", "  No pending market orders."])
 
             # Add warning lines on null balances.
-            if market_1_base_balance <= 0:
+            # TO-DO: Build min order size logic into exchange connector and expose maker_min_order and taker_min_order variables,
+            # which can replace the hard-coded 0.0001 value. 
+            if market_1_base_balance <= 0.0001:
                 warning_lines.append(f"  Primary market {market_1_base} balance is 0. Cannot place order.")
-            if market_1_quote_balance <= 0:
+            if market_1_quote_balance <= 0.0001:
                 warning_lines.append(f"  Primary market {market_1_quote} balance is 0. Cannot place order.")
-            if market_2_base_balance <= 0:
+            if market_2_base_balance <= 0.0001:
                 warning_lines.append(f"  Secondary market {market_2_base} balance is 0. Cannot place order.")
-            if market_2_quote_balance <= 0:
+            if market_2_quote_balance <= 0.0001:
                 warning_lines.append(f"  Secondary market {market_2_quote} balance is 0.Cannot place order.")
 
         if len(warning_lines) > 0:

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -293,15 +293,17 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                 lines.extend(["", "  No active maker orders."])
 
             # Add warning lines on null balances.
-            if maker_base_balance <= 0:
-                warning_lines.append(f"  Maker market {maker_base} balance is 0. No ask order is possible.")
-            if maker_quote_balance <= 0:
-                warning_lines.append(f"  Maker market {maker_quote} balance is 0. No bid order is possible.")
-            if taker_base_balance <= 0:
-                warning_lines.append(f"  Taker market {taker_base} balance is 0. No bid order is possible because "
+            # TO-DO: Build min order size logic into exchange connector and expose maker_min_order and taker_min_order variables,
+            # which can replace the hard-coded 0.0001 value. 
+            if maker_base_balance <= 0.0001:
+                warning_lines.append(f"  Maker market {maker_base} balance is too low. No ask order is possible.")
+            if maker_quote_balance <= 0.0001:
+                warning_lines.append(f"  Maker market {maker_quote} balance is too low. No bid order is possible.")
+            if taker_base_balance <= 0.0001:
+                warning_lines.append(f"  Taker market {taker_base} balance is too low. No bid order is possible because "
                                      f"there's no {taker_base} available for hedging orders.")
-            if taker_quote_balance <= 0:
-                warning_lines.append(f"  Taker market {taker_quote} balance is 0. No ask order is possible because "
+            if taker_quote_balance <= 0.0001:
+                warning_lines.append(f"  Taker market {taker_quote} balance is too low. No ask order is possible because "
                                      f"there's no {taker_quote} available for hedging orders.")
 
         if len(warning_lines) > 0:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
* Show low balance warnings when balances < 0.0001 threshold. This often occurs when running a bot drains a wallet balance, but since balances are still positive, Hummingbot wouldn't display the warnings before.