### PR TITLE
fix / maker order size is 0 bug

### DIFF
--- a/hummingbot/cli/hummingbot_application.py
+++ b/hummingbot/cli/hummingbot_application.py
@@ -574,12 +574,7 @@ class HummingbotApplication:
                                                   [self.markets[taker_market], raw_taker_symbol] + list(taker_assets) +
                                                   [top_depth_tolerance]))
 
-            strategy_logging_options = (CrossExchangeMarketMakingStrategy.OPTION_LOG_CREATE_ORDER |
-                                        CrossExchangeMarketMakingStrategy.OPTION_LOG_ADJUST_ORDER |
-                                        CrossExchangeMarketMakingStrategy.OPTION_LOG_MAKER_ORDER_FILLED |
-                                        CrossExchangeMarketMakingStrategy.OPTION_LOG_REMOVING_ORDER |
-                                        CrossExchangeMarketMakingStrategy.OPTION_LOG_STATUS_REPORT |
-                                        CrossExchangeMarketMakingStrategy.OPTION_LOG_MAKER_ORDER_HEDGED)
+            strategy_logging_options = CrossExchangeMarketMakingStrategy.OPTION_LOG_ALL
 
             self.strategy = CrossExchangeMarketMakingStrategy(market_pairs=[self.market_pair],
                                                               min_profitability=min_profitability,

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -865,9 +865,6 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             double order_row_price = 0
             double order_row_amount = 0
 
-        if maker_order_size <= 0:
-            raise ValueError(f"Maker order size ({maker_order_size}) must be greater than 0.")
-
         iter_func = taker_order_book.bid_entries
         if not is_maker_bid:
             iter_func = taker_order_book.ask_entries
@@ -1124,13 +1121,12 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                         float(bid_size_limit)
                     )
 
-            effective_hedging_price = self.c_calculate_effective_hedging_price(
-                taker_order_book,
-                True,
-                float(bid_size)
-            )
-
             if bid_size > s_decimal_zero:
+                effective_hedging_price = self.c_calculate_effective_hedging_price(
+                    taker_order_book,
+                    True,
+                    float(bid_size)
+                )
                 if self._logging_options & self.OPTION_LOG_CREATE_ORDER:
                     self.log_with_clock(
                         logging.INFO,
@@ -1172,13 +1168,13 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                         float(ask_size_limit)
                     )
 
-            effective_hedging_price = self.c_calculate_effective_hedging_price(
-                taker_order_book,
-                False,
-                float(ask_size)
-            )
 
             if ask_size > s_decimal_zero:
+                effective_hedging_price = self.c_calculate_effective_hedging_price(
+                    taker_order_book,
+                    False,
+                    float(ask_size)
+                )
                 if self._logging_options & self.OPTION_LOG_CREATE_ORDER:
                     self.log_with_clock(
                         logging.INFO,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

- Related Github issue: https://github.com/CoinAlpha/hummingbot/issues/118
- Related Clubhouse Story: https://app.clubhouse.io/coinalpha/story/3741/maker-order-size-must-be-greater-than-0

**A description of the changes proposed in the pull request**:
- Currently, when a user's balance is too low on the maker exchange, they get ```ValueError: Maker order size (0.0) must be greater than 0.```
- The reason is that we are calculating hedging price even though the maker_order_size is 0. So moving that code block to trigger only when the order_size is greater than 0. 
Also changing the log message to display all since now the bot will be silent when there is an insuffcient balance.
