### PR TITLE
Updated c_process_market_pair

### DIFF
--- a/hummingbot/strategy/arbitrage/arbitrage.pyx
+++ b/hummingbot/strategy/arbitrage/arbitrage.pyx
@@ -329,6 +329,10 @@ cdef class ArbitrageStrategy(StrategyBase):
         profitability_buy_market_2_sell_market_1 = market_1_bid_price/market_2_ask_price
         profitability_buy_market_1_sell_market_2 = market_2_bid_price/market_1_ask_price
 
+        if profitability_buy_market_1_sell_market_2 < (1 + self._min_profitability) \
+            and profitability_buy_market_2_sell_market_1 < (1 + self._min_profitability):
+            return
+
         if profitability_buy_market_1_sell_market_2 > profitability_buy_market_2_sell_market_1:
             # it is more profitable to buy on market_1 and sell on market_2
             self.c_process_market_pair_inner(


### PR DESCRIPTION
Recheck if there is no arb even at the top entries of the orderbook. No need to get the orderbook entries.

**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Arbitrage strategy does not need to get bid and ask entries if there is no arb at the top of the orderbook
