### PR TITLE
Bug/fix crazy cancel

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pxd
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pxd
@@ -35,6 +35,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
         dict _order_fill_buy_events
         dict _order_fill_sell_events
         dict _suggested_price_samples
+        dict _in_flight_cancels
         EventListener _order_filled_listener
         EventListener _buy_order_completed_listener
         EventListener _sell_order_completed_listener

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -785,6 +785,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             double top_bid_price
             double top_ask_price
             double raw_size_limit
+            double profitable_hedge_price
             double maker_balance_size_limit
             double taker_balance_size_limit
             double taker_order_book_size_limit
@@ -814,7 +815,8 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             maker_balance_size_limit = maker_market.c_get_balance(market_pair.maker_quote_currency) / float(next_price)
             taker_balance_size_limit = (taker_market.c_get_balance(market_pair.taker_base_currency) *
                                         self._order_size_taker_balance_factor)
-            taker_order_book_size_limit = (taker_order_book.c_get_volume_for_price(False, float(next_price)) *
+            profitable_hedge_price = float(next_price) * (1 + self._min_profitability)
+            taker_order_book_size_limit = (taker_order_book.c_get_volume_for_price(False, profitable_hedge_price) *
                                            self._order_size_taker_volume_factor)
             raw_size_limit = min(
                 taker_order_book_size_limit,
@@ -833,6 +835,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             taker_balance_size_limit = (taker_market.c_get_balance(market_pair.taker_quote_currency) /
                                         float(next_price) *
                                         self._order_size_taker_balance_factor)
+            profitable_hedge_price = float(next_price) / (1 + self._min_profitability)
             taker_order_book_size_limit = (taker_order_book.c_get_volume_for_price(True, float(next_price)) *
                                            self._order_size_taker_volume_factor)
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -772,6 +772,17 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                                                         bint is_bid,
                                                         double own_order_depth = 0):
         """
+        Get the ideal market making order size and maximum order size given a market pair and a side.
+
+        This function does a few things:
+         1. Get the widest possible order price for market making on the maker market.
+         2. Calculate the largest order size possible given the current balances on both maker and taker markets.
+         3. Calculate the largest order size possible that's still profitable after hedging.
+
+        The price returned is calculated from step 1. The order size returned is the minimum from 2 and 3. If either
+        there's not enough balance for the maker order or the hedging trade; or if it's not possible to hedge the
+        trade profitably, then the returned order size will be 0.
+
         :param market_pair: The cross exchange market pair to calculate order price/size limits.
         :param is_bid: Whether the order to make will be bid or ask.
         :param own_order_depth: Market depth caused by existing order issued by ourselves.

--- a/wings/market/ddex_market.pxd
+++ b/wings/market/ddex_market.pxd
@@ -18,6 +18,7 @@ cdef class DDEXMarket(MarketBase):
         double _last_update_trade_fees_timestamp
         double _poll_interval
         dict _in_flight_orders
+        dict _in_flight_cancels
         object _order_expiry_queue
         TransactionTracker _tx_tracker
         object _w3

--- a/wings/market/ddex_market.pxd
+++ b/wings/market/ddex_market.pxd
@@ -18,7 +18,7 @@ cdef class DDEXMarket(MarketBase):
         double _last_update_trade_fees_timestamp
         double _poll_interval
         dict _in_flight_orders
-        dict _in_flight_cancels
+        object _in_flight_cancels
         object _order_expiry_queue
         TransactionTracker _tx_tracker
         object _w3

--- a/wings/market/ddex_market.pyx
+++ b/wings/market/ddex_market.pyx
@@ -551,7 +551,7 @@ cdef class DDEXMarket(MarketBase):
             self.logger().info(f"Failed to cancel order {client_order_id}. Order not found in tracked orders.")
             if client_order_id in self._in_flight_cancels:
                 del self._in_flight_cancels[client_order_id]
-            return
+            return {}
 
         try:
             exchange_order_id = await order.get_exchange_order_id()
@@ -564,7 +564,8 @@ cdef class DDEXMarket(MarketBase):
             response_data["client_order_id"] = client_order_id
             return response_data
         finally:
-            del self._in_flight_cancels[client_order_id]
+            if client_order_id in self._in_flight_cancels:
+                del self._in_flight_cancels[client_order_id]
 
     async def list_orders(self) -> Dict[str, Any]:
         url = "%s/orders?status=all" % (self.DDEX_REST_ENDPOINT,)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/3765/crazy-cancelling-when-active-order-cancel-is-enabled

**A description of the changes proposed in the pull request**:
- Added in-flight cancel order tracking in both XEMM and DDEX market connector s.t. it won't try to cancel the same order repeatedly when network is slow
- Added min profitability calculation when making new orders in XEMM, s.t. it won't make below-min-profitability orders and then cancel it the next second