### PR TITLE
Fixed broken XEMM unit test case.

### DIFF
--- a/hummingbot/cli/utils/exchange_rate_conversion.py
+++ b/hummingbot/cli/utils/exchange_rate_conversion.py
@@ -50,13 +50,13 @@ class ExchangeRateConversion:
                 exchange_rate_config = global_config_map["exchange_rate_conversion"].value
             else:
                 exchange_rate_config = self._exchange_rate_config_override
-            exchange_rate_fetcher_config = global_config_map["exchange_rate_fetcher"].value
+            exchange_rate_fetcher_config = global_config_map["exchange_rate_fetcher"].value or {}
             self._exchange_rate_config = {e[0]: {"default": e[1], "source": e[2]} for e in exchange_rate_config}
             self._exchange_rate = {k: float(v.get("default", 1.0)) for k, v in self._exchange_rate_config.items()}
             self._exchange_rate_fetcher_config = {e[0]: {"default": None, "source": e[1]} for e in exchange_rate_fetcher_config}
             self._exchange_rate_manual = {k: None for k, v in self._exchange_rate_fetcher_config.items()} 
         except Exception:
-            self.logger().error("Error initiating config for exchange rate conversion.")
+            self.logger().error("Error initiating config for exchange rate conversion.", exc_info=True)
 
     def adjust_token_rate(self, symbol: str, price: float) -> float:
         if not self._started:

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -86,7 +86,7 @@ dependencies:
     - eth-typing==2.1.0
     - eth-utils==1.4.1
     - hexbytes==0.1.0
-    - hummingsim==20190328
+    - hummingsim==20190415
     - hyperlink==18.0.0
     - hypothesis==4.14.2
     - idna-ssl==1.1.0

--- a/test/test_cross_exchange_market_making.py
+++ b/test/test_cross_exchange_market_making.py
@@ -61,7 +61,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         self.maker_data: MockOrderBookLoader = MockOrderBookLoader(*self.maker_symbols)
         self.taker_data: MockOrderBookLoader = MockOrderBookLoader(*self.taker_symbols)
         self.maker_data.set_balanced_order_book(1.0, 0.5, 1.5, 0.01, 10)
-        self.taker_data.set_balanced_order_book(1.0, 0.5, 1.5, 0.001, 3)
+        self.taker_data.set_balanced_order_book(1.0, 0.5, 1.5, 0.001, 4)
         self.maker_market.add_data(self.maker_data)
         self.taker_market.add_data(self.taker_data)
         self.maker_market.set_balance("COINALPHA", 5)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This fixes broken XEMM test case due to the following changes in hummingbot:
 - Refactoring of the market classes, which means hummingsim needs to be updated
 - Addition of `exchange_rate_fetcher_config` in exchange rate conversion class
 - New profitability accounting logic in XEMM when making orders, which means the test case needs a thicker order on the taker side to give the same numbers as before