### PR TITLE
bug / Fixed #147: DDEX market buy amounts should be in terms of quote tokens.

### DIFF
--- a/wings/order_book.pxd
+++ b/wings/order_book.pxd
@@ -30,3 +30,4 @@ cdef class OrderBook(PubSub):
     cdef double c_get_volume_for_price(self, bint is_buy, double price) except? -1
     cdef double c_get_quote_volume_for_price(self, bint is_buy, double price) except? -1
     cdef double c_get_vwap_for_volume(self, bint is_buy, double volume) except? -1
+    cdef double c_get_quote_volume_for_base_amount(self, bint is_buy, double base_amount) except? -1


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**Optional**:
- Related Github issue: https://github.com/CoinAlpha/hummingbot/issues/147
- Related Clubhouse Story:

**A description of the changes proposed in the pull request**:
- Market buy orders in DDEX should be in quote token amounts
- Changed event logic to account for quote token amounts in market buy order data API
- Fixed unit test case `test_market_buy_and_sell ()` for testing market buy and sells