### PR TITLE
bug / Added "trading started" message

### DIFF
--- a/hummingbot/strategy/arbitrage/arbitrage.pyx
+++ b/hummingbot/strategy/arbitrage/arbitrage.pyx
@@ -286,6 +286,9 @@ cdef class ArbitrageStrategy(StrategyBase):
                     if should_report_warnings:
                         self.logger().warning(f"Markets are not ready. No arbitrage trading is permitted.")
                     return
+                else:
+                    if self.OPTION_LOG_STATUS_REPORT:
+                        self.logger().info(f"Markets are ready. Trading started.")
 
             if not all([market.network_status is NetworkStatus.CONNECTED for market in self._markets]):
                 if should_report_warnings:

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -469,6 +469,9 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                     if should_report_warnings:
                         self.logger().warning(f"Markets are not ready. No market making trades are permitted.")
                     return
+                else:
+                    if self.OPTION_LOG_STATUS_REPORT:
+                        self.logger().info(f"Markets are ready. Trading started.")
 
             if should_report_warnings:
                 if not all([market.network_status is NetworkStatus.CONNECTED for market in self._markets]):


### PR DESCRIPTION
… "no trading" message after markets are ready at bot start up.

**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:

**A description of the changes proposed in the pull request**:
After starting the bot successfully now, e.g. with arbitrage strategy, the bot would often print out a "markets are not ready" log message at the beginning because the markets are still connecting.

However, once the markets are ready, there's no update on the log panel to say trading has started. This missing update is misleading to users because they may think the logs are saying there's a problem when in fact trading has already started.
