### PR TITLE
fix / Ignore invalid state errors when an async call future has already been cancelled from outside.

### DIFF
--- a/wings/async_call_scheduler.py
+++ b/wings/async_call_scheduler.py
@@ -80,6 +80,9 @@ class AsyncCallScheduler:
                 except Exception:
                     pass
                 raise
+            except asyncio.InvalidStateError:
+                # The future is already cancelled from outside. Ignore.
+                pass
             except Exception as e:
                 self.logger().error("API call error.", exc_info=True)
                 try:


### PR DESCRIPTION
As title.

**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
Fixed #209 
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/3990/bug-wings-async-call-scheduler-error-api-call-error

**A description of the changes proposed in the pull request**:
- Added a catch block for the invalid state error when setting the result to async call future. The invalid state error is unimportant here because the future has already been cancelled.