### PR TITLE
fix / remove stack trace from cli

### DIFF
--- a/hummingbot/logger/cli_handler.py
+++ b/hummingbot/logger/cli_handler.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from logging import StreamHandler
+from typing import Optional
+
+
+class CLIHandler(StreamHandler):
+    def formatException(self, _) -> Optional[str]:
+        return None
+
+    def format(self, record) -> str:
+        if record.exc_text is not None:
+            record.exc_text = None
+        retval: str = super().format(record)
+        if record.exc_info:
+            retval += " (Stack trace dumped to log file)"
+        return retval

--- a/hummingbot/logger/cli_handler.py
+++ b/hummingbot/logger/cli_handler.py
@@ -9,9 +9,10 @@ class CLIHandler(StreamHandler):
         return None
 
     def format(self, record) -> str:
-        if record.exc_text is not None:
-            record.exc_text = None
+        exc_info = record.exc_info
+        if record.exc_info is not None:
+            record.exc_info = None
         retval: str = super().format(record)
-        if record.exc_info:
-            retval += " (Stack trace dumped to log file)"
+        if exc_info:
+            retval += " (See log file for stack trace dump)"
         return retval

--- a/hummingbot/logger/cli_handler.py
+++ b/hummingbot/logger/cli_handler.py
@@ -15,4 +15,5 @@ class CLIHandler(StreamHandler):
         retval: str = super().format(record)
         if exc_info:
             retval += " (See log file for stack trace dump)"
+        record.exc_info = exc_info
         return retval

--- a/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
+++ b/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 1
+template_version: 2
 
 formatters:
     simple:
@@ -8,17 +8,17 @@ formatters:
 
 handlers:
     console:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: DEBUG
         formatter: simple
         stream: ext://sys.stdout
     console_warning:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: WARNING
         formatter: simple
         stream: ext://sys.stdout
     console_info:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: INFO
         formatter: simple
         stream: ext://sys.stdout

--- a/hummingbot/templates/log_templates/hummingbot_logs_full_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_full_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 1
+template_version: 2
 
 formatters:
     simple:
@@ -8,17 +8,17 @@ formatters:
 
 handlers:
     console:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: DEBUG
         formatter: simple
         stream: ext://sys.stdout
     console_warning:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: WARNING
         formatter: simple
         stream: ext://sys.stdout
     console_info:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: INFO
         formatter: simple
         stream: ext://sys.stdout

--- a/hummingbot/templates/log_templates/hummingbot_logs_none_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_none_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 1
+template_version: 2
 
 formatters:
     simple:
@@ -8,17 +8,17 @@ formatters:
 
 handlers:
     console:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: DEBUG
         formatter: simple
         stream: ext://sys.stdout
     console_warning:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: WARNING
         formatter: simple
         stream: ext://sys.stdout
     console_info:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: INFO
         formatter: simple
         stream: ext://sys.stdout

--- a/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 1
+template_version: 2
 
 formatters:
     simple:
@@ -8,17 +8,17 @@ formatters:
 
 handlers:
     console:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: DEBUG
         formatter: simple
         stream: ext://sys.stdout
     console_warning:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: WARNING
         formatter: simple
         stream: ext://sys.stdout
     console_info:
-        class: logging.StreamHandler
+        class: hummingbot.logger.cli_handler.CLIHandler
         level: INFO
         formatter: simple
         stream: ext://sys.stdout


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/3807/logs-that-appear-in-the-user-console-must-be-actionable

**A description of the changes proposed in the pull request**:
This is the first of the multi-part fix to the logging review.

This removes all stack traces from the CLI log panel. The stack trace will still appear in the log file and in Datadog as intended.