### PR TITLE
fix/obsolete hummingsim version on macOS

### DIFF
--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -88,7 +88,7 @@ dependencies:
     - eth-typing==2.1.0
     - eth-utils==1.4.1
     - hexbytes==0.1.0
-    - hummingsim==20190517
+    - hummingsim==20190519.1
     - hyperlink==18.0.0
     - hypothesis==4.14.2
     - idna-ssl==1.1.0


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
This bumps the hummingsim version on macOS which fixes import errors in unit test cases.