### PR TITLE
(fix) orders are not removed from tracking after being cancelled

### DIFF
--- a/wings/market/binance_market.pyx
+++ b/wings/market/binance_market.pyx
@@ -1065,6 +1065,7 @@ cdef class BinanceMarket(MarketBase):
         return cancel_result
 
     cdef c_cancel(self, str symbol, str order_id):
+        self.c_stop_tracking_order(order_id)
         asyncio.ensure_future(self.execute_cancel(symbol, order_id))
         return order_id
 

--- a/wings/market/coinbase_pro_market.pyx
+++ b/wings/market/coinbase_pro_market.pyx
@@ -776,6 +776,7 @@ cdef class CoinbaseProMarket(MarketBase):
         return order_id
 
     cdef c_cancel(self, str symbol, str order_id):
+        self.c_stop_tracking_order(order_id)
         asyncio.ensure_future(self.execute_cancel(symbol, order_id))
         return order_id
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Calls the stop tracking order in Binance and coinbase markets after order cancellation so that they are removed from tracked orders. This prevents the Pure MM strategy from crashing when I stop it.