### PR TITLE
fix / insufficient market depth

### DIFF
--- a/hummingbot/cli/hummingbot_application.py
+++ b/hummingbot/cli/hummingbot_application.py
@@ -167,11 +167,6 @@ class HummingbotApplication:
             self.app.log("Invalid command: %s" % (str(e),))
         except ArgumentParserError as e:
             self.app.log(str(e))
-        except EnvironmentError as e:
-            # Handle order book too thin error more gracefully
-            if "no price quote is possible" in str(e):
-                self.logger().error(f"Order book error: Not enough volume on order book. Please consider choosing a "
-                                    f"trading pair with more volume or trade on a different exchange. {e}")
         except NotImplementedError:
             self.app.log("Command not yet implemented. This feature is currently under development.")
         except Exception as e:

--- a/hummingbot/market/ddex/ddex_market.pyx
+++ b/hummingbot/market/ddex/ddex_market.pyx
@@ -681,7 +681,7 @@ cdef class DDEXMarket(MarketBase):
         # Convert the amount to quote tokens amount, for market buy orders, as required by DDEX order API.
         if order_type is OrderType.MARKET:
             quote_amount = (<OrderBook>self.c_get_order_book(symbol)).c_get_quote_volume_for_base_amount(
-                True, amount)
+                True, amount).result_volume
 
             # Quantize according to price rules, not base token amount rules.
             q_amt = str(self.c_quantize_order_price(symbol, quote_amount))

--- a/test/test_bamboo_relay_order_book_tracker.py
+++ b/test/test_bamboo_relay_order_book_tracker.py
@@ -41,12 +41,16 @@ class BambooRelayOrderBookTrackerUnitTest(unittest.TestCase):
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         weth_dai_book: OrderBook = order_books["WETH-DAI"]
         zrx_weth_book: OrderBook = order_books["ZRX-WETH"]
-        print(weth_dai_book.snapshot)
-        print(zrx_weth_book.snapshot)
-        self.assertGreaterEqual(weth_dai_book.get_price_for_volume(True, 10), weth_dai_book.get_price(True))
-        self.assertLessEqual(weth_dai_book.get_price_for_volume(False, 10), weth_dai_book.get_price(False))
-        self.assertGreaterEqual(zrx_weth_book.get_price_for_volume(True, 10), zrx_weth_book.get_price(True))
-        self.assertLessEqual(zrx_weth_book.get_price_for_volume(False, 10), zrx_weth_book.get_price(False))
+        # print(weth_dai_book.snapshot)
+        # print(zrx_weth_book.snapshot)
+        self.assertGreaterEqual(weth_dai_book.get_price_for_volume(True, 10).result_price,
+                                weth_dai_book.get_price(True))
+        self.assertLessEqual(weth_dai_book.get_price_for_volume(False, 10).result_price,
+                             weth_dai_book.get_price(False))
+        self.assertGreaterEqual(zrx_weth_book.get_price_for_volume(True, 10).result_price,
+                                zrx_weth_book.get_price(True))
+        self.assertLessEqual(zrx_weth_book.get_price_for_volume(False, 10).result_price,
+                             zrx_weth_book.get_price(False))
 
 
 def main():

--- a/test/test_binance_order_book_tracker.py
+++ b/test/test_binance_order_book_tracker.py
@@ -40,13 +40,17 @@ class BinanceOrderBookTrackerUnitTest(unittest.TestCase):
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         btcusdt_book: OrderBook = order_books["BTCUSDT"]
         xrpusdt_book: OrderBook = order_books["XRPUSDT"]
-        print(btcusdt_book.snapshot)
-        print("xrpusdt")
-        print(xrpusdt_book.snapshot)
-        self.assertGreaterEqual(btcusdt_book.get_price_for_volume(True, 10), btcusdt_book.get_price(True))
-        self.assertLessEqual(btcusdt_book.get_price_for_volume(False, 10), btcusdt_book.get_price(False))
-        self.assertGreaterEqual(xrpusdt_book.get_price_for_volume(True, 10000), xrpusdt_book.get_price(True))
-        self.assertLessEqual(xrpusdt_book.get_price_for_volume(False, 10000), xrpusdt_book.get_price(False))
+        # print(btcusdt_book.snapshot)
+        # print("xrpusdt")
+        # print(xrpusdt_book.snapshot)
+        self.assertGreaterEqual(btcusdt_book.get_price_for_volume(True, 10).result_price,
+                                btcusdt_book.get_price(True))
+        self.assertLessEqual(btcusdt_book.get_price_for_volume(False, 10).result_price,
+                             btcusdt_book.get_price(False))
+        self.assertGreaterEqual(xrpusdt_book.get_price_for_volume(True, 10000).result_price,
+                                xrpusdt_book.get_price(True))
+        self.assertLessEqual(xrpusdt_book.get_price_for_volume(False, 10000).result_price,
+                             xrpusdt_book.get_price(False))
 
 
 def main():

--- a/test/test_bittrex_order_book_tracker.py
+++ b/test/test_bittrex_order_book_tracker.py
@@ -42,11 +42,15 @@ class BittrexOrderBookTrackerUnitTest(unittest.TestCase):
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         btcusdt_book: OrderBook = order_books["USDT-BTC"]
         xrpusdt_book: OrderBook = order_books["USDT-XRP"]
-        print(btcusdt_book.snapshot)
-        self.assertGreaterEqual(btcusdt_book.get_price_for_volume(True, 10), btcusdt_book.get_price(True))
-        self.assertLessEqual(btcusdt_book.get_price_for_volume(False, 10), btcusdt_book.get_price(False))
-        self.assertGreaterEqual(xrpusdt_book.get_price_for_volume(True, 10000), xrpusdt_book.get_price(True))
-        self.assertLessEqual(xrpusdt_book.get_price_for_volume(False, 10000), xrpusdt_book.get_price(False))
+        # print(btcusdt_book.snapshot)
+        self.assertGreaterEqual(btcusdt_book.get_price_for_volume(True, 10).result_price,
+                                btcusdt_book.get_price(True))
+        self.assertLessEqual(btcusdt_book.get_price_for_volume(False, 10).result_price,
+                             btcusdt_book.get_price(False))
+        self.assertGreaterEqual(xrpusdt_book.get_price_for_volume(True, 10000).result_price,
+                                xrpusdt_book.get_price(True))
+        self.assertLessEqual(xrpusdt_book.get_price_for_volume(False, 10000).result_price,
+                             xrpusdt_book.get_price(False))
 
 
 def main():

--- a/test/test_coinbase_pro_order_book_tracker.py
+++ b/test/test_coinbase_pro_order_book_tracker.py
@@ -42,10 +42,12 @@ class CoinbaseProOrderBookTrackerUnitTest(unittest.TestCase):
         self.ev_loop.run_until_complete(asyncio.sleep(5.0))
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         test_order_book: OrderBook = order_books[test_symbol]
-        print("test_order_book")
-        print(test_order_book.snapshot)
-        self.assertGreaterEqual(test_order_book.get_price_for_volume(True, 10), test_order_book.get_price(True))
-        self.assertLessEqual(test_order_book.get_price_for_volume(False, 10), test_order_book.get_price(False))
+        # print("test_order_book")
+        # print(test_order_book.snapshot)
+        self.assertGreaterEqual(test_order_book.get_price_for_volume(True, 10).result_price,
+                                test_order_book.get_price(True))
+        self.assertLessEqual(test_order_book.get_price_for_volume(False, 10).result_price,
+                             test_order_book.get_price(False))
 
         test_active_order_tracker = self.order_book_tracker._active_order_trackers[test_symbol]
         self.assertTrue(len(test_active_order_tracker.active_asks) > 0)

--- a/test/test_ddex_order_book_tracker.py
+++ b/test/test_ddex_order_book_tracker.py
@@ -41,14 +41,18 @@ class DDEXOrderBookTrackerUnitTest(unittest.TestCase):
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         zrx_weth_book: OrderBook = order_books["ZRX-WETH"]
         weth_tusd_book: OrderBook = order_books["WETH-TUSD"]
-        print("zrx_weth_book")
-        print(zrx_weth_book.snapshot)
-        print("weth_tusd_book")
-        print(weth_tusd_book.snapshot)
-        self.assertGreaterEqual(zrx_weth_book.get_price_for_volume(True, 10), zrx_weth_book.get_price(True))
-        self.assertLessEqual(zrx_weth_book.get_price_for_volume(False, 10), zrx_weth_book.get_price(False))
-        self.assertGreaterEqual(weth_tusd_book.get_price_for_volume(True, 10), weth_tusd_book.get_price(True))
-        self.assertLessEqual(weth_tusd_book.get_price_for_volume(False, 10), weth_tusd_book.get_price(False))
+        # print("zrx_weth_book")
+        # print(zrx_weth_book.snapshot)
+        # print("weth_tusd_book")
+        # print(weth_tusd_book.snapshot)
+        self.assertGreaterEqual(zrx_weth_book.get_price_for_volume(True, 10).result_price,
+                                zrx_weth_book.get_price(True))
+        self.assertLessEqual(zrx_weth_book.get_price_for_volume(False, 10).result_price,
+                             zrx_weth_book.get_price(False))
+        self.assertGreaterEqual(weth_tusd_book.get_price_for_volume(True, 10).result_price,
+                                weth_tusd_book.get_price(True))
+        self.assertLessEqual(weth_tusd_book.get_price_for_volume(False, 10).result_price,
+                             weth_tusd_book.get_price(False))
 
 
 def main():

--- a/test/test_huobi_order_book_tracker.py
+++ b/test/test_huobi_order_book_tracker.py
@@ -40,12 +40,16 @@ class HuobiOrderBookTrackerUnitTest(unittest.TestCase):
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         btcusdt_book: OrderBook = order_books["btcusdt"]
         xrpusdt_book: OrderBook = order_books["xrpusdt"]
-        print(btcusdt_book.snapshot)
-        print(xrpusdt_book.snapshot)
-        self.assertGreaterEqual(btcusdt_book.get_price_for_volume(True, 10), btcusdt_book.get_price(True))
-        self.assertLessEqual(btcusdt_book.get_price_for_volume(False, 10), btcusdt_book.get_price(False))
-        self.assertGreaterEqual(xrpusdt_book.get_price_for_volume(True, 10000), xrpusdt_book.get_price(True))
-        self.assertLessEqual(xrpusdt_book.get_price_for_volume(False, 10000), xrpusdt_book.get_price(False))
+        # print(btcusdt_book.snapshot)
+        # print(xrpusdt_book.snapshot)
+        self.assertGreaterEqual(btcusdt_book.get_price_for_volume(True, 10).result_price,
+                                btcusdt_book.get_price(True))
+        self.assertLessEqual(btcusdt_book.get_price_for_volume(False, 10).result_price,
+                             btcusdt_book.get_price(False))
+        self.assertGreaterEqual(xrpusdt_book.get_price_for_volume(True, 10000).result_price,
+                                xrpusdt_book.get_price(True))
+        self.assertLessEqual(xrpusdt_book.get_price_for_volume(False, 10000).result_price,
+                             xrpusdt_book.get_price(False))
 
 
 def main():

--- a/test/test_radar_relay_order_book_tracker.py
+++ b/test/test_radar_relay_order_book_tracker.py
@@ -41,12 +41,16 @@ class RadarRelayOrderBookTrackerUnitTest(unittest.TestCase):
         order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
         weth_dai_book: OrderBook = order_books["WETH-DAI"]
         zrx_weth_book: OrderBook = order_books["ZRX-WETH"]
-        print(weth_dai_book.snapshot)
-        print(zrx_weth_book.snapshot)
-        self.assertGreaterEqual(weth_dai_book.get_price_for_volume(True, 10), weth_dai_book.get_price(True))
-        self.assertLessEqual(weth_dai_book.get_price_for_volume(False, 10), weth_dai_book.get_price(False))
-        self.assertGreaterEqual(zrx_weth_book.get_price_for_volume(True, 10), zrx_weth_book.get_price(True))
-        self.assertLessEqual(zrx_weth_book.get_price_for_volume(False, 10), zrx_weth_book.get_price(False))
+        # print(weth_dai_book.snapshot)
+        # print(zrx_weth_book.snapshot)
+        self.assertGreaterEqual(weth_dai_book.get_price_for_volume(True, 10).result_price,
+                                weth_dai_book.get_price(True))
+        self.assertLessEqual(weth_dai_book.get_price_for_volume(False, 10).result_price,
+                             weth_dai_book.get_price(False))
+        self.assertGreaterEqual(zrx_weth_book.get_price_for_volume(True, 10).result_price,
+                                zrx_weth_book.get_price(True))
+        self.assertLessEqual(zrx_weth_book.get_price_for_volume(False, 10).result_price,
+                             zrx_weth_book.get_price(False))
 
 
 def main():

--- a/wings/order_book.pxd
+++ b/wings/order_book.pxd
@@ -7,6 +7,8 @@ cimport numpy as np
 from hummingbot.core.OrderBookEntry cimport OrderBookEntry
 from hummingbot.core.pubsub cimport PubSub
 
+from .order_book_query_result cimport OrderBookQueryResult
+
 cdef class OrderBook(PubSub):
     cdef set[OrderBookEntry] _bid_book
     cdef set[OrderBookEntry] _ask_book
@@ -25,9 +27,9 @@ cdef class OrderBook(PubSub):
                                 np.ndarray[np.float64_t, ndim=2] bids_array,
                                 np.ndarray[np.float64_t, ndim=2] asks_array)
     cdef double c_get_price(self, bint is_buy) except? -1
-    cdef double c_get_price_for_volume(self, bint is_buy, double volume) except? -1
-    cdef double c_get_price_for_quote_volume(self, bint is_buy, double quote_volume) except? -1
-    cdef double c_get_volume_for_price(self, bint is_buy, double price) except? -1
-    cdef double c_get_quote_volume_for_price(self, bint is_buy, double price) except? -1
-    cdef double c_get_vwap_for_volume(self, bint is_buy, double volume) except? -1
-    cdef double c_get_quote_volume_for_base_amount(self, bint is_buy, double base_amount) except? -1
+    cdef OrderBookQueryResult c_get_price_for_volume(self, bint is_buy, double volume)
+    cdef OrderBookQueryResult c_get_price_for_quote_volume(self, bint is_buy, double quote_volume)
+    cdef OrderBookQueryResult c_get_volume_for_price(self, bint is_buy, double price)
+    cdef OrderBookQueryResult c_get_quote_volume_for_price(self, bint is_buy, double price)
+    cdef OrderBookQueryResult c_get_vwap_for_volume(self, bint is_buy, double volume)
+    cdef OrderBookQueryResult c_get_quote_volume_for_base_amount(self, bint is_buy, double base_amount)

--- a/wings/order_book_query_result.pxd
+++ b/wings/order_book_query_result.pxd
@@ -1,0 +1,8 @@
+# distutils: language=c++
+
+cdef class OrderBookQueryResult:
+    cdef:
+        public double query_price
+        public double query_volume
+        public double result_price
+        public double result_volume

--- a/wings/order_book_query_result.pyx
+++ b/wings/order_book_query_result.pyx
@@ -1,0 +1,8 @@
+# distutils: language=c++
+
+cdef class OrderBookQueryResult:
+    def __cinit__(self, double query_price, double query_volume, double result_price, double result_volume):
+        self.query_price = query_price
+        self.query_volume = query_volume
+        self.result_price = result_price
+        self.result_volume = result_volume


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/3983/change-c-get-price-for-and-c-get-volume-for-to-not-raise-error-on-not-enough-volumes

**A description of the changes proposed in the pull request**:
This patch removes exceptions from order book query functions by including the queried price / depth into the return value.