### PR TITLE
fix / fix binance price precision

### DIFF
--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -972,8 +972,12 @@ cdef class BinanceMarket(MarketBase):
             self.c_start_tracking_order(order_id, -1, symbol, True, decimal_amount, order_type)
             order_result = None
             if order_type is OrderType.LIMIT:
+                order_price = self.quantize_order_price(symbol, price)
+                #order_price = f"{price:f}"
                 order_price = f"{Decimal(str(price)):f}"
                 order_decimal_amount = f"{Decimal(str(decimal_amount)):f}"
+                #order_decimal_amount = f"{decimal_amount:f}"
+                #self.logger().info(f"decimal_amount:{decimal_amount} order_price:{order_price}")
                 order_result = await self.query_api(self._binance_client.order_limit_buy,
                                                     symbol=symbol,
                                                     quantity=order_decimal_amount,
@@ -1042,11 +1046,16 @@ cdef class BinanceMarket(MarketBase):
 
 
         try:
+
             self.c_start_tracking_order(order_id, -1, symbol, False, decimal_amount, order_type)
             order_result = None
             if order_type is OrderType.LIMIT:
+                order_price = self.quantize_order_price(symbol, price)
                 order_price = f"{Decimal(str(price)):f}"
+                #order_price = f"{price:f}"
+                #self.logger().info(f"decimal_amount:{decimal_amount} order_price:{order_price}")
                 order_decimal_amount = f"{Decimal(str(decimal_amount)):f}"
+                #order_decimal_amount = f"{decimal_amount:f}"
                 order_result = await self.query_api(self._binance_client.order_limit_sell,
                                                     symbol=symbol,
                                                     quantity=order_decimal_amount,

--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -1,4 +1,5 @@
 import math
+from numpy import format_float_positional
 import aiohttp
 from aiokafka import (
     AIOKafkaConsumer,
@@ -975,7 +976,7 @@ cdef class BinanceMarket(MarketBase):
                 order_result = await self.query_api(self._binance_client.order_limit_buy,
                                                     symbol=symbol,
                                                     quantity=str(decimal_amount),
-                                                    price=price,
+                                                    price=format_float_positional(price),
                                                     newClientOrderId=order_id)
             elif order_type is OrderType.MARKET:
                 order_result = await self.query_api(self._binance_client.order_market_buy,
@@ -1037,6 +1038,7 @@ cdef class BinanceMarket(MarketBase):
             raise ValueError(f"Sell order amount {decimal_amount} is lower than the minimum order size "
                              f"{trading_rule.min_order_size}.")
 
+
         try:
             self.c_start_tracking_order(order_id, -1, symbol, False, decimal_amount, order_type)
             order_result = None
@@ -1044,7 +1046,7 @@ cdef class BinanceMarket(MarketBase):
                 order_result = await self.query_api(self._binance_client.order_limit_sell,
                                                     symbol=symbol,
                                                     quantity=str(decimal_amount),
-                                                    price=str(price),
+                                                    price=format_float_positional(price),
                                                     newClientOrderId=order_id)
             elif order_type is OrderType.MARKET:
                 order_result = await self.query_api(self._binance_client.order_market_sell,

--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -1,5 +1,4 @@
 import math
-from numpy import format_float_positional
 import aiohttp
 from aiokafka import (
     AIOKafkaConsumer,
@@ -973,15 +972,18 @@ cdef class BinanceMarket(MarketBase):
             self.c_start_tracking_order(order_id, -1, symbol, True, decimal_amount, order_type)
             order_result = None
             if order_type is OrderType.LIMIT:
+                order_price = f"{Decimal(str(price)):f}"
+                order_decimal_amount = f"{Decimal(str(decimal_amount)):f}"
                 order_result = await self.query_api(self._binance_client.order_limit_buy,
                                                     symbol=symbol,
-                                                    quantity=str(decimal_amount),
-                                                    price=format_float_positional(price),
+                                                    quantity=order_decimal_amount,
+                                                    price=order_price,
                                                     newClientOrderId=order_id)
             elif order_type is OrderType.MARKET:
+                order_decimal_amount = f"{Decimal(str(decimal_amount)):f}"
                 order_result = await self.query_api(self._binance_client.order_market_buy,
                                                     symbol=symbol,
-                                                    quantity=str(decimal_amount),
+                                                    quantity=order_decimal_amount,
                                                     newClientOrderId=order_id)
             else:
                 raise ValueError(f"Invalid OrderType {order_type}. Aborting.")
@@ -1043,15 +1045,18 @@ cdef class BinanceMarket(MarketBase):
             self.c_start_tracking_order(order_id, -1, symbol, False, decimal_amount, order_type)
             order_result = None
             if order_type is OrderType.LIMIT:
+                order_price = f"{Decimal(str(price)):f}"
+                order_decimal_amount = f"{Decimal(str(decimal_amount)):f}"
                 order_result = await self.query_api(self._binance_client.order_limit_sell,
                                                     symbol=symbol,
-                                                    quantity=str(decimal_amount),
-                                                    price=format_float_positional(price),
+                                                    quantity=order_decimal_amount,
+                                                    price=order_price,
                                                     newClientOrderId=order_id)
             elif order_type is OrderType.MARKET:
+                order_decimal_amount = f"{Decimal(str(decimal_amount)):f}"
                 order_result = await self.query_api(self._binance_client.order_market_sell,
                                                     symbol=symbol,
-                                                    quantity=str(decimal_amount),
+                                                    quantity=order_decimal_amount,
                                                     newClientOrderId=order_id)
             else:
                 raise ValueError(f"Invalid OrderType {order_type}. Aborting.")

--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -993,7 +993,7 @@ cdef class BinanceMarket(MarketBase):
                                      self._current_timestamp,
                                      order_type,
                                      symbol,
-                                     decimal_amount,
+                                     float(decimal_amount),
                                      0.0 if math.isnan(price) else price,
                                      order_id
                                  ))
@@ -1066,7 +1066,7 @@ cdef class BinanceMarket(MarketBase):
                                      self._current_timestamp,
                                      order_type,
                                      symbol,
-                                     decimal_amount,
+                                     float(decimal_amount),
                                      0.0 if math.isnan(price) else price,
                                      order_id
                                  ))

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -626,8 +626,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         bid_order_id = self.c_buy_with_specific_market(
                     maker_market,
                     market_pair.maker_symbol,
-                    float(self.order_size),
-                    float(place_bid_price),
+                    self.order_size,
+                    place_bid_price,
                     OrderType.LIMIT,
                     expiration_seconds
                 )
@@ -651,8 +651,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         ask_order_id = self.c_sell_with_specific_market(
                     maker_market,
                     market_pair.maker_symbol,
-                    float(self.order_size),
-                    float(place_ask_price),
+                    self.order_size,
+                    place_ask_price,
                     OrderType.LIMIT,
                     expiration_seconds
                 )

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -205,7 +205,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         return self._ask_place_threshold
 
     @property
-    def order_size(self):
+    def order_size(self) -> float:
         return self._order_size
 
     @logging_options.setter
@@ -598,20 +598,19 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         cdef:
             MarketBase maker_market = market_pair.maker_market
             OrderBook maker_order_book = maker_market.c_get_order_book(market_pair.maker_symbol)
-            top_bid_price = maker_market.c_get_price(market_pair.maker_symbol, False)
-            top_ask_price = maker_market.c_get_price(market_pair.maker_symbol, True)
+            double top_bid_price = maker_market.c_get_price(market_pair.maker_symbol, False)
+            double top_ask_price = maker_market.c_get_price(market_pair.maker_symbol, True)
             str maker_name = maker_market.name
-
-        price_quant = maker_market.get_order_price_quantum(market_pair.maker_symbol, top_bid_price)
-        mid_price = (top_ask_price + top_bid_price) / 2
-        place_bid_price = mid_price * ( 1 - self.bid_place_threshold)
-        place_ask_price = mid_price * ( 1 + self.ask_place_threshold)
-        place_bid_price = round(Decimal(place_bid_price)/price_quant) * price_quant
-        place_ask_price = round(Decimal(place_ask_price)/price_quant) * price_quant
+            object price_quant = maker_market.get_order_price_quantum(
+                market_pair.maker_symbol,
+                top_bid_price
+            )
+            double mid_price = (top_ask_price + top_bid_price) / 2
+            double place_bid_price = mid_price * (1 - self.bid_place_threshold)
+            double place_ask_price = mid_price * (1 + self.ask_place_threshold)
 
         if maker_name in self._radar_relay_type_exchanges:
             expiration_seconds = self._cancel_order_wait_time
-
         else:
             expiration_seconds = NaN
 

--- a/test/test_binance_market.py
+++ b/test/test_binance_market.py
@@ -316,12 +316,14 @@ class BinanceMarketUnitTest(unittest.TestCase):
         quantize_ask_price: Decimal = self.market.quantize_order_price(symbol, ask_price * 1.5)
 
         self.market.buy(symbol, quantized_amount, OrderType.LIMIT, quantize_bid_price)
+        self.market.buy("LOOMETH", amount)
         self.market.sell(symbol, quantized_amount, OrderType.LIMIT, quantize_ask_price)
 
         self.run_parallel(asyncio.sleep(1))
         [cancellation_results] = self.run_parallel(self.market.cancel_all(5))
         for cr in cancellation_results:
             self.assertEqual(cr.success, True)
+        self.market.sell("LOOMETH", amount)
 
     def test_order_price_precision(self):
         symbol = "IOSTETH"
@@ -329,7 +331,7 @@ class BinanceMarketUnitTest(unittest.TestCase):
         ask_price: float = self.market.get_price(symbol, False)
         amount: float = 0.02 / bid_price
         quantized_amount: Decimal = self.market.quantize_order_amount(symbol, amount)
-        order_id = self.market.buy("IOSTETH", amount)
+        self.market.buy("IOSTETH", amount)
 
         # Intentionally setting invalid price to prevent getting filled
         quantize_bid_price: Decimal = self.market.quantize_order_price(symbol, bid_price * 0.7)
@@ -344,7 +346,7 @@ class BinanceMarketUnitTest(unittest.TestCase):
         [cancellation_results] = self.run_parallel(self.market.cancel_all(5))
         for cr in cancellation_results:
             self.assertEqual(cr.success, True)
-        order_id = self.market.sell("IOSTETH", amount)
+        self.market.sell("IOSTETH", amount)
 
     def test_server_time_offset(self):
         BinanceTime.get_instance().SERVER_TIME_OFFSET_CHECK_INTERVAL = 3.0

--- a/test/test_binance_market.py
+++ b/test/test_binance_market.py
@@ -334,8 +334,9 @@ class BinanceMarketUnitTest(unittest.TestCase):
             time_offset = BinanceTime.get_instance().time_offset_ms
             print("offest", time_offset)
             # check if it is less than 5% off
-            self.assertTrue(time_offset > 0)
-            self.assertTrue(abs(time_offset - 30.0 * 1e3) < 1.5 * 1e3)
+            self.assertTrue(time_offset != 0)
+            self.assertTrue((abs(time_offset) - 30.0 * 1e3) < 1.5 * 1e3)
+
 
 
 if __name__ == "__main__":

--- a/test/test_binance_market.py
+++ b/test/test_binance_market.py
@@ -316,14 +316,12 @@ class BinanceMarketUnitTest(unittest.TestCase):
         quantize_ask_price: Decimal = self.market.quantize_order_price(symbol, ask_price * 1.5)
 
         self.market.buy(symbol, quantized_amount, OrderType.LIMIT, quantize_bid_price)
-        self.market.buy("LOOMETH", amount)
         self.market.sell(symbol, quantized_amount, OrderType.LIMIT, quantize_ask_price)
 
         self.run_parallel(asyncio.sleep(1))
         [cancellation_results] = self.run_parallel(self.market.cancel_all(5))
         for cr in cancellation_results:
             self.assertEqual(cr.success, True)
-        self.market.sell("LOOMETH", amount)
 
     def test_order_price_precision(self):
         symbol = "IOSTETH"

--- a/test/test_binance_market.py
+++ b/test/test_binance_market.py
@@ -407,9 +407,8 @@ class BinanceMarketUnitTest(unittest.TestCase):
             time_offset = BinanceTime.get_instance().time_offset_ms
             print("offest", time_offset)
             # check if it is less than 5% off
-            self.assertTrue(time_offset != 0)
-            self.assertTrue((abs(time_offset) - 30.0 * 1e3) < 1.5 * 1e3)
-
+            self.assertTrue(time_offset > 0)
+            self.assertTrue(abs(time_offset - 30.0 * 1e3) < 1.5 * 1e3)
 
 
 if __name__ == "__main__":

--- a/test/test_binance_market.py
+++ b/test/test_binance_market.py
@@ -327,8 +327,8 @@ class BinanceMarketUnitTest(unittest.TestCase):
             self.assertEqual(cr.success, True)
 
     def test_order_price_precision(self):
-        # As of the day this test was written, the min order size is 1 IOST, and
-        # order step size is also 1 IOST.
+        # As of the day this test was written, the min order size (base) is 1 IOST, the min order size (quote) is
+        # 0.01 ETH, and order step size is 1 IOST.
         symbol = "IOSTETH"
         bid_price: float = self.market.get_price(symbol, True)
         ask_price: float = self.market.get_price(symbol, False)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
This fixes an issue where the Binance market connector emits prices in scientific notation (e.g. 1.234e-7) for some trading pairs such as IOSTETH. This is caused by missing quantization for order prices and also incorrect number formatting logic when make orders to Binance.

- Added proper quantization and number formatting logic for both price and order sizes.
- Added unit test case for IOSTETH orders.