### PR TITLE
Introduce a single command to run all stable tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: test
 
 test:
-	nosetests -A 'stable' test/test*.py
+	nosetests -d -v -A 'stable' test/test*.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	nosetests -A 'stable' test/test*.py

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -25,6 +25,7 @@ dependencies:
   - mkl_fft=1.0.10=py36ha843d7b_0
   - mkl_random=1.0.2=py36hd81dba3_0
   - ncurses=6.1=he6710b0_1
+  - nose=1.3.7=py36_2
   - numexpr=2.6.9=py36h9e4a6bb_0
   - numpy=1.15.4=py36h7e9f1db_0
   - numpy-base=1.15.4=py36hde5b4d6_0
@@ -59,7 +60,6 @@ dependencies:
   - zeromq=4.3.1=he6710b0_3
   - zlib=1.2.11=h7b6447c_3
   - pip:
-    - hummingsim==20190524
     - 0x-contract-addresses==2.0.1
     - 0x-contract-artifacts==2.0.0
     - 0x-json-schemas==1.0.0
@@ -73,6 +73,7 @@ dependencies:
     - attrs==18.2.0
     - autobahn==19.2.1
     - automat==0.7.0
+    - cachetools==3.0.0
     - chardet==3.0.4
     - constantly==15.1.0
     - cytoolz==0.9.0.1
@@ -86,25 +87,30 @@ dependencies:
     - eth-typing==2.0.0
     - eth-utils==1.4.1
     - hexbytes==0.1.0
+    - hummingsim==20190524
     - hyperlink==18.0.0
+    - hypothesis==4.23.8
     - idna-ssl==1.1.0
     - incremental==17.5.0
+    - jsonschema==3.0.1
     - kafka-python==1.4.4
     - lru-dict==1.1.6
     - multidict==4.5.2
+    - mypy-extensions==0.4.1
     - parsimonious==0.8.1
     - pyasn1==0.4.5
     - pyasn1-modules==0.2.4
     - pycryptodome==3.7.3
     - pyhamcrest==1.9.0
     - pyperclip==1.7.0
+    - pyrsistent==0.15.2
     - python-binance==0.7.1
     - regex==2019.2.21
     - requests==2.21.0
     - rlp==1.1.0
-    - ruamel.yaml==0.15.89
+    - ruamel-yaml==0.15.89
     - service-identity==18.1.0
-    - tables==3.4.4
+    - stringcase==1.2.0
     - toolz==0.9.0
     - twisted==18.9.0
     - txaio==18.8.1
@@ -112,5 +118,5 @@ dependencies:
     - web3==4.8.3
     - websockets==6.0
     - yarl==1.3.0
-    - zope.interface==4.6.0
-    - cachetools==3.0.0
+    - zope-interface==4.6.0
+prefix: /home/echio/anaconda3/envs/hummingbot

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - mkl=2019.3=199
   - mkl_fft=1.0.10=py36h5e564d8_0
   - mkl_random=1.0.2=py36h27c97d8_0
+  - nose=1.3.7=py36_2
   - ncurses=6.1=h0a44026_1
   - numexpr=2.6.9=py36h7413580_0
   - numpy=1.16.2=py36hacdab7b_0

--- a/test/test_arbitrage.py
+++ b/test/test_arbitrage.py
@@ -2,6 +2,8 @@
 from os.path import join, realpath
 import sys; sys.path.insert(0, realpath(join(__file__, "../../")))
 
+from nose.plugins.attrib import attr
+
 from hummingbot.strategy.market_symbol_pair import MarketSymbolPair
 import logging; logging.basicConfig(level=logging.ERROR)
 import pandas as pd
@@ -26,6 +28,7 @@ from hummingbot.strategy.arbitrage.arbitrage import ArbitrageStrategy
 from hummingbot.strategy.arbitrage.arbitrage_market_pair import ArbitrageMarketPair
 
 
+@attr('stable')
 class ArbitrageUnitTest(unittest.TestCase):
     start: pd.Timestamp = pd.Timestamp("2019-01-01", tz="UTC")
     end: pd.Timestamp = pd.Timestamp("2019-01-01 01:00:00", tz="UTC")
@@ -273,13 +276,3 @@ class ArbitrageUnitTest(unittest.TestCase):
             (1.045, 0.95, 1.1, 0.95, 15.0),
             (1.045, 1.005, 1.1, 1.005, 10.0)
         ])
-
-
-def main():
-    #logging.getLogger("hummingbot.strategy").setLevel(logging.DEBUG)
-    #logging.getLogger("hummingbot").setLevel(logging.DEBUG)
-    unittest.main()
-
-
-if __name__ == "__main__":
-    main()

--- a/test/test_cross_exchange_market_making.py
+++ b/test/test_cross_exchange_market_making.py
@@ -3,6 +3,8 @@
 from os.path import join, realpath
 import sys; sys.path.insert(0, realpath(join(__file__, "../../")))
 
+from nose.plugins.attrib import attr
+
 from decimal import Decimal
 import logging; logging.basicConfig(level=logging.ERROR)
 import pandas as pd
@@ -39,6 +41,7 @@ from hummingbot.strategy.cross_exchange_market_making import CrossExchangeMarket
 from hummingbot.strategy.cross_exchange_market_making.cross_exchange_market_pair import CrossExchangeMarketPair
 
 
+@attr('stable')
 class HedgedMarketMakingUnitTest(unittest.TestCase):
     start: pd.Timestamp = pd.Timestamp("2019-01-01", tz="UTC")
     end: pd.Timestamp = pd.Timestamp("2019-01-01 01:00:00", tz="UTC")
@@ -475,11 +478,3 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         self.assertEqual(0, len(self.strategy.active_bids))
         self.assertEqual(0, len(self.strategy.active_asks))
         self.assertEqual(0, len(self.cancel_order_logger.event_log))
-
-
-def main():
-    unittest.main()
-
-
-if __name__ == "__main__":
-    main()

--- a/test/test_discovery_strategy.py
+++ b/test/test_discovery_strategy.py
@@ -6,6 +6,8 @@ from unittest.mock import create_autospec
 
 sys.path.insert(0, realpath(join(__file__, "../../")))
 
+from nose.plugins.attrib import attr
+
 from hummingbot.strategy.discovery import DiscoveryStrategy, DiscoveryMarketPair
 import logging; logging.basicConfig(level=logging.ERROR)
 import pandas as pd
@@ -23,6 +25,7 @@ def run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+@attr('stable')
 class DiscoveryUnitTest(unittest.TestCase):
     start: pd.Timestamp = pd.Timestamp("2019-01-01", tz="UTC")
     end: pd.Timestamp = pd.Timestamp("2019-01-01 01:00:00", tz="UTC")
@@ -130,10 +133,3 @@ class DiscoveryUnitTest(unittest.TestCase):
 
         run(self.strategy.fetch_market_info(self.market_pair))
         self.assertTrue(self.strategy.get_matching_pair(self.market_pair) == expected_pair)
-
-def main():
-    unittest.main()
-
-
-if __name__ == "__main__":
-    main()

--- a/test/test_pure_market_making.py
+++ b/test/test_pure_market_making.py
@@ -3,6 +3,8 @@
 from os.path import join, realpath
 import sys; sys.path.insert(0, realpath(join(__file__, "../../")))
 
+from nose.plugins.attrib import attr
+
 from decimal import Decimal
 import logging; logging.basicConfig(level=logging.ERROR)
 import pandas as pd
@@ -38,6 +40,7 @@ from hummingbot.strategy.pure_market_making import PureMarketMakingStrategy
 from hummingbot.strategy.pure_market_making.pure_market_pair import PureMarketPair
 
 
+@attr('stable')
 class PureMarketMakingUnitTest(unittest.TestCase):
     start: pd.Timestamp = pd.Timestamp("2019-01-01", tz="UTC")
     end: pd.Timestamp = pd.Timestamp("2019-01-01 01:00:00", tz="UTC")
@@ -369,11 +372,3 @@ class PureMarketMakingUnitTest(unittest.TestCase):
         self.clock.backtest_til(self.start_timestamp + 2 * self.clock_tick_size + 1)
         self.assertEqual(0, len(self.strategy.active_bids))
         self.assertEqual(0, len(self.strategy.active_asks))
-
-
-def main():
-    unittest.main()
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Before submitting this PR, please make sure:

[Y] Your code builds clean without any errors or warnings
[Y] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)
Optional:

Related Github issue: N/A
Related Clubhouse Story: 4099
A description of the changes proposed in the pull request:
Introduce a command to run all stable tests in Hummingbot using Makefile and nose. The set of stable tests is not exhaustive but just to cover the obvious cases.
Going forward we should start to make tests stable by default (with mocks, fakes, etc), but this will be a good start.