### PR TITLE
fix / change defaults for logging and XEMM params

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
@@ -52,7 +52,6 @@ cross_exchange_market_making_config_map = {
     "min_profitability":                ConfigVar(key="min_profitability",
                                                   prompt="What is the minimum profitability for you to make a trade? "\
                                                          "(Enter 0.01 to indicate 1%) >>> ",
-                                                  default=0.003,
                                                   type_str="float"),
     "trade_size_override":              ConfigVar(key="trade_size_override",
                                                   prompt="What is your preferred trade size? (denominated in "
@@ -66,9 +65,9 @@ cross_exchange_market_making_config_map = {
                                                   type_str="list",
                                                   required_if=lambda: False,
                                                   default=[
-                                                      ["^.+(USDT|USDC|USDS|DAI|PAX|TUSD)$", 1000],
-                                                      ["^.+ETH$", 10],
-                                                      ["^.+BTC$", 0.5],
+                                                      ["^.+(USDT|USDC|USDS|DAI|PAX|TUSD)$", 0],
+                                                      ["^.+ETH$", 0],
+                                                      ["^.+BTC$", 0],
                                                   ]),
     "active_order_canceling":           ConfigVar(key="active_order_canceling",
                                                   prompt="Do you want to actively adjust/cancel orders? (Default "\

--- a/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
+++ b/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
@@ -63,7 +63,7 @@ loggers:
         handlers: [console_info, file_handler]
         propagate: false
     hummingbot.market:
-      level: NETWORK
+        level: NETWORK
         handlers: [console_info, file_handler]
         propagate: false
     hummingbot.wallet:

--- a/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
+++ b/hummingbot/templates/hummingbot_logs_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 4
+template_version: 5
 
 formatters:
     simple:
@@ -32,7 +32,7 @@ handlers:
         class: hummingbot.logger.reporting_proxy_handler.ReportingProxyHandler
         level: DEBUG
         proxy_url: https://api.coinalpha.com/reporting-proxy
-        capacity: 5
+        capacity: 1
     "null":
         class: logging.NullHandler
         level: DEBUG
@@ -63,7 +63,7 @@ loggers:
         handlers: [console_info, file_handler]
         propagate: false
     hummingbot.market:
-        level: NETWORK
+      level: NETWORK
         handlers: [console_info, file_handler]
         propagate: false
     hummingbot.wallet:
@@ -80,5 +80,5 @@ loggers:
         propagate: false
 
 root:
-    level: NETWORK
+    level: INFO
     handlers: [console, file_handler]

--- a/hummingbot/templates/log_templates/hummingbot_logs_full_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_full_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 4
+template_version: 5
 
 formatters:
     simple:
@@ -32,7 +32,7 @@ handlers:
         class: hummingbot.logger.reporting_proxy_handler.ReportingProxyHandler
         level: DEBUG
         proxy_url: https://api.coinalpha.com/reporting-proxy
-        capacity: 5
+        capacity: 1
     "null":
         class: logging.NullHandler
         level: DEBUG

--- a/hummingbot/templates/log_templates/hummingbot_logs_none_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_none_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 4
+template_version: 5
 
 formatters:
     simple:
@@ -32,7 +32,7 @@ handlers:
         class: hummingbot.logger.reporting_proxy_handler.ReportingProxyHandler
         level: DEBUG
         proxy_url: https://api.coinalpha.com/reporting-proxy
-        capacity: 5
+        capacity: 1
     "null":
         class: logging.NullHandler
         level: DEBUG

--- a/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
@@ -1,6 +1,6 @@
 ---
 version: 1
-template_version: 4
+template_version: 5
 
 formatters:
     simple:
@@ -32,7 +32,7 @@ handlers:
         class: hummingbot.logger.reporting_proxy_handler.ReportingProxyHandler
         level: DEBUG
         proxy_url: https://api.coinalpha.com/reporting-proxy
-        capacity: 5
+        capacity: 1
     "null":
         class: logging.NullHandler
         level: DEBUG

--- a/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
+++ b/hummingbot/templates/log_templates/hummingbot_logs_summary_TEMPLATE.yml
@@ -63,7 +63,7 @@ loggers:
         handlers: [console_info, file_handler]
         propagate: false
     hummingbot.market:
-      level: NETWORK
+        level: NETWORK
         handlers: [console_info, file_handler]
         propagate: false
     hummingbot.wallet:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
This PR changes some of the default settings in Hummingbot:
* Change log reporting batching capacity to 1 to ensure logging of filled order volume
* Change log template version to 5 to refresh users' log templates 
* Changed default settings for `top_depth_tolerance` in cross-exchange market making to 0. This is a setting for advanced users, and it's potentially confusing for new users, who just want to test it out.
* Deleted the default setting for `min_profitability` in cross-exchange market making. This should be a required user input.
