### PR TITLE
fix / scrolling bug

### DIFF
--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -634,7 +634,7 @@ class HummingbotApplication:
 
         if len(loading_markets) > 0:
             self._notify(f"   x Market check:  Waiting for markets " +
-                         ",".join([m.name.capitalize()  for m in loading_markets]) + f" to get ready for trading. \n"
+                         ",".join([m.name.capitalize() for m in loading_markets]) + f" to get ready for trading. \n"
                          f"                    Please keep the bot running and try to start again in a few minutes. \n")
 
             for market in loading_markets:

--- a/hummingbot/client/ui/custom_widgets.py
+++ b/hummingbot/client/ui/custom_widgets.py
@@ -1,5 +1,10 @@
 from __future__ import unicode_literals
 import six
+from collections import deque
+from typing import (
+    List,
+    Deque,
+)
 
 from prompt_toolkit.auto_suggest import DynamicAutoSuggest
 from prompt_toolkit.buffer import Buffer
@@ -49,7 +54,7 @@ class CustomTextArea:
                  dont_extend_height=False, dont_extend_width=False,
                  line_numbers=False, get_line_prefix=None, scrollbar=False,
                  style='', search_field=None, preview_search=True, prompt='',
-                 input_processors=None):
+                 input_processors=None, max_line_count=1000, initial_text=""):
         assert isinstance(text, six.text_type)
         assert search_field is None or isinstance(search_field, SearchToolbar)
 
@@ -68,6 +73,7 @@ class CustomTextArea:
         self.auto_suggest = auto_suggest
         self.read_only = read_only
         self.wrap_lines = wrap_lines
+        self.max_line_count = max_line_count
 
         self.buffer = CustomBuffer(
             document=Document(text, 0),
@@ -125,6 +131,9 @@ class CustomTextArea:
             right_margins=right_margins,
             get_line_prefix=get_line_prefix)
 
+        self.log_lines: Deque[str] = deque()
+        self.log(initial_text)
+
     @property
     def text(self):
         """
@@ -160,3 +169,22 @@ class CustomTextArea:
 
     def __pt_container__(self):
         return self.window
+
+    def log(self, text: str):
+        if self.window.render_info is None:
+            max_width = 100
+        else:
+            max_width = self.window.render_info.window_width - 2
+        new_lines_raw: List[str] = str(text).split('\n')
+        new_lines = []
+        for line in new_lines_raw:
+            while len(line) > max_width:
+                new_lines.append(line[0:max_width])
+                line = line[max_width:]
+            new_lines.append(line)
+
+        self.log_lines.extend(new_lines)
+        while len(self.log_lines) > self.max_line_count:
+            self.log_lines.popleft()
+        new_text: str = "\n".join(self.log_lines)
+        self.buffer.document = Document(text=new_text, cursor_position=len(new_text))

--- a/hummingbot/client/ui/custom_widgets.py
+++ b/hummingbot/client/ui/custom_widgets.py
@@ -171,10 +171,14 @@ class CustomTextArea:
         return self.window
 
     def log(self, text: str):
+        # Getting the max width of the window area
         if self.window.render_info is None:
             max_width = 100
         else:
             max_width = self.window.render_info.window_width - 2
+
+        # Split the string into multiple lines if there is a "\n" or if the string exceeds max window width
+        # This operation should not be too expensive because only the newly added lines are processed
         new_lines_raw: List[str] = str(text).split('\n')
         new_lines = []
         for line in new_lines_raw:

--- a/hummingbot/client/ui/hummingbot_cli.py
+++ b/hummingbot/client/ui/hummingbot_cli.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 import asyncio
-from typing import Callable, Deque
-from collections import deque
+from typing import Callable
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.application import Application
 from prompt_toolkit.clipboard.pyperclip import PyperclipClipboard
@@ -11,9 +10,13 @@ from prompt_toolkit.eventloop import use_asyncio_event_loop
 from prompt_toolkit.layout.processors import BeforeInput, PasswordProcessor
 from prompt_toolkit.completion import Completer
 
-from hummingbot.client.ui.layout import create_input_field, create_log_field, create_output_field, generate_layout, HEADER
+from hummingbot.client.ui.layout import (
+    create_input_field,
+    create_log_field,
+    create_output_field,
+    generate_layout,
+)
 from hummingbot.client.ui.style import load_style
-from hummingbot.client.settings import MAXIMUM_OUTPUT_PANE_LINE_COUNT
 
 
 class HummingbotCLI:
@@ -32,8 +35,6 @@ class HummingbotCLI:
         self.input_field.accept_handler = self.accept
         self.app = Application(layout=self.layout, full_screen=True, key_bindings=self.bindings, style=load_style(),
                                mouse_support=True, clipboard=PyperclipClipboard())
-        self.log_lines: Deque[str] = deque()
-        self.log(HEADER)
 
         # settings
         self.prompt_text = ">>> "
@@ -66,11 +67,7 @@ class HummingbotCLI:
         self.pending_input = None
 
     def log(self, text: str):
-        self.log_lines.extend(str(text).split('\n'))
-        while len(self.log_lines) > MAXIMUM_OUTPUT_PANE_LINE_COUNT:
-            self.log_lines.popleft()
-        new_text: str = "\n".join(self.log_lines)
-        self.output_field.buffer.document = Document(text=new_text, cursor_position=len(new_text))
+        self.output_field.log(text)
 
     def change_prompt(self, prompt: str, is_password: bool = False):
         self.prompt_text = prompt

--- a/hummingbot/client/ui/layout.py
+++ b/hummingbot/client/ui/layout.py
@@ -21,6 +21,11 @@ from prompt_toolkit.utils import is_windows
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.layout.controls import FormattedTextControl
 
+from hummingbot.client.settings import (
+    MAXIMUM_OUTPUT_PANE_LINE_COUNT,
+    MAXIMUM_LOG_PANE_LINE_COUNT,
+)
+
 
 HEADER = """
                                                    *,.                     
@@ -89,6 +94,8 @@ def create_output_field():
         focus_on_click=False,
         read_only=False,
         scrollbar=True,
+        max_line_count=MAXIMUM_OUTPUT_PANE_LINE_COUNT,
+        initial_text=HEADER,
     )
 
 
@@ -98,6 +105,9 @@ def create_log_field():
         text="Running logs\n",
         focus_on_click=False,
         read_only=False,
+        scrollbar=True,
+        max_line_count=MAXIMUM_LOG_PANE_LINE_COUNT,
+        initial_text="Running Logs \n"
     )
 
 

--- a/hummingbot/client/ui/stdout_redirection.py
+++ b/hummingbot/client/ui/stdout_redirection.py
@@ -2,12 +2,8 @@
 
 from __future__ import unicode_literals
 from prompt_toolkit.eventloop import get_event_loop
-from prompt_toolkit.document import Document
-from hummingbot.client.settings import MAXIMUM_LOG_PANE_LINE_COUNT
 
 from contextlib import contextmanager
-from collections import deque
-from typing import Deque
 import threading
 import sys
 
@@ -56,19 +52,13 @@ class StdoutProxy(object):
         self.errors = original_stdout.errors
         self.encoding = original_stdout.encoding
         self.log_field = log_field
-        self.log_lines: Deque[str] = deque()
-        self.log_lines.append("Running logs\n")
 
     def _write_and_flush(self, text):
         if not text:
             return
 
         def write_and_flush():
-            self.log_lines.extend(text.split("\n"))
-            while len(self.log_lines) > MAXIMUM_LOG_PANE_LINE_COUNT:
-                self.log_lines.popleft()
-            new_text: str = "\n".join(self.log_lines)
-            self.log_field.buffer.document = Document(text=new_text, cursor_position=len(new_text))
+            self.log_field.log(text)
 
         get_event_loop().call_from_executor(write_and_flush)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
There is bug that prevents the output pane scrolling when bounty terms (or any large chunk of text) is printed. This is caused by a known bug in prompt toolkit (https://github.com/prompt-toolkit/python-prompt-toolkit/issues/686). 

The issue is that a long line of text gets visually "wrapped" in a window, but the program only reads its height as 1 because there is no line break. This is not obvious at first since most lines don't exceed the window's width. But as more logs are added, the difference between the visual height and the calculated height becomes bigger, and scrolling breaks because it depends on calculated window height.

My workaround is basically breaking lines that exceed window width to chunks and log them as separate lines.

This fixes our original log pane scrolling issue as well.