### PR TITLE
fix / vulnerable_parsers

### DIFF
--- a/hummingbot/__init__.py
+++ b/hummingbot/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import logging
 from typing import Optional
 import logging
 import subprocess

--- a/hummingbot/strategy/discovery/discovery_config_map.py
+++ b/hummingbot/strategy/discovery/discovery_config_map.py
@@ -1,13 +1,13 @@
+import json
+from typing import Any
+
 from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.client.config.config_validators import (
-    is_exchange,
-)
+from hummingbot.client.config.config_validators import is_exchange
 from hummingbot.client.settings import (
     EXAMPLE_PAIRS,
     required_exchanges,
 )
 from hummingbot.core.utils.symbol_fetcher import SymbolFetcher
-from typing import Any
 
 
 def discovery_symbol_list_prompt(market_name):
@@ -20,7 +20,7 @@ def trading_pair_array_validator(market: str, trading_pair_list: Any):
         if type(trading_pair_list) is str:
             if len(trading_pair_list) == 0:
                 return True
-            trading_pair_list = eval(trading_pair_list)
+            trading_pair_list = json.loads(trading_pair_list)
 
         known_symbols = SymbolFetcher.get_instance().symbols.get(market, [])
         if len(known_symbols) == 0:


### PR DESCRIPTION
This fixes https://github.com/CoinAlpha/hummingbot/issues/555

**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
https://github.com/CoinAlpha/hummingbot/issues/555
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This patch removes all `eval()` from hummingbot code. No change to YAML.load() since we're using the `ruamel.yaml` parser rather than the pyyaml parser - the `RoundTripConstructor` and `RoundTripParser` behind the default rumal.yaml parser doesn't allow escape objects and is thus safe against arbitrary code execution attacks.