### PR TITLE
(docs) move developer docs to own section

### DIFF
--- a/documentation/docs/cheatsheets/client.md
+++ b/documentation/docs/cheatsheets/client.md
@@ -32,14 +32,14 @@
 |-------- | ----------- | ----------- |
 | `Double CTRL + C` | Exit | Press `CTRL + C` twice to exit the bot.
 | `CTRL + S` | Status | Show bot status.
-| `CTRL + F` | *Search / Hide Search | Toggle search in log pane.
+| `CTRL + F` | Search | Toggles search in log pane (see below for usage)
 | `CTRL + A` | Select All | Select all text in input pane [used for text edit in Input pane only].
 | `CTRL + Z` | Undo | Undo action in input pane [used for text edit in Input pane only].
 | `Single CTRL + C` | Copy | Copy text [used for text edit in Input pane only].
 | `CTRL + V` | Paste | Paste text [used for text edit in Input pane only].
 
-***Note about search:*** 
-1. Press `CTRL + F` to trigger display the search field
-2. Enter your search keyword (not case sensitive)
-3. Hit `Enter` to jump to the next matching keyword (incremental search)
-4. When you are done. Press `CTRL + F` again to go back to reset.
+!!! tip "Tip: How to use the Search feature"
+    1. Press `CTRL + F` to trigger display the search field
+    2. Enter your search keyword (not case sensitive)
+    3. Hit `Enter` to jump to the next matching keyword (incremental search)
+    4. When you are done. Press `CTRL + F` again to go back to reset.

--- a/documentation/docs/developers/connectors/index.md
+++ b/documentation/docs/developers/connectors/index.md
@@ -1,0 +1,5 @@
+# Developing Connectors
+
+This is a stub page that doesn't yet have content.
+
+Help improve it by clicking the pencil icon on the right.

--- a/documentation/docs/developers/exchange-connectors.md
+++ b/documentation/docs/developers/exchange-connectors.md
@@ -1,1 +1,0 @@
-🚧 Content for this page is currently under development.

--- a/documentation/docs/developers/index.md
+++ b/documentation/docs/developers/index.md
@@ -1,3 +1,13 @@
+# Developer Manual
+
+This section is for developers looking to contribute to Hummingbot or extend its capabilities:
+
+* [Strategies](/developers/strategies): Create and customize your own strategies
+* [Connectors](/developers/connectors): Develop new exchange connectors *(coming soon!)*
+* [Debug console](/developers/debug): Inspect and modify Hummingbot state while it's running
+
+## Contributing to Hummingbot
+
 Hummingbot is an open source project intended to provide a base layer infrastructure for users to customize and develope their own strategies, features, and add on new exchange connectors.
 
 We welcome code contributions.

--- a/documentation/docs/developers/strategies/index.md
+++ b/documentation/docs/developers/strategies/index.md
@@ -1,4 +1,4 @@
-## Strategies Architecture
+# Strategies Architecture
 
 ![StrategyBase class relations](/assets/img/strategy-uml.svg)
 
@@ -8,7 +8,7 @@ The concrete strategy classes included with Hummingbot, including [`ArbitrageStr
 
 Each `StrategyBase` object may be managing multiple [`MarketBase`](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/market/market_base.pyx) and [`WalletBase`](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/wallet/wallet_base.pyx) objects.
 
-### How It Works
+## How It Works
 
 All strategy modules are child classes of [`TimeIterator`](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/strategy/strategy_base.pyx), which is called via `c_tick()` every second.
 
@@ -16,7 +16,7 @@ What this means is, a running strategy module is called every second via its `c_
 
 If you're reading or writing a strategy module, the `c_tick()` function should be treated as the entry point of a strategy module. If you're reading a strategy module's code, `c_tick()` should be where you start. If you're writing a new strategy module, `c_tick()` is also going to where you start writing the important bits of your strategy.
 
-### Markets
+## Markets
 
 Each `StrategyBase` object may be associated with multiple markets.
 
@@ -32,7 +32,7 @@ Each `StrategyBase` object may be associated with multiple markets.
 
     List of `MarketBase` objects currently associated with this `StrategyBase` object.
 
-### Market Events Interface
+## Market Events Interface
 
 The `StrategyBase` class comes with a set of interfaces functions for handling market events from associated `MarketBase` objects, which may be overridded by child classes to receive and process market events.
 
@@ -70,7 +70,7 @@ The event interface functions are as follows:
 
     A sell order has been completely filled. Argument is a [`SellOrderCompletedEvent`](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/core/event/events.py) object.
 
-### Creating and Cancelling Orders
+## Creating and Cancelling Orders
 
 `StrategyBase` includes pre-defined logic for creating and cancelling trading orders - which are the primary ways for a strategy to interact with associated markets.
 
@@ -102,7 +102,7 @@ It is highly encouraged to use these functions to create and remove orders, rath
     - `market_pair`: a `MarketSymbolPair` object specifying the `MarketBase` object and market symbol to cancel order from.
     - `order_id`: Order ID string returned from a previous call to order creation functions above.
 
-### Order Tracking
+## Order Tracking
 
 Each `StrategyBase` object comes with an internal attribute `_sb_order_tracker`, which is an [`OrderTracker`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/order_tracker.pyx) object. The `OrderTracker` object is responsible for tracking all active and in-flight orders created by the `StrategyBase` object, and also all in-flight order cancels.
 
@@ -147,76 +147,3 @@ Below are some of the user functions or properties under `OrderTracker` that you
     Returns a dictionary of order IDs that are being cancelled.
 
     Return type: `Dict[str, float]`
-
-
-## Pure Market Making
-
-### Architecture
-
-The built-in pure market making strategy in Hummingbot periodically requests limit order proposals from configurable order pricing and sizing plugins, and also periodically refreshes the orders by cancelling existing limit orders.
-
-Here's a high level view of the logic flow inside the built-in pure market making strategy.
-
-![Figure 5: Pure market making strategy logical flowchart](/assets/img/pure-mm-flowchart.svg)
-
-The pure market making strategy operates in a tick-by-tick manner, as described in the [Strategies Overview](/strategies) document. Each tick is typically 1 second, although it can be programmatically modified to longer or shorter durations.
-
-At each tick, the pure market making strategy would first query the order filter plugin whether to proceed or not. Assuming the answer is yes, then it'll query the order pricing and sizing plugins and calculate whether and what market making orders it should emit. At the same time, it'll also look at any existing limit orders it previously placed on the market and decide whether it should cancel those.
-
-The process repeats over and over at each tick, causing limit orders to be periodically placed and cancelled according to the proposals made by the order pricing and sizing plugins.
-
-### Plugins
-
-There are a few plugin interfaces that the pure market making strategy depends on arriving at its order proposals.
-
-![Figure 6: Pure market making strategy plugins](/assets/img/pure-mm-uml.svg)
-
-* [`OrderFilterDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_filter_delegate.pxd)
-
-    Makes the Yes / No decision to proceed with processing the current clock tick or not.
-
-* [`OrderPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_pricing_delegate.pxd)
-
-    Returns a [`PriceProposal`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/data_types.py) with lists of prices for creating bid and ask orders. If no order should be created at the current clock tick (e.g. because there're already existing orders), it may choose to return empty lists instead.
-
-* [`OrderSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_sizing_delegate.pxd)
-
-    Returns a [`SizingProposal`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/data_types.py) with lists of order sizes for creating bid and ask orders, given the pricing proposal. If a proposed order at a certain price should not be created (e.g. there's not enough balance on the exchange), it may choose to return zero size for that order instead.
-
-### Built-in Plugins
-
-If you configure the pure market making strategy with multiple orders **disabled**, then Hummingbot will be using [`ConstantSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_spread_pricing_delegate.pyx) and [`ConstantSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_size_sizing_delegate.pyx) for the pricing and sizing plugins.
-
-#### ConstantSpreadPricingDelegate
-
-If you look into the logic of the [`ConstantSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_spread_pricing_delegate.pyx), it's extremely simple - it'll always propose a bid and an ask order at a pre-configured spread from the current mid-price. It doesn't do any checks about whether you have existing orders, or have enough balance to create the orders - but that's fine.
-
-#### ConstantSizeSizingDelegate
-
-The logic inside [`ConstantSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_size_sizing_delegate.pyx) looks a bit more involved, because it's checking whether there're existing limit orders that are still active, and also whether there's enough balance in the exchange to create new orders. But beyond the checks, it's really just proposing constant order size proposals.
-
-If all the checks are green (i.e. no active limit orders, and enough balance to make new orders), then it will make an order size proposal with the pre-configured size on both the bid and ask sides. Otherwise, it'll propose 0 order sizes.
-
-If you configure the pure market making strategy with multiple orders **enabled**, then Hummingbot will be using [`ConstantMultipleSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_multiple_spread_pricing_delegate.pyx) and [`StaggeredMultipleSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/staggered_multiple_size_sizing_delegate.pyx) for the pricing and sizing plugins instead.
-
-### Refreshing orders periodically
-
-For each limit order that was emitted by the pure market making strategy, an expiry timestamp would be generated for that order and the order will be tracked by the strategy. The time until expiry for new orders is configured via the **cancel_order_wait_time** option in [Configuration Parameters](#configuration-parameters).
-
-Once an order's expiration time has passed, the pure market making strategy will create a cancel order proposal for that order.
-
-### Executing order proposals
-
-After collecting all the order pricing, sizing and cancel order proposals from plugins and the internal refresh order logic - the pure market making strategy logic will merge all of the proposals and execute them.
-
-### Example Order Flow
-
-Below is a hypothetical example of how the pure market making strategy works for a few clock ticks.
-
-At clock tick *n*, there may be existing limit orders on both the bid and ask sides, and both have not yet expired. Assuming we're using the `ConstantSizeSizingDelegate` and `ConstantSpreadPricingDelegate` in this case, the proposed sizes for new orders will be 0. There'll be no cancel order proposals. So the strategy will do nothing for this clock tick.
-
-At clock tick *n+1*, the limit bid order has expired. The strategy will then generate a cancel order proposal for the expired bid order. The cancellation will then be send to the exchange and executed.
-
-At clock tick *n+2*, the `ConstantSizeSizingDelegate` notices there's no longer an order at the bid side. So it'll propose a non-zero order size for a new bid order. Let's assume the existing ask order hasn't expired yet, so no cancellation proposals will be generated at this clock tick. At the execution phase, the strategy will simply create a bid order calculated from the current market mid-price. Thus the bid order is refreshed.
-
-This cycle of order creation and order cancellation will repeat again and again for as long as the strategy is running. If a limit order is completely filled by a market order, the strategy will simply refresh it at the next clock tick.

--- a/documentation/docs/developers/strategies/pure-market-making.md
+++ b/documentation/docs/developers/strategies/pure-market-making.md
@@ -1,0 +1,71 @@
+# Pure Market Making
+
+## Architecture
+
+The built-in pure market making strategy in Hummingbot periodically requests limit order proposals from configurable order pricing and sizing plugins, and also periodically refreshes the orders by cancelling existing limit orders.
+
+Here's a high level view of the logic flow inside the built-in pure market making strategy.
+
+![Figure 5: Pure market making strategy logical flowchart](/assets/img/pure-mm-flowchart.svg)
+
+The pure market making strategy operates in a tick-by-tick manner, as described in the [Strategies Overview](/strategies) document. Each tick is typically 1 second, although it can be programmatically modified to longer or shorter durations.
+
+At each tick, the pure market making strategy would first query the order filter plugin whether to proceed or not. Assuming the answer is yes, then it'll query the order pricing and sizing plugins and calculate whether and what market making orders it should emit. At the same time, it'll also look at any existing limit orders it previously placed on the market and decide whether it should cancel those.
+
+The process repeats over and over at each tick, causing limit orders to be periodically placed and cancelled according to the proposals made by the order pricing and sizing plugins.
+
+## Plugins
+
+There are a few plugin interfaces that the pure market making strategy depends on arriving at its order proposals.
+
+![Figure 6: Pure market making strategy plugins](/assets/img/pure-mm-uml.svg)
+
+* [`OrderFilterDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_filter_delegate.pxd)
+
+    Makes the Yes / No decision to proceed with processing the current clock tick or not.
+
+* [`OrderPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_pricing_delegate.pxd)
+
+    Returns a [`PriceProposal`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/data_types.py) with lists of prices for creating bid and ask orders. If no order should be created at the current clock tick (e.g. because there're already existing orders), it may choose to return empty lists instead.
+
+* [`OrderSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_sizing_delegate.pxd)
+
+    Returns a [`SizingProposal`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/data_types.py) with lists of order sizes for creating bid and ask orders, given the pricing proposal. If a proposed order at a certain price should not be created (e.g. there's not enough balance on the exchange), it may choose to return zero size for that order instead.
+
+## Built-in Plugins
+
+If you configure the pure market making strategy with multiple orders **disabled**, then Hummingbot will be using [`ConstantSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_spread_pricing_delegate.pyx) and [`ConstantSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_size_sizing_delegate.pyx) for the pricing and sizing plugins.
+
+### ConstantSpreadPricingDelegate
+
+If you look into the logic of the [`ConstantSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_spread_pricing_delegate.pyx), it's extremely simple - it'll always propose a bid and an ask order at a pre-configured spread from the current mid-price. It doesn't do any checks about whether you have existing orders, or have enough balance to create the orders - but that's fine.
+
+### ConstantSizeSizingDelegate
+
+The logic inside [`ConstantSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_size_sizing_delegate.pyx) looks a bit more involved, because it's checking whether there're existing limit orders that are still active, and also whether there's enough balance in the exchange to create new orders. But beyond the checks, it's really just proposing constant order size proposals.
+
+If all the checks are green (i.e. no active limit orders, and enough balance to make new orders), then it will make an order size proposal with the pre-configured size on both the bid and ask sides. Otherwise, it'll propose 0 order sizes.
+
+If you configure the pure market making strategy with multiple orders **enabled**, then Hummingbot will be using [`ConstantMultipleSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_multiple_spread_pricing_delegate.pyx) and [`StaggeredMultipleSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/staggered_multiple_size_sizing_delegate.pyx) for the pricing and sizing plugins instead.
+
+## Refreshing Orders
+
+For each limit order that was emitted by the pure market making strategy, an expiry timestamp would be generated for that order and the order will be tracked by the strategy. The time until expiry for new orders is configured via the **cancel_order_wait_time** option in [Configuration Parameters](#configuration-parameters).
+
+Once an order's expiration time has passed, the pure market making strategy will create a cancel order proposal for that order.
+
+## Executing Order Proposals
+
+After collecting all the order pricing, sizing and cancel order proposals from plugins and the internal refresh order logic - the pure market making strategy logic will merge all of the proposals and execute them.
+
+## Example Order Flow
+
+Below is a hypothetical example of how the pure market making strategy works for a few clock ticks.
+
+At clock tick *n*, there may be existing limit orders on both the bid and ask sides, and both have not yet expired. Assuming we're using the `ConstantSizeSizingDelegate` and `ConstantSpreadPricingDelegate` in this case, the proposed sizes for new orders will be 0. There'll be no cancel order proposals. So the strategy will do nothing for this clock tick.
+
+At clock tick *n+1*, the limit bid order has expired. The strategy will then generate a cancel order proposal for the expired bid order. The cancellation will then be send to the exchange and executed.
+
+At clock tick *n+2*, the `ConstantSizeSizingDelegate` notices there's no longer an order at the bid side. So it'll propose a non-zero order size for a new bid order. Let's assume the existing ask order hasn't expired yet, so no cancellation proposals will be generated at this clock tick. At the execution phase, the strategy will simply create a bid order calculated from the current market mid-price. Thus the bid order is refreshed.
+
+This cycle of order creation and order cancellation will repeat again and again for as long as the strategy is running. If a limit order is completely filled by a market order, the strategy will simply refresh it at the next clock tick.

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -11,7 +11,8 @@ Hummingbot is open source software that helps you create, configure and manage h
 ## How the documentation is organized
 
 * [General](/): For new users. Learn about how Hummingbot works, install the software, and quickly start running your first bot.
-* [User Manual](/manual): For experienced users who want to get the most of Hummingbot, and for developers looking to contribute to or extend Hummingbot's capabilities.
+* [User Manual](/manual): For experienced users who want to get the most of Hummingbot
+* [Developer Manual](/developers): For developers looking to contribute to Hummingbot or extend its capabilities
 * [Release Notes](/release-notes): New features, bug fixes, and other updates from our bi-weekly releases.
 
 ## First steps

--- a/documentation/docs/manual.md
+++ b/documentation/docs/manual.md
@@ -1,11 +1,11 @@
 # User Manual
 
-This section is for experienced users who want to get the most of Hummingbot, as well as for developers looking to contribute to or extend Hummingbot's capabilities:
+This section is for experienced users who want to get the most of Hummingbot:
 
-* Installation: How to install Hummingbot via Docker or from source, on a variety of platforms.
-* Configuration: How to configure a trading bot
-* Operation: How to run and manage your trading bots
-* Connectors: Reference for connectors to centralized and decentralized exchanges, along with how to create your own connectors
-* Strategies: Reference for trading strategies available in Hummingbot, along with how to create your own strategies
-* Data feeds: Reference for external data feeds used to fetch real-time conversion rates, along with how to add your own
-* Utilities: Miscellaneous features such as logging, Telegram integration, and the debug console
+* [Installation](/installation): How to install Hummingbot via Docker or from source, on a variety of platforms.
+* [Configuration](/operation/configuration): How to configure a trading bot
+* [Operation](/operation/client): How to run and manage your trading bots
+* [Connectors](/connectors): Reference for connectors to centralized and decentralized exchanges
+* [Strategies](/strategies): Reference for trading strategies available in Hummingbot
+* [Data Feeds](/feeds): Reference for external data feeds used to fetch real-time conversion rates, along with how to add your own
+* Utilities: Miscellaneous features such as [logging](operation/logging) and the [Telegram integration](/operation/telegram).

--- a/documentation/docs/release-notes/0.11.0.md
+++ b/documentation/docs/release-notes/0.11.0.md
@@ -1,0 +1,36 @@
+# Release Notes - Version 0.11.0
+
+🚀Welcome to `hummingbot` version 0.11.0! In this release, we focused on making Hummingbot more accessible for developers and improving the bounty hunter experience. Please see below for what's new in this release.
+
+## 📝 Introducing the Developer Manual
+
+## 📝 New strategy: `simple_trade`
+
+## 🐞 Bounty registration recovery
+
+## 🐞 Fraud detection and trade verification
+
+## 🛑 CoinGecko data feed integration
+
+## 🐞 Other bug fixes and miscellaneous updates
+
+Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/support/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+
+Below are the main ones that we fixed in this release:
+
+* IDEX min bug
+* Fixed a bug that prevented trading bots from running due to a legacy data feed dependency
+* Removed the need to enter in an Ethereum node address when running bots on centralized exchanges
+* Added more detailed performance calculations in the `history` command
+* Warnings in the `status` output are now cleared when the bot is re-configured
+* Users can now re-register for Liquidity Bounties if something goes wrong the first time
+
+## Coming soon
+
+Here's what we currently working on that we expect to ship in the next month:
+
+* Paper trading mode
+* Improvements to the **pure market making** strategy
+* Updated **Bamboo Relay** connector
+* New connector: Huobi Global
+* New connector: Bittrex

--- a/documentation/docs/release-notes/index.md
+++ b/documentation/docs/release-notes/index.md
@@ -2,4 +2,4 @@
 
 We generally release a new version of Hummingbot every 2 weeks, along with periodic intermittent releases.
 
-The latest stable release is **[0.10.1](/release-notes/0.10.1)**, released on July 16, 2019. This release is a hotfix to version [0.10.0](/release-notes/0.10.0).
+The latest stable release is **[0.11.0](/release-notes/0.11.0)**, released on July 29, 2019.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -141,11 +141,13 @@ nav:
         - Logs and Logging: operation/logging.md
         - Using Exchange Rates: operation/exchange-rates.md
         - Integrating Telegram: operation/telegram.md
-      - Developers:
-        - Overview: developers/index.md
+    - Developer Manual:
+        - Intro: developers/index.md
+        - Strategies: 
+          - Architecture: developers/strategies/index.md
+          - Pure Market Making: developers/strategies/pure-market-making.md
+        - Connectors: developers/connectors/index.md
         - Debug Console: developers/debug.md
-        - Strategies: developers/strategies.md
-        - Exchange Connectors: developers/exchange-connectors.md
     - Release Notes:
       - About Releases: release-notes/index.md
       - 0.10.1: release-notes/0.10.1.md

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -150,6 +150,7 @@ nav:
         - Debug Console: developers/debug.md
     - Release Notes:
       - About Releases: release-notes/index.md
+      - 0.11.0: release-notes/0.11.0.md
       - 0.10.1: release-notes/0.10.1.md
       - 0.10.0: release-notes/0.10.0.md
       - 0.9.1: release-notes/0.9.1.md


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
* Moved developer-focused docs to it's own "developer manual" section
* Text changes
* Added tip box for the search feature