### PR TITLE
fix / binance race condition

### DIFF
--- a/hummingbot/market/binance/binance_market.pxd
+++ b/hummingbot/market/binance/binance_market.pxd
@@ -18,6 +18,7 @@ cdef class BinanceMarket(MarketBase):
         double _last_pull_timestamp
         dict _in_flight_deposits
         dict _in_flight_orders
+        dict _order_not_found_records
         TransactionTracker _tx_tracker
         dict _withdraw_rules
         dict _trading_rules


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #601
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This patch adds a mechanism to require "Order does not exist" errors to be confirmed 3 times before treating it as failed, which fixes a race condition bug between the order status check loop and order creation.