### PR TITLE
docs / macOS script download link & IDEX new update

### DIFF
--- a/documentation/docs/connectors/bamboo-relay.md
+++ b/documentation/docs/connectors/bamboo-relay.md
@@ -2,8 +2,8 @@
 
 ## About Bamboo Relay
 
-[Bamboo Relay](https://bamboorelay.com/) is an exchange application specializing in ERC-20 tokens that uses the [0x Protocol](https://0x.org/). 
- Currently, Bamboo Relay allows any user to connect their wallet and trade between any coin pair combination. 
+[Bamboo Relay](https://bamboorelay.com/) is an exchange application specializing in ERC-20 tokens that uses the [0x Protocol](https://0x.org/).
+ Currently, Bamboo Relay allows any user to connect their wallet and trade between any coin pair combination.
 
 ## Using the Connector
 
@@ -32,7 +32,7 @@ When running the connector in coordinated mode it is advised to enable this sett
 
 ### Minimum Order Sizes
 
-The minimum acceptable order size is 0.00000001 normalized units of price, amount or total, which ever of these is the lowest.
+The minimum acceptable order size is 0.00000001 normalized units of price, amount or total, whichever of these is the lowest.
 
 ### Transaction Fees
 

--- a/documentation/docs/connectors/ddex.md
+++ b/documentation/docs/connectors/ddex.md
@@ -62,4 +62,4 @@ In this example, the minimum order size is 0.5 WETH.
 
 ### Transaction Fees
 
-The standard charge for transactions on DDEX is 0.1% for market makers and 0.3% for market takers. However, high volume market makers and hydro protocol token holders can recieve discounted trading fees. More details can be on the DDEX [trading fees page](https://ddex.zendesk.com/hc/en-us/articles/115004535333-DDEX-1-0-Fees-Update).
+The standard charge for transactions on DDEX is 0.1% for market makers and 0.3% for market takers. However, high volume market makers and hydro protocol token holders can receive discounted trading fees. More details can be on the DDEX [trading fees page](https://ddex.zendesk.com/hc/en-us/articles/115004535333-DDEX-1-0-Fees-Update).

--- a/documentation/docs/connectors/idex.md
+++ b/documentation/docs/connectors/idex.md
@@ -19,6 +19,10 @@ IDEX requires an API key authentication to access API endpoints required for Hum
 
 ## Miscellaneous Info
 
+### Asset Availability for US Markets
+
+In compliance with US laws, IDEX has limit access to certain assets for customers in the US region (see [Updated Asset Availability for US Markets](https://medium.com/idex/idex-kyc-transition-period-and-updated-asset-availability-for-us-markets-set-to-begin-d45e945f842d)).
+
 ### Minimum Order Sizes
 
 For IDEX, maker orders must be at least the equivalent of 0.15 ETH and taker orders must be at least 0.05 ETH. In general, this means that maker orders must be at minimum $40 and taker orders should be greater than $13.

--- a/documentation/docs/installation/from-source/macOS.md
+++ b/documentation/docs/installation/from-source/macOS.md
@@ -48,7 +48,7 @@ You can install Hummingbot by selecting ***either*** of the following options fr
 
 ```bash tab="Option 1: Easy Install"
 # 1) Download Hummingbot install script
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/from-source/install-source-macOS.sh -o install-source-macOS.sh
+curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/install-from-source/install-source-macOS.sh -o install-source-macOS.sh
 
 # 2) Enable script permissions
 chmod a+x install-source-macOS.sh

--- a/documentation/docs/operation/client.md
+++ b/documentation/docs/operation/client.md
@@ -35,8 +35,8 @@ Hummingbot can automatically start the execution of a previously configured trad
 ```bash tab="Docker command"
 docker run -it \
 -e STRATEGY=${STRATEGY} \
--e CONFIG_FILE_NAME=${CONFIG_FILENAME}" \
--e WALLET=${WALLET}
+-e CONFIG_FILE_NAME=${CONFIG_FILENAME} \
+-e WALLET=${WALLET} \
 -e WALLET_PASSWORD=${WALLET_PASSWORD} \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**Optional**:
- Related Github issue: https://github.com/CoinAlpha/hummingbot/issues/716

**A description of the changes proposed in the pull request**:

- corrected link to specify download path of installation script for MacOS.
- added information and reference URL regarding asset availability for US markets for IDEX
- fixed minor typo errors