### PR TITLE
feat / paper trade ui

### DIFF
--- a/hummingbot/client/command/__init__.py
+++ b/hummingbot/client/command/__init__.py
@@ -7,6 +7,7 @@ from .get_balance_command import GetBalanceCommand
 from .help_command import HelpCommand
 from .history_command import HistoryCommand
 from .list_command import ListCommand
+from .paper_trade_command import PaperTradeCommand
 from .start_command import StartCommand
 from .status_command import StatusCommand
 from .stop_command import StopCommand
@@ -22,6 +23,7 @@ __all__ = [
     HelpCommand,
     HistoryCommand,
     ListCommand,
+    PaperTradeCommand,
     StartCommand,
     StatusCommand,
     StopCommand,

--- a/hummingbot/client/command/bounty_command.py
+++ b/hummingbot/client/command/bounty_command.py
@@ -114,7 +114,7 @@ class BountyCommand:
                     self._notify("\nYour wallets:")
                     self.list("wallets")
 
-                value = await self.config_single_variable(cvar)
+                value = await self.prompt_single_variable(cvar)
                 cvar.value = parse_cvar_value(cvar, value)
                 if cvar.type == "bool" and cvar.value is False:
                     raise ValueError(f"{cvar.key} is required.")

--- a/hummingbot/client/command/config_command.py
+++ b/hummingbot/client/command/config_command.py
@@ -34,27 +34,34 @@ class ConfigCommand:
     def config(self,  # type: HummingbotApplication
                key: str = None,
                key_list: Optional[List[str]] = None):
+        """
+        Router function that for all commands related to bot configuration
+        """
         self.app.clear_input()
-
         if self.strategy or (self.config_complete and key is None):
             asyncio.ensure_future(self.reset_config_loop(key))
             return
-        if key is not None and key not in load_required_configs().keys():
-            self._notify("Invalid config variable %s" % (key,))
-            return
+
         if key is not None:
-            keys = [key]
+            try:
+                self._get_config_var_with_key(key)
+                asyncio.ensure_future(self._config_single_key(key), loop=self.ev_loop)
+            except ValueError as e:
+                self.logger().error(e)
+                self._notify("Invalid config variable %s" % (key,))
+
         elif key_list is not None:
             keys = key_list
+            asyncio.ensure_future(self._config_loop(keys), loop=self.ev_loop)
         else:
             keys = self._get_empty_configs()
-        asyncio.ensure_future(self._config_loop(keys), loop=self.ev_loop)
+            asyncio.ensure_future(self._config_loop(keys), loop=self.ev_loop)
 
     @property
     def config_complete(self,  # type: HummingbotApplication
-                        ):
+                        ) -> bool:
         config_map = load_required_configs()
-        keys = self.key_filter(self._get_empty_configs())
+        keys = self._get_empty_configs()
         for key in keys:
             cvar = config_map.get(key)
             if cvar.value is None and cvar.required:
@@ -65,6 +72,15 @@ class ConfigCommand:
     def _get_empty_configs() -> List[str]:
         config_map = load_required_configs()
         return [key for key, config in config_map.items() if config.value is None]
+
+    @staticmethod
+    def get_all_available_config_keys() -> List[str]:
+        all_available_config_keys = list(in_memory_config_map.keys()) + list(global_config_map.keys())
+        current_strategy: str = in_memory_config_map.get("strategy").value
+        strategy_cm: Optional[Dict[str, ConfigVar]] = get_strategy_config_map(current_strategy)
+        if strategy_cm:
+            all_available_config_keys += list(strategy_cm.keys())
+        return all_available_config_keys
 
     async def reset_config_loop(self,  # type: HummingbotApplication
                                 key: str = None):
@@ -171,10 +187,17 @@ class ConfigCommand:
             strategy_path = await self._import_or_create_strategy_config()
         return strategy_path
 
-    async def config_single_variable(self,  # type: HummingbotApplication
+    async def prompt_single_variable(self,  # type: HummingbotApplication
                                      cvar: ConfigVar,
-                                     is_single_key: bool = False) -> Any:
-        if cvar.required or is_single_key:
+                                     requirement_overwrite: bool = False) -> Any:
+        """
+        Prompt a single variable in the input pane, validates and returns the user input
+        :param cvar: the config var to be prompted
+        :param requirement_overwrite: Set to true when a config var is forced to be prompted,
+               even if it is not required by default setting
+        :return: a validated user input or the variable's default value
+        """
+        if cvar.required or requirement_overwrite:
             if cvar.key == "strategy_file_path":
                 val = await self._import_or_create_strategy_config()
             elif cvar.key == "wallet":
@@ -188,67 +211,56 @@ class ConfigCommand:
                 val = await self.app.prompt(prompt=cvar.prompt, is_password=cvar.is_secure)
             if not cvar.validate(val):
                 self._notify("%s is not a valid %s value" % (val, cvar.key))
-                val = await self.config_single_variable(cvar)
+                val = await self.prompt_single_variable(cvar, requirement_overwrite)
         else:
             val = cvar.value
         if val is None or (isinstance(val, string_types) and len(val) == 0):
             val = cvar.default
         return val
 
-    def key_filter(self, keys: List[str]):
-        try:
-            exclude_keys = set()
-            if global_config_map.get("paper_trade_enabled").value:
-                exclude_keys.update(["wallet",
-                                     "coinbase_pro_api_key",
-                                     "coinbase_pro_secret_key",
-                                     "coinbase_pro_passphrase",
-                                     "binance_api_key",
-                                     "binance_api_secret",
-                                     "huobi_api_key",
-                                     "huobi_secret_key",
-                                     "idex_api_key",
-                                     "ethereum_rpc_url"
-                                     ])
-            return [k for k in keys if k not in exclude_keys]
-        except Exception as err:
-            self.logger().error("Error filtering config keys.", exc_info=True)
-            return keys
+    @staticmethod
+    def _get_config_var_with_key(key: str) -> ConfigVar:
+        current_strategy: str = in_memory_config_map.get("strategy").value
+        strategy_cm: Optional[Dict[str, ConfigVar]] = get_strategy_config_map(current_strategy)
+        if key in in_memory_config_map:
+            cv: ConfigVar = in_memory_config_map.get(key)
+        elif key in global_config_map:
+            cv: ConfigVar = global_config_map.get(key)
+        elif strategy_cm is not None and key in strategy_cm:
+            cv: ConfigVar = strategy_cm.get(key)
+        else:
+            raise ValueError(f"No config variable associated with key name {key}")
+        return cv
 
-    async def _inner_config_loop(self, _keys: List[str], single_key: bool):
-        keys = self.key_filter(_keys)
+    async def _inner_config_loop(self, keys: List[str]):
+        """
+        Inner loop used by `self._config_loop` that recursively calls itself until all required configs are filled.
+        This enables the bot to detect any newly added requirements as the user fills currently required variables.
+        Use case example:
+        When the user selects a particular market, the API keys related to that market becomes required.
+        :param keys:
+        """
         for key in keys:
-            current_strategy: str = in_memory_config_map.get("strategy").value
-            strategy_cm: Dict[str, ConfigVar] = get_strategy_config_map(current_strategy)
-            if key in in_memory_config_map:
-                cv: ConfigVar = in_memory_config_map.get(key)
-            elif key in global_config_map:
-                cv: ConfigVar = global_config_map.get(key)
-            else:
-                cv: ConfigVar = strategy_cm.get(key)
-
-            value = await self.config_single_variable(cv, is_single_key=single_key)
+            cv: ConfigVar = self._get_config_var_with_key(key)
+            value = await self.prompt_single_variable(cv, requirement_overwrite=False)
             cv.value = parse_cvar_value(cv, value)
-            if single_key:
-                self._notify(f"\nNew config saved:\n{key}: {str(value)}")
         if not self.config_complete:
-            await self._inner_config_loop(self._get_empty_configs(), single_key)
+            await self._inner_config_loop(self._get_empty_configs())
 
     async def _config_loop(self,  # type: HummingbotApplication
                            keys: List[str] = []):
-
+        """
+        Loop until all necessary config variables are complete and the bot is ready for "start"
+        """
         self._notify("Please follow the prompt to complete configurations: ")
         self.placeholder_mode = True
         self.app.toggle_hide_input()
 
-        single_key = len(keys) == 1
-
         try:
-            await self._inner_config_loop(keys, single_key)
+            await self._inner_config_loop(keys)
             await write_config_to_yml()
-            if not single_key:
-                self._notify("\nConfig process complete. Enter \"start\" to start market making.")
-                self.app.set_text("start")
+            self._notify("\nConfig process complete. Enter \"start\" to start market making.")
+            self.app.set_text("start")
         except asyncio.TimeoutError:
             self.logger().error("Prompt timeout")
         except Exception as err:
@@ -257,3 +269,38 @@ class ConfigCommand:
             self.app.toggle_hide_input()
             self.placeholder_mode = False
             self.app.change_prompt(prompt=">>> ")
+
+    async def _config_single_key(self,  # type: HummingbotApplication
+                                 key: str):
+        """
+        Configure a single variable only.
+        Prompt the user to finish all configurations if there are remaining empty configs at the end.
+        """
+        self._notify("Please follow the prompt to complete configurations: ")
+        self.placeholder_mode = True
+        self.app.toggle_hide_input()
+
+        try:
+            cv: ConfigVar = self._get_config_var_with_key(key)
+            value = await self.prompt_single_variable(cv, requirement_overwrite=True)
+            cv.value = parse_cvar_value(cv, value)
+            await write_config_to_yml()
+            self._notify(f"\nNew config saved:\n{key}: {str(value)}")
+
+            if not self.config_complete:
+                choice = await self.app.prompt("Your configuration is incomplete. Would you like to proceed and "
+                                               "finish all necessary configurations? (y/n) >>> ")
+                if choice.lower() in {"y", "yes"}:
+                    self.config()
+                    return
+                else:
+                    self._notify("Aborted.")
+        except asyncio.TimeoutError:
+            self.logger().error("Prompt timeout")
+        except Exception as err:
+            self.logger().error("Unknown error while writing config. %s" % (err,), exc_info=True)
+        finally:
+            self.app.toggle_hide_input()
+            self.placeholder_mode = False
+            self.app.change_prompt(prompt=">>> ")
+

--- a/hummingbot/client/command/paper_trade_command.py
+++ b/hummingbot/client/command/paper_trade_command.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hummingbot.client.hummingbot_application import HummingbotApplication
+
+
+class PaperTradeCommand:
+    def paper_trade(self,  # type: HummingbotApplication
+                    ):
+        self.config("paper_trade_enabled")

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -144,7 +144,7 @@ def load_required_configs(*args) -> OrderedDict:
     else:
         strategy_config_map = get_strategy_config_map(current_strategy)
         # create an ordered dict where `strategy` is inserted first
-        # so that strategy-specific configs are prompted first and populate required exchanges
+        # so that strategy-specific configs are prompted first and populate required_exchanges
         return _merge_dicts(in_memory_config_map, strategy_config_map, global_config_map)
 
 
@@ -201,11 +201,14 @@ async def write_config_to_yml():
     """
     from hummingbot.client.config.in_memory_config_map import in_memory_config_map
     current_strategy = in_memory_config_map.get("strategy").value
-    strategy_config_map = get_strategy_config_map(current_strategy)
-    strategy_file_path = join(CONF_FILE_PATH, in_memory_config_map.get("strategy_file_path").value)
+    strategy_file_path = in_memory_config_map.get("strategy_file_path").value
+
+    if current_strategy is not None and strategy_file_path is not None:
+        strategy_config_map = get_strategy_config_map(current_strategy)
+        strategy_file_path = join(CONF_FILE_PATH, strategy_file_path)
+        await save_to_yml(strategy_file_path, strategy_config_map)
 
     await save_to_yml(GLOBAL_CONFIG_PATH, global_config_map)
-    await save_to_yml(strategy_file_path, strategy_config_map)
 
 
 async def create_yml_files():

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -15,18 +15,20 @@ def generate_client_id() -> str:
 
 
 # Required conditions
+def paper_trade_disabled():
+    return global_config_map.get("paper_trade_enabled").value is False
+
+
 def using_strategy(strategy: str) -> Callable:
     return lambda: global_config_map.get("strategy").value == strategy
 
 
 def using_exchange(exchange: str) -> Callable:
-    return lambda: global_config_map.get("paper_trade_enabled").value is False \
-                   and exchange in required_exchanges
+    return lambda: paper_trade_disabled() and exchange in required_exchanges
 
 
 def using_wallet() -> bool:
-    return global_config_map.get("paper_trade_enabled").value is False \
-           and any([e in DEXES for e in required_exchanges])
+    return paper_trade_disabled() and any([e in DEXES for e in required_exchanges])
 
 
 # Main global config store
@@ -175,6 +177,7 @@ global_config_map = {
 
     "kill_switch_enabled":              ConfigVar(key="kill_switch_enabled",
                                                   prompt="Would you like to enable the kill switch? (y/n) >>> ",
+                                                  required_if=paper_trade_disabled,
                                                   type_str="bool",
                                                   default=False),
     "kill_switch_rate":                 ConfigVar(key="kill_switch_rate",

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -20,11 +20,13 @@ def using_strategy(strategy: str) -> Callable:
 
 
 def using_exchange(exchange: str) -> Callable:
-    return lambda: exchange in required_exchanges
+    return lambda: global_config_map.get("paper_trade_enabled").value is False \
+                   and exchange in required_exchanges
 
 
 def using_wallet() -> bool:
-    return any([e in DEXES for e in required_exchanges])
+    return global_config_map.get("paper_trade_enabled").value is False \
+           and any([e in DEXES for e in required_exchanges])
 
 
 # Main global config store
@@ -79,6 +81,23 @@ global_config_map = {
                                                   default=DEFAULT_LOG_FILE_PATH),
 
     # Required by chosen CEXes or DEXes
+    "paper_trade_enabled":              ConfigVar(key="paper_trade_enabled",
+                                                  prompt="Enable paper trading mode (y/n) ? >>> ",
+                                                  type_str="bool",
+                                                  default=False,
+                                                  required_if=lambda: True),
+    "paper_trade_account_balance":      ConfigVar(key="paper_trade_account_balance",
+                                                  prompt="Enter paper trade balance settings [asset, balance] >>> ",
+                                                  required_if=lambda: False,
+                                                  type_str="list",
+                                                  default=[["USDT", 3000],
+                                                           ["ONE", 1000],
+                                                           ["BTC", 1],
+                                                           ["ETH", 10],
+                                                           ["WETH", 10],
+                                                           ["USDC", 3000],
+                                                           ["TUSD", 3000],
+                                                           ["PAX", 3000]]),
     "binance_api_key":                  ConfigVar(key="binance_api_key",
                                                   prompt="Enter your Binance API key >>> ",
                                                   required_if=using_exchange("binance"),
@@ -117,7 +136,8 @@ global_config_map = {
                                                   type_str="bool",
                                                   default=True),
     "bamboo_relay_pre_emptive_soft_cancels":      ConfigVar(key="bamboo_relay_pre_emptive_soft_cancels",
-                                                            prompt="Would you like to pre-emptively soft cancel orders (y/n) >>> ",
+                                                            prompt="Would you like to pre-emptively soft cancel "
+                                                                   "orders (y/n) >>> ",
                                                             required_if=using_exchange("bamboo_relay"),
                                                             type_str="bool",
                                                             default=True),
@@ -179,21 +199,4 @@ global_config_map = {
                                                   prompt="What is your default exchange rate data feed name? >>> ",
                                                   required_if=lambda: False,
                                                   default="coin_gecko_api"),
-    "paper_trade_enabled":              ConfigVar(key="paper_trade_enabled",
-                                                  prompt="Enable paper trading mode? >>> ",
-                                                  type_str="bool",
-                                                  default=False,
-                                                  required_if=lambda: False),
-    "paper_trade_account_balance":      ConfigVar(key="paper_trade_account_balance",
-                                                  prompt="Enter paper trade balance settings [asset, balance] >>> ",
-                                                  required_if=lambda: False,
-                                                  type_str="list",
-                                                  default=[["USDT", 3000],
-                                                           ["ONE", 1000],
-                                                           ["BTC", 1],
-                                                           ["ETH", 10],
-                                                           ["WETH", 10],
-                                                           ["USDC", 3000],
-                                                           ["TUSD", 3000],
-                                                           ["PAX", 3000]])
 }

--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -67,7 +67,7 @@ class HummingbotCompleter(Completer):
 
     @property
     def _config_completer(self):
-        return WordCompleter(load_required_configs(), ignore_case=True)
+        return WordCompleter(self.hummingbot_application.get_all_available_config_keys(), ignore_case=True)
 
     def _complete_strategies(self, document: Document) -> bool:
         return "strategy" in self.prompt_text

--- a/hummingbot/client/ui/layout.py
+++ b/hummingbot/client/ui/layout.py
@@ -131,6 +131,14 @@ def get_bounty_status():
     return [(style, f"bounty_status: {bounty_status}")]
 
 
+def get_paper_trade_status():
+    from hummingbot.client.config.global_config_map import global_config_map
+    enabled = global_config_map["paper_trade_enabled"].value is True
+    paper_trade_status = "ON" if enabled else "OFF"
+    style = "class:primary" if enabled else "class:warning"
+    return [(style, f"paper_trade_mode: {paper_trade_status}")]
+
+
 def get_title_bar_right_text():
     copy_key = "CTRL + SHIFT" if is_windows() else "fn"
     return [
@@ -148,6 +156,7 @@ def generate_layout(input_field: TextArea,
         VSplit([
             Window(FormattedTextControl(get_version), style="class:title"),
             Window(FormattedTextControl(get_bounty_status), style="class:title"),
+            Window(FormattedTextControl(get_paper_trade_status), style="class:title"),
             Window(FormattedTextControl(get_title_bar_right_text), align=WindowAlign.RIGHT, style="class:title"),
         ], height=1),
         VSplit([

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -38,50 +38,6 @@ def load_parser(hummingbot) -> ThrowingArgumentParser:
     parser = ThrowingArgumentParser(prog="", add_help=False)
     subparsers = parser.add_subparsers()
 
-    help_parser = subparsers.add_parser("help", help="Print a list of commands")
-    help_parser.add_argument("command", nargs="?", default="all", help="Get help for a specific command")
-    help_parser.set_defaults(func=hummingbot.help)
-
-    start_parser = subparsers.add_parser("start", help="Start market making with Hummingbot")
-    start_parser.add_argument("--log-level", help="Level of logging")
-    start_parser.set_defaults(func=hummingbot.start)
-
-    config_parser = subparsers.add_parser("config", help="Add your personal credentials e.g. exchange API keys")
-    config_parser.add_argument("key", nargs="?", default=None, help="Configure a specific variable")
-    config_parser.set_defaults(func=hummingbot.config)
-
-    status_parser = subparsers.add_parser("status", help="Get current bot status")
-    status_parser.set_defaults(func=hummingbot.status)
-
-    list_parser = subparsers.add_parser("list", help="List global objects")
-    list_parser.add_argument("obj", choices=["wallets", "exchanges", "configs", "trades"],
-                             help="Type of object to list", nargs="?")
-    list_parser.set_defaults(func=hummingbot.list)
-
-    get_balance_parser = subparsers.add_parser("get_balance", help="Print balance of a certain currency ")
-    get_balance_parser.add_argument("-c", "--currency", help="Specify the currency you are querying balance for")
-    get_balance_parser.add_argument("-w", "--wallet", action="store_true", help="Get balance in the current wallet")
-    get_balance_parser.add_argument("-e", "--exchange", help="Get balance in a specific exchange")
-    get_balance_parser.set_defaults(func=hummingbot.get_balance)
-
-    exit_parser = subparsers.add_parser("exit", help="Securely exit the command line")
-    exit_parser.add_argument("-f", "--force", action="store_true", help="Does not cancel outstanding orders",
-                             default=False)
-    exit_parser.set_defaults(func=hummingbot.exit)
-
-    stop_parser = subparsers.add_parser('stop', help='Stop the bot\'s active strategy')
-    stop_parser.set_defaults(func=hummingbot.stop)
-
-    export_private_key_parser = subparsers.add_parser("export_private_key", help="Print your account private key")
-    export_private_key_parser.set_defaults(func=lambda: asyncio.ensure_future(hummingbot.export_private_key()))
-
-    history_parser = subparsers.add_parser("history", help="Get your bot\"s past trades and performance analytics")
-    history_parser.set_defaults(func=hummingbot.history)
-
-    export_trades_parser = subparsers.add_parser("export_trades", help="Export your trades to a csv file")
-    export_trades_parser.add_argument("-p", "--path", help="Save csv to specific path")
-    export_trades_parser.set_defaults(func=hummingbot.export_trades)
-
     bounty_parser = subparsers.add_parser("bounty", help="Participate in hummingbot's liquidity bounty programs")
     bounty_parser.add_argument("--register", action="store_true", help="Register to collect liquidity bounties")
     bounty_parser.add_argument("--status", action="store_true", help="Show your current bounty status")
@@ -90,7 +46,51 @@ def load_parser(hummingbot) -> ThrowingArgumentParser:
     bounty_parser.add_argument("--restore-id", action="store_true", help="Restore your lost bounty ID")
     bounty_parser.set_defaults(func=hummingbot.bounty)
 
+    config_parser = subparsers.add_parser("config", help="Add your personal credentials e.g. exchange API keys")
+    config_parser.add_argument("key", nargs="?", default=None, help="Configure a specific variable")
+    config_parser.set_defaults(func=hummingbot.config)
+
+    exit_parser = subparsers.add_parser("exit", help="Securely exit the command line")
+    exit_parser.add_argument("-f", "--force", action="store_true", help="Does not cancel outstanding orders",
+                             default=False)
+    exit_parser.set_defaults(func=hummingbot.exit)
+
+    export_private_key_parser = subparsers.add_parser("export_private_key", help="Print your account private key")
+    export_private_key_parser.set_defaults(func=lambda: asyncio.ensure_future(hummingbot.export_private_key()))
+
+    export_trades_parser = subparsers.add_parser("export_trades", help="Export your trades to a csv file")
+    export_trades_parser.add_argument("-p", "--path", help="Save csv to specific path")
+    export_trades_parser.set_defaults(func=hummingbot.export_trades)
+
+    get_balance_parser = subparsers.add_parser("get_balance", help="Print balance of a certain currency ")
+    get_balance_parser.add_argument("-c", "--currency", help="Specify the currency you are querying balance for")
+    get_balance_parser.add_argument("-w", "--wallet", action="store_true", help="Get balance in the current wallet")
+    get_balance_parser.add_argument("-e", "--exchange", help="Get balance in a specific exchange")
+    get_balance_parser.set_defaults(func=hummingbot.get_balance)
+
+    help_parser = subparsers.add_parser("help", help="Print a list of commands")
+    help_parser.add_argument("command", nargs="?", default="all", help="Get help for a specific command")
+    help_parser.set_defaults(func=hummingbot.help)
+
+    history_parser = subparsers.add_parser("history", help="Get your bot\"s past trades and performance analytics")
+    history_parser.set_defaults(func=hummingbot.history)
+
+    list_parser = subparsers.add_parser("list", help="List global objects")
+    list_parser.add_argument("obj", choices=["wallets", "exchanges", "configs", "trades"],
+                             help="Type of object to list", nargs="?")
+    list_parser.set_defaults(func=hummingbot.list)
+
     paper_trade_parser = subparsers.add_parser("paper_trade", help="Enable / Disable paper trade mode.")
     paper_trade_parser.set_defaults(func=hummingbot.paper_trade)
+
+    start_parser = subparsers.add_parser("start", help="Start market making with Hummingbot")
+    start_parser.add_argument("--log-level", help="Level of logging")
+    start_parser.set_defaults(func=hummingbot.start)
+
+    status_parser = subparsers.add_parser("status", help="Get current bot status")
+    status_parser.set_defaults(func=hummingbot.status)
+
+    stop_parser = subparsers.add_parser('stop', help='Stop the bot\'s active strategy')
+    stop_parser.set_defaults(func=hummingbot.stop)
 
     return parser

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -90,4 +90,7 @@ def load_parser(hummingbot) -> ThrowingArgumentParser:
     bounty_parser.add_argument("--restore-id", action="store_true", help="Restore your lost bounty ID")
     bounty_parser.set_defaults(func=hummingbot.bounty)
 
+    paper_trade_parser = subparsers.add_parser("paper_trade", help="Enable / Disable paper trade mode.")
+    paper_trade_parser.set_defaults(func=hummingbot.paper_trade)
+
     return parser

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -32,7 +32,7 @@ pure_market_making_config_map = {
                                                   validator=is_valid_maker_market_symbol),
     "mode":                             ConfigVar(key="mode",
                                                   prompt="Enter quantity of orders per side [bid/ask] "
-                                                         "(single/multiple) default is single >>> ",
+                                                         "(single/multiple) >>> ",
                                                   type_str="str",
                                                   validator=lambda v: v in {"single", "multiple"},
                                                   default="single"),


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:
- Added a command called paper_trade that prompts users whether they want to turn paper trading mode on or off.
- Enable paper trade configuration (and all other global configurations) to be set before the user enters a strategy
- Added a status indicator to the top bar for paper_trading_mode: ON similar to bounty_status.
- Added some in-code documentation to the config module
- Some minor wording changes 

@michaelc9 I rewrote the `key_filter` functionality, because I think it would require us to input all the exchange API keys in that list every time we add an exchange. Instead, I added the requirement in `using_exchange` or `using_wallet`, as well as how the config command works currently. 