### PR TITLE
feat / failed order kill switch

### DIFF
--- a/hummingbot/client/__init__.py
+++ b/hummingbot/client/__init__.py
@@ -1,0 +1,2 @@
+import pandas as pd
+pd.options.display.float_format = '{:.7g}'.format

--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -948,10 +948,7 @@ cdef class BinanceMarket(MarketBase):
         except asyncio.CancelledError:
             raise
 
-        except asyncio.TimeoutError:
-            self.logger().network(f"Timeout Error encountered while submitting buy ",exc_info=True)
-
-        except Exception:
+        except Exception as e:
             self.c_stop_tracking_order(order_id)
             order_type_str = 'MARKET' if order_type == OrderType.MARKET else 'LIMIT'
             self.logger().network(
@@ -1041,8 +1038,7 @@ cdef class BinanceMarket(MarketBase):
                                      float(decimal_price),
                                      order_id
                                  ))
-        except asyncio.TimeoutError:
-            self.logger().network(f"Timeout Error encountered while submitting sell ",exc_info=True)
+
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/hummingbot/market/huobi/huobi_market.pyx
+++ b/hummingbot/market/huobi/huobi_market.pyx
@@ -589,8 +589,6 @@ cdef class HuobiMarket(MarketBase):
                                  ))
         except asyncio.CancelledError:
             raise
-        except asyncio.TimeoutError:
-            self.logger().network(f"Timeout Error encountered while submitting buy ",exc_info=True)
         except Exception:
             self.c_stop_tracking_order(order_id)
             order_type_str = "MARKET" if order_type == OrderType.MARKET else "LIMIT"
@@ -661,8 +659,6 @@ cdef class HuobiMarket(MarketBase):
                                      float(decimal_price),
                                      order_id
                                  ))
-        except asyncio.TimeoutError:
-            self.logger().network(f"Timeout Error encountered while submitting sell ",exc_info=True)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/hummingbot/market/radar_relay/radar_relay_market.pyx
+++ b/hummingbot/market/radar_relay/radar_relay_market.pyx
@@ -767,7 +767,6 @@ cdef class RadarRelayMarket(MarketBase):
 
             return order_id
         except Exception as e:
-            self.logger().error(str(e))
             self.c_stop_tracking_order(order_id)
             self.logger().network(
                 f"Error submitting {trade_type_desc} order to Radar Relay for {str(q_amt)} {symbol}.",

--- a/hummingbot/strategy/arbitrage/arbitrage.pxd
+++ b/hummingbot/strategy/arbitrage/arbitrage.pxd
@@ -21,6 +21,10 @@ cdef class ArbitrageStrategy(StrategyBase):
         set _buy_markets
         int64_t _logging_options
         object _exchange_rate_conversion
+        int _failed_order_tolerance
+        bint _cool_off_logged
+        int _failed_market_order_count
+        int _last_failed_market_order_timestamp
 
     cdef tuple c_calculate_arbitrage_top_order_profitability(self, object market_pair)
     cdef c_process_market_pair(self, object market_pair)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/4994/arbitrage-strategy-keeps-trying-to-trade-even-if-one-side-fails
https://app.clubhouse.io/coinalpha/story/5613/paper-trading-mode-status-minor-issues


**A description of the changes proposed in the pull request**:
- Added failed order kill switch to force stop arbitrage strategy when the number of failed orders exceeds tolerance (default is 1).
- Added extended cool off after failed orders (default is 30 minutes * number of failed orders: 30 mins, 60 mins, 90 mins, etc)
- Set global display option for dataframe to show float with 7 significant digits
