### PR TITLE
fix / Make asset matching case insensitive for history command

### DIFF
--- a/hummingbot/client/__init__.py
+++ b/hummingbot/client/__init__.py
@@ -1,16 +1,26 @@
+import logging
+import numpy
+
 import pandas as pd
 import decimal
 
-ctx = decimal.Context()
-ctx.prec = 7
 
-
-def float_to_str(f):
+def format_decimal(n):
     """
     Convert the given float to a string without scientific notation
     """
-    d1 = ctx.create_decimal(repr(f))
-    return format(d1.normalize(), 'f')
+    try:
+        with decimal.localcontext() as ctx:
+            ctx.prec = 7
+            if isinstance(n, float):
+                d = ctx.create_decimal(repr(n))
+                return format(d.normalize(), 'f')
+            elif isinstance(n, decimal.Decimal):
+                return format(n.normalize(), 'f')
+            else:
+                return str(n)
+    except Exception as e:
+        logging.getLogger().error(str(e))
 
 
-pd.options.display.float_format = lambda x: float_to_str(x)
+pd.options.display.float_format = lambda x: format_decimal(x)

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -25,6 +25,7 @@ class HistoryCommand:
         for market_name in self.markets:
             balance_dict = self.markets[market_name].get_all_balances()
             for asset in self.assets:
+                asset = asset.upper()
                 if asset not in snapshot:
                     snapshot[asset] = {}
                 if asset in balance_dict:
@@ -38,18 +39,16 @@ class HistoryCommand:
         if len(self.starting_balances) == 0:
             self._notify("  Balance snapshots are not available before bot starts")
             return
-
         rows = []
         for market_name, market in self.markets.items():
-            for asset in self.assets:
+            for asset in set(a.upper() for a in self.assets):
                 starting_balance = self.starting_balances.get(asset).get(market_name)
                 current_balance = self.balance_snapshot().get(asset).get(market_name)
                 rows.append([market.display_name,
                              asset,
-                             starting_balance,
-                             current_balance,
-                             current_balance - starting_balance])
-
+                             float(starting_balance),
+                             float(current_balance),
+                             float(current_balance - starting_balance)])
         df = pd.DataFrame(rows, index=None, columns=["Market", "Asset", "Starting", "Current", "Delta"])
         if len(df) > 0:
             lines = ["", "  Inventory:"] + ["    " + line for line in str(df).split("\n")]
@@ -67,7 +66,7 @@ class HistoryCommand:
                 for is_starting in [True, False]:
                     market_name = market_symbol_pair.market.name
                     asset_name = market_symbol_pair.base_asset if is_base else market_symbol_pair.quote_asset
-
+                    asset_name = asset_name.upper()
                     if len(self.assets) == 0 or len(self.markets) == 0:
                         # Prevent KeyError '***SYMBOL***'
                         amount = self.starting_balances[asset_name][market_name]

--- a/hummingbot/core/data_type/limit_order.pyx
+++ b/hummingbot/core/data_type/limit_order.pyx
@@ -19,8 +19,8 @@ cdef class LimitOrder:
                 limit_order.symbol,
                 limit_order.base_currency,
                 limit_order.quote_currency,
-                limit_order.price.normalize(),
-                limit_order.quantity.normalize()
+                float(limit_order.price),
+                float(limit_order.quantity)
             ] for limit_order in limit_orders]
 
         return pd.DataFrame(data=data, columns=columns)

--- a/hummingbot/market/paper_trade/paper_trade_market.pyx
+++ b/hummingbot/market/paper_trade/paper_trade_market.pyx
@@ -910,12 +910,14 @@ cdef class PaperTradeMarket(MarketBase):
             return Decimal(f"1e-15")
 
     cdef object c_quantize_order_price(self, str symbol, double price):
-        price = float('%.8g' % price) # hard code to round to 8 significant digits
+        price = float('%.7g' % price) # hard code to round to 8 significant digits
         price_quantum = self.c_get_order_price_quantum(symbol, price)
         return round(Decimal('%s' % price) / price_quantum) * price_quantum
 
     cdef object c_quantize_order_amount(self, str symbol, double amount, double price = 0.0):
-        amount = float('%.8g' % amount)# hard code to round to 8 significant digits
+        amount = float('%.7g' % amount)# hard code to round to 8 significant digits
+        if amount <= 1e-7:
+            amount = 0
         order_size_quantum = self.c_get_order_size_quantum(symbol, amount)
         return (Decimal('%s' % amount) // order_size_quantum) * order_size_quantum
 

--- a/hummingbot/model/trade_fill.py
+++ b/hummingbot/model/trade_fill.py
@@ -4,7 +4,7 @@ import pandas as pd
 from typing import (
     Any,
     Dict,
-List,
+    List,
 )
 from hummingbot.core.event.events import (
     TradeType,
@@ -69,7 +69,7 @@ class TradeFill(HummingbotBase):
                               "price",
                               "amount",
                               "order_type",
-                              "trade_type",
+                              "side",
                               "market",
                               "timestamp",
                               "fee_percent",


### PR DESCRIPTION

**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/5538/inventory-tab-under-history-command-should-have-all-asset-in-same-case

**A description of the changes proposed in the pull request**:
- Make asset matching case insensitive for history command
- Make all dataframe float and decimal comply with display format (7 significant digits, no trailing zero and scientific notation)
- Shorten history trade column name to reduce row overflow