### PR TITLE
Feat/add transaction cost pure mm

### DIFF
--- a/documentation/docs/strategies/pure-market-making.md
+++ b/documentation/docs/strategies/pure-market-making.md
@@ -74,6 +74,8 @@ Adding the transaction cost will reduce the bid order price and increase the ask
 
 We currently display warnings if the adjusted price post adding the transaction costs is 10% away from the original price. This setting can be modified by changing `warning_report_threshold` in the c_add_transaction_costs_to_pricing_proposal function inside hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx.
 
+If the Buy price with the transaction cost is zero or negative, it is not profitable to place orders and orders will not be placed.
+
 ### Multiple Order Configuration
 
 Multiple orders allow you to create multiple orders for each bid and ask side, e.g. multiple bid orders with different prices and different sizes.

--- a/documentation/docs/strategies/pure-market-making.md
+++ b/documentation/docs/strategies/pure-market-making.md
@@ -62,6 +62,18 @@ The following walks through all the steps when running `config` for the first ti
 | `How long do you want to wait before placing the next order in case your order gets filled (in seconds). (Default is 10 seconds)? >>> " ` | This sets `filled_order_replenish_wait_time` (see [definition](#configuration-parameters)) |
 | `Do you want to enable order_filled_stop_cancellation. If enabled, when orders are completely filled, the other side remains uncanceled (Default is False)? >>> " ` | This sets `enable_order_filled_stop_cancellation` (see [definition](#configuration-parameters)) |
 
+### Adding Transaction Costs to Prices
+
+Transaction costs are by default now added to the prices. This setting can be disabled by going to hummingbot/strategy/pure_market_making/start.py and setting `add_transaction_costs_to_orders` to False. fee_pct refers to the percentage maker fees per order (generally common in Centralized exchanges) while fixed fees refers to the flat fees (generally common in Decentralized exchanges)
+
+The bid order price is now calculated as (mid_price * (1 - fee_pct) * order_size - fixed_fees) / order_size
+
+The ask order price is now calculated as (mid_price * (1 + fee_pct) * order_size + fixed_fees) / order_size
+
+Adding the transaction cost will reduce the bid order price and increase the ask order price.
+
+We currently display warnings if the adjusted price post adding the transaction costs is 10% away from the original price. This setting can be modified by changing `warning_report_threshold` in the c_add_transaction_costs_to_pricing_proposal function inside hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx.
+
 ### Multiple Order Configuration
 
 Multiple orders allow you to create multiple orders for each bid and ask side, e.g. multiple bid orders with different prices and different sizes.

--- a/hummingbot/strategy/pure_market_making/pure_market_making_v2.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_v2.pxd
@@ -45,7 +45,7 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
     cdef double c_sum_flat_fees(self,
                                 str quote_currency,
                                 list flat_fees)
-    cdef object c_add_transaction_costs_to_pricing_proposal(self,
-                                                            object market_info,
-                                                            object pricing_proposal,
-                                                            object sizing_proposal)
+    cdef tuple c_check_and_add_transaction_costs_to_pricing_proposal(self,
+                                                                     object market_info,
+                                                                     object pricing_proposal,
+                                                                     object sizing_proposal)

--- a/hummingbot/strategy/pure_market_making/pure_market_making_v2.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_v2.pxd
@@ -42,3 +42,10 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
                                                     object market_info,
                                                     object pricing_proposal,
                                                     list active_orders)
+    cdef double c_sum_flat_fees(self,
+                                str quote_currency,
+                                list flat_fees)
+    cdef object c_add_transaction_costs_to_pricing_proposal(self,
+                                                            object market_info,
+                                                            object pricing_proposal,
+                                                            object sizing_proposal)

--- a/hummingbot/strategy/pure_market_making/pure_market_making_v2.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_v2.pxd
@@ -16,6 +16,7 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
         bint _all_markets_ready
         bint _enable_order_filled_stop_cancellation
         bint _jump_orders_enabled
+        bint _add_transaction_costs_to_orders
 
         double _cancel_order_wait_time
         double _status_report_interval

--- a/hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx
@@ -406,11 +406,11 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
                     buy_amount,
                     buy_price
                 )
-                # accumulated flat fees of exchange
+                # Total flat fees charged by the exchange
                 total_flat_fees = self.c_sum_flat_fees(market_info.quote_asset,
                                                        fee_object.flat_fees)
                 # Find the fixed cost per unit size for the total amount
-                # Fees is in Float units
+                # Fees is in Float
                 fixed_cost_per_unit = total_flat_fees / float(buy_amount)
                 # New Price = Price * (1 - maker_fees) - Fixed_fees_per_unit
                 buy_price_with_tx_cost = float(buy_price) * (1 - fee_object.percent) - fixed_cost_per_unit
@@ -433,11 +433,11 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
                     sell_amount,
                     sell_price
                 )
-                # accumulated flat fees of exchange
+                # Total flat fees charged by the exchange
                 total_flat_fees = self.c_sum_flat_fees(market_info.quote_asset,
                                                        fee_object.flat_fees)
                 # Find the fixed cost per unit size for the total amount
-                # Fees is in Float units
+                # Fees is in Float
                 fixed_cost_per_unit = total_flat_fees / float(sell_amount)
                 # New Price = Price * (1 + maker_fees) + Fixed_fees_per_unit
                 sell_price_with_tx_cost = float(sell_price) * (1 + fee_object.percent) + fixed_cost_per_unit

--- a/hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx
@@ -426,7 +426,7 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
                 buy_price_with_tx_cost = buy_price
 
             buy_price_with_tx_cost = maker_market.c_quantize_order_price(market_info.trading_pair,
-                                                                         buy_price_with_tx_cost)
+                                                                         Decimal(buy_price_with_tx_cost))
 
             # If the buy price with the transaction cost is 10% below the buy price due to price adjustment,
             # Display warning
@@ -462,7 +462,7 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
                 sell_price_with_tx_cost = sell_price
 
             sell_price_with_tx_cost = maker_market.c_quantize_order_price(market_info.trading_pair,
-                                                                          sell_price_with_tx_cost)
+                                                                          Decimal(sell_price_with_tx_cost))
 
             if (sell_price_with_tx_cost / sell_price) > (1 + warning_report_threshold):
                 if should_report_warnings:

--- a/hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_v2.pyx
@@ -94,6 +94,7 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
                  cancel_order_wait_time: float = 60,
                  filled_order_replenish_wait_time: float = 10,
                  enable_order_filled_stop_cancellation: bool = False,
+                 add_transaction_costs_to_orders: bool = True,
                  jump_orders_enabled: bool = False,
                  jump_orders_depth: float = 0,
                  logging_options: int = OPTION_LOG_ALL,
@@ -112,6 +113,7 @@ cdef class PureMarketMakingStrategyV2(StrategyBase):
         self._all_markets_ready = False
         self._cancel_order_wait_time = cancel_order_wait_time
         self._filled_order_replenish_wait_time = filled_order_replenish_wait_time
+        self._add_transaction_costs_to_orders = add_transaction_costs_to_orders
 
         self._time_to_cancel = {}
 

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -37,6 +37,7 @@ def start(self):
             "enable_order_filled_stop_cancellation").value
         jump_orders_enabled = pure_market_making_config_map.get("jump_orders_enabled").value
         jump_orders_depth = pure_market_making_config_map.get("jump_orders_depth").value
+        add_transaction_cost_to_orders: bool = True
 
         pricing_delegate = None
         sizing_delegate = None
@@ -89,6 +90,7 @@ def start(self):
                                                    cancel_order_wait_time=cancel_order_wait_time,
                                                    jump_orders_enabled=jump_orders_enabled,
                                                    jump_orders_depth=jump_orders_depth,
+                                                   add_transaction_cost_to_orders=add_transaction_cost_to_orders,
                                                    logging_options=strategy_logging_options)
     except Exception as e:
         self._notify(str(e))

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -37,7 +37,7 @@ def start(self):
             "enable_order_filled_stop_cancellation").value
         jump_orders_enabled = pure_market_making_config_map.get("jump_orders_enabled").value
         jump_orders_depth = pure_market_making_config_map.get("jump_orders_depth").value
-        add_transaction_cost_to_orders: bool = True
+        add_transaction_costs_to_orders: bool = True
 
         pricing_delegate = None
         sizing_delegate = None
@@ -90,7 +90,7 @@ def start(self):
                                                    cancel_order_wait_time=cancel_order_wait_time,
                                                    jump_orders_enabled=jump_orders_enabled,
                                                    jump_orders_depth=jump_orders_depth,
-                                                   add_transaction_cost_to_orders=add_transaction_cost_to_orders,
+                                                   add_transaction_costs_to_orders=add_transaction_costs_to_orders,
                                                    logging_options=strategy_logging_options)
     except Exception as e:
         self._notify(str(e))

--- a/test/test_pure_market_making_v2.py
+++ b/test/test_pure_market_making_v2.py
@@ -429,6 +429,55 @@ class PureMarketMakingV2UnitTest(unittest.TestCase):
         self.assertEqual(0, len(self.strategy.active_bids))
         self.assertEqual(0, len(self.strategy.active_asks))
 
+    def test_strategy_with_transaction_costs(self):
+        self.clock.remove_iterator(self.strategy)
+        logging_options: int = (PureMarketMakingStrategyV2.OPTION_LOG_ALL &
+                                (~PureMarketMakingStrategyV2.OPTION_LOG_NULL_ORDER_SIZE))
+        self.strategy_with_tx_costs: PureMarketMakingStrategyV2 = PureMarketMakingStrategyV2(
+            [self.market_info],
+            filled_order_replenish_wait_time=self.cancel_order_wait_time,
+            add_transaction_costs_to_orders=True,
+            filter_delegate=self.filter_delegate,
+            sizing_delegate=self.constant_sizing_delegate,
+            pricing_delegate=self.constant_pricing_delegate,
+            cancel_order_wait_time=45,
+            logging_options=logging_options
+        )
+        self.clock.add_iterator(self.strategy_with_tx_costs)
+        self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
+        self.assertEqual(1, len(self.strategy_with_tx_costs.active_bids))
+        self.assertEqual(1, len(self.strategy_with_tx_costs.active_asks))
+
+        # Fees are zero here, check whether order placements are working
+        bid_order: LimitOrder = self.strategy_with_tx_costs.active_bids[0][1]
+        ask_order: LimitOrder = self.strategy_with_tx_costs.active_asks[0][1]
+        self.assertEqual(Decimal("99"), bid_order.price)
+        self.assertEqual(Decimal("101"), ask_order.price)
+        self.assertEqual(Decimal("1.0"), bid_order.quantity)
+        self.assertEqual(Decimal("1.0"), ask_order.quantity)
+
+        # Check if orders are placed after cancel_order_wait_time
+        self.clock.backtest_til(self.start_timestamp + 2 * self.clock_tick_size + 1)
+        self.assertEqual(2, len(self.cancel_order_logger.event_log))
+        bid_order: LimitOrder = self.strategy_with_tx_costs.active_bids[0][1]
+        ask_order: LimitOrder = self.strategy_with_tx_costs.active_asks[0][1]
+        self.assertEqual(Decimal("99"), bid_order.price)
+        self.assertEqual(Decimal("101"), ask_order.price)
+        self.assertEqual(Decimal("1.0"), bid_order.quantity)
+        self.assertEqual(Decimal("1.0"), ask_order.quantity)
+
+        # Check if order fills are working
+        self.simulate_limit_order_fill(self.maker_market, bid_order)
+        self.simulate_limit_order_fill(self.maker_market, ask_order)
+
+        fill_events = self.maker_order_fill_logger.event_log
+        self.assertEqual(2, len(fill_events))
+        bid_fills: List[OrderFilledEvent] = [evt for evt in fill_events if evt.trade_type is TradeType.SELL]
+        ask_fills: List[OrderFilledEvent] = [evt for evt in fill_events if evt.trade_type is TradeType.BUY]
+        self.assertEqual(1, len(bid_fills))
+        self.assertEqual(1, len(ask_fills))
+        self.maker_order_fill_logger.clear()
+
     def test_multiple_orders_equal_sizes(self):
         self.clock.remove_iterator(self.strategy)
         self.clock.add_iterator(self.multi_order_equal_strategy)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/4884/add-transaction-costs-to-pure-mm-strategy

**A description of the changes proposed in the pull request**:
1. Added transaction costs to pricing
2. Added warning if price with transaction cost is 10% away from the original price. This threshold is configurable
3. Added unit test for transaction costs
4. Tested it working fine on Binance Eth/USDT on both single and multiple orders
5. Added documentation for the same