### PR TITLE
fix/ Huobi "partial-canceled" orders stuck bug

### DIFF
--- a/hummingbot/market/huobi/huobi_market.pyx
+++ b/hummingbot/market/huobi/huobi_market.pyx
@@ -393,7 +393,7 @@ cdef class HuobiMarket(MarketBase):
                     )
                     continue
                 if order_update.get("error") is not None:
-                    error_code = order_update.get("error").get("error-code")
+                    error_code = order_update.get("error").get("err-code")
                     if error_code == "base-record-invalid" or error_code == "order-orderstate-error":
                         # 'base-record-invalid' - order no longer exists
                         # 'order-orderstate-error' - order is either partial-canceled, filled, canceled, or cancelling

--- a/hummingbot/market/huobi/huobi_market.pyx
+++ b/hummingbot/market/huobi/huobi_market.pyx
@@ -396,7 +396,7 @@ cdef class HuobiMarket(MarketBase):
                     error_code = order_update.get("error").get("error-code")
                     if error_code == "base-record-invalid" or error_code == "order-orderstate-error":
                         # 'base-record-invalid' - order no longer exists
-                        # 'order-orderstate-error' - order is either partial-canceled, filled, canceled, or canceling
+                        # 'order-orderstate-error' - order is either partial-canceled, filled, canceled, or cancelling
                         # Huobi seems to return error if an order has been "partial-canceled"
                         self.c_stop_tracking_order(tracked_order.client_order_id)
                         self.logger().info(f"The order {tracked_order.client_order_id} has been cancelled according"

--- a/hummingbot/market/huobi/huobi_market.pyx
+++ b/hummingbot/market/huobi/huobi_market.pyx
@@ -394,7 +394,10 @@ cdef class HuobiMarket(MarketBase):
                     continue
                 if order_update.get("error") is not None:
                     error_code = order_update.get("error").get("error-code")
-                    if error_code == "base-record-invalid":  # order no longer exists
+                    if error_code == "base-record-invalid" or error_code == "order-orderstate-error":
+                        # 'base-record-invalid' - order no longer exists
+                        # 'order-orderstate-error' - order is either partial-canceled, filled, canceled, or canceling
+                        # Huobi seems to return error if an order has been "partial-canceled"
                         self.c_stop_tracking_order(tracked_order.client_order_id)
                         self.logger().info(f"The order {tracked_order.client_order_id} has been cancelled according"
                                            f" to order status API. error code - {error_code}")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #750 
- Related Clubhouse Story: 


**A description of the changes proposed in the pull request**:
seems like checking the order status of a partially filled then canceled order returns an error. Changed code to assume that if it receives this error, the cancel was successful.