### PR TITLE
fix / typo error in help command

### DIFF
--- a/documentation/docs/cheatsheets/client.md
+++ b/documentation/docs/cheatsheets/client.md
@@ -4,18 +4,20 @@
 
 | Command | Function |
 |---------|----------|
-| `help` | Prints a list of available commands.
-| `start` | Starts the bot. If any configuration settings are missing, it will automatically prompt you for them.
+| `bounty` | Participate in Hummingbot's liquidity bounty program or get bounty status.
 | `config` | Configures or, if a bot is already running, re-configures the bot.
-| `status` | Get a status report about the current bot status.
-| `list` | List wallets, exchanges, configs, and completed trades.<br/><br/>*Example usage: `list [wallets|exchanges|configs|trades]`*
-| `get_balance` | Get the balance of an exchange or wallet, or get the balance of a specific currency in an exchange or wallet.<br/><br/>*Example usage: `get_balance [-c WETH -w|-c ETH -e binance]` to show available WETH balance in the Ethereum wallet and ETH balance in Binance, respectively*.
 | `exit`| Cancels all orders, saves the log, and exits Hummingbot.
-|`exit -f`| Force quit without cancelling orders.
+| `exit -f`| Force quit without cancelling orders.
+| `export_private_key` | Print your Ethereum wallet private key.
+| `export_trades` | Export your trades to a csv file.
+| `get_balance` | Get the balance of an exchange or wallet, or get the balance of a specific currency in an exchange or wallet.<br/><br/>*Example usage: `get_balance [-c WETH -w|-c ETH -e binance]` to show available WETH balance in the Ethereum wallet and ETH balance in Binance, respectively*.
+| `help` | Prints a list of available commands. Adding a command after `help` will display available positional and optional arguments.<br/><br/>*Example: `help bounty` will show how to use the `bounty` command.
+| `history`| Print bot's past trades and performance analytics. For an explanation of how Hummingbot calculates profitability, see our blog [here](https://hummingbot.io/blog/2019-07-measure-performance-crypto-trading/#tldr).
+| `list` | List wallets, exchanges, configs, and completed trades.<br/><br/>*Example usage: `list [wallets|exchanges|configs|trades]`*
+| `paper_trade` | Enable or disable [paper trade mode](/utilities/paper-trade).
+| `start` | Starts the bot. If any configuration settings are missing, it will automatically prompt you for them.
+| `status` | Get a status report about the current bot status.
 | `stop` | Cancels all outstanding orders and stops the bot.
-|`export_private_key`| Print your ethereum wallet private key.
-|`history`| Print bot's past trades and performance analytics. For an explanation of how Hummingbot calculates profitability, see our blog [here](https://hummingbot.io/blog/2019-07-measure-performance-crypto-trading/#tldr).
-|`export_trades`| Export your trades to a csv file.
 
 ## Bounty-Related Commands
 

--- a/documentation/docs/operation/client.md
+++ b/documentation/docs/operation/client.md
@@ -66,18 +66,21 @@ The CLI is divided into three panes:
 
 | Command | Function |
 |---------|----------|
-| `help` | Prints a list of available commands.
-| `start` | Starts the bot. If any configuration settings are missing, it will automatically prompt you for them.
+| `bounty` | Participate in Hummingbot's liquidity bounty program or get bounty status.
 | `config` | Configures or, if a bot is already running, re-configures the bot.
-| `status` | Get a status report about the current bot status.
-| `list` | List wallets, exchanges, configs, and completed trades.<br/><br/>*Example usage: `list [wallets|exchanges|configs|trades]`*
-| `get_balance` | Get the balance of an exchange or wallet, or get the balance of a specific currency in an exchange or wallet.<br/><br/>*Example usage: `get_balance [-c WETH -w|-c ETH -e binance]` to show available WETH balance in the Ethereum wallet and ETH balance in Binance, respectively*.
 | `exit`| Cancels all orders, saves the log, and exits Hummingbot.
-|`exit -f`| Force quit without cancelling orders.
+| `exit -f`| Force quit without cancelling orders.
+| `export_private_key` | Print your Ethereum wallet private key.
+| `export_trades` | Export your trades to a csv file.
+| `get_balance` | Get the balance of an exchange or wallet, or get the balance of a specific currency in an exchange or wallet.<br/><br/>*Example usage: `get_balance [-c WETH -w|-c ETH -e binance]` to show available WETH balance in the Ethereum wallet and ETH balance in Binance, respectively*.
+| `help` | Prints a list of available commands. Adding a command after `help` will display available positional and optional arguments.<br/><br/>*Example: `help bounty` will show how to use the `bounty` command.
+| `history`| Print bot's past trades and performance analytics. For an explanation of how Hummingbot calculates profitability, see our blog [here](https://hummingbot.io/blog/2019-07-measure-performance-crypto-trading/#tldr).
+| `list` | List wallets, exchanges, configs, and completed trades.<br/><br/>*Example usage: `list [wallets|exchanges|configs|trades]`*
+| `paper_trade` | Enable or disable [paper trade mode](/utilities/paper-trade).
+| `start` | Starts the bot. If any configuration settings are missing, it will automatically prompt you for them.
+| `status` | Get a status report about the current bot status.
 | `stop` | Cancels all outstanding orders and stops the bot.
-|`export_private_key`| Print your ethereum wallet private key.
-|`history`| Print bot's past trades and performance analytics. For an explanation of how Hummingbot calculates profitability, see our blog [here](https://hummingbot.io/blog/2019-07-measure-performance-crypto-trading/#tldr).
-|`export_trades`| Export your trades to a csv file.
+
 
 ## Bounty-Related Commands
 

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -73,7 +73,7 @@ def load_parser(hummingbot) -> ThrowingArgumentParser:
     help_parser.add_argument("command", nargs="?", default="all", help="Get help for a specific command")
     help_parser.set_defaults(func=hummingbot.help)
 
-    history_parser = subparsers.add_parser("history", help="Get your bot\"s past trades and performance analytics")
+    history_parser = subparsers.add_parser("history", help="Get your bot\'s past trades and performance analytics")
     history_parser.set_defaults(func=hummingbot.history)
 
     list_parser = subparsers.add_parser("list", help="List global objects")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

- Fixed typo error for `history` command description when sending `help`
- Update related documentation

![image](https://user-images.githubusercontent.com/50150287/66251237-b4ffbd80-e780-11e9-980f-349b1cea4728.png)