### PR TITLE
fix / minor edits to strategy prompts

### DIFF
--- a/documentation/docs/strategies/pure-market-making.md
+++ b/documentation/docs/strategies/pure-market-making.md
@@ -154,8 +154,8 @@ Assume you are running pure parket making in single order mode, the order size i
 
 | Prompt | Description |
 |-----|-----|
-| `Do you want to enable jump_orders. If enabled, if the top bid price is lesser than your order price, buy order will jump to one tick above top bid price & vice versa for sell.(Default is False)? >>> ` | This sets `jump_orders_enabled` (see [definition](#configuration-parameters)) |
-| `How deep do you want to go into the order book for calculating the top bid and ask, ignoring dust orders on the top. (expressed in base currency). (Default is 0) ? >>> "` | This sets `jump_orders_depth` (see [definition](#configuration-parameters)) |
+| `Do you want to enable jump_orders? If enabled, when the top bid price is lesser than your order price, buy order will jump to one tick above top bid price & vice versa for sell. (Default is False) >>> ` | This sets `jump_orders_enabled` (see [definition](#configuration-parameters)) |
+| `How deep do you want to go into the order book for calculating the top bid and ask, ignoring dust orders on the top (expressed in base currency)? (Default is 0) >>> "` | This sets `jump_orders_depth` (see [definition](#configuration-parameters)) |
 
 
 ## Configuration Parameters

--- a/hummingbot/strategy/discovery/discovery_config_map.py
+++ b/hummingbot/strategy/discovery/discovery_config_map.py
@@ -10,7 +10,7 @@ from hummingbot.core.utils.trading_pair_fetcher import TradingPairFetcher
 
 
 def discovery_symbol_list_prompt(market_name):
-    return "Enter list of trading pairs or token names on %s (e.g. [%s] or press ENTER for all symbols.) >>> " % (
+    return "Enter list of trading pairs or token names on %s (e.g. [%s] or press ENTER for all symbols) >>> " % (
         market_name,
         EXAMPLE_PAIRS.get(market_name, ""),
     )
@@ -97,7 +97,7 @@ discovery_config_map = {
     ),
     "target_amount": ConfigVar(
         key="target_amount",
-        prompt="What is the max order size for discovery? >>> " "(default to infinity)",
+        prompt="What is the max order size for discovery? " "(default to infinity) >>> ",
         default=float("inf"),
         type_str="float",
     ),

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -108,15 +108,17 @@ pure_market_making_config_map = {
                                                        type_str="bool",
                                                        default=False),
     "jump_orders_enabled": ConfigVar(key="jump_orders_enabled",
-                                     prompt="How deep do you want to go into the order book for calculating "
-                                            "the top bid and ask, ignoring dust orders on the top"
-                                            "(Default is False)? >>> ",
+                                     prompt="Do you want to enable jump_orders? "
+                                            "If enabled, when the top bid price is lesser than your order price, "
+                                            "buy order will jump to one tick above top bid price "
+                                            "& vice versa for sell order. "
+                                            "(Default is False) >>> ",
                                      type_str="bool",
                                      default=False),
     "jump_orders_depth": ConfigVar(key="jump_orders_depth",
-                                   prompt="How deep do you want to go into the order book for calculating"
-                                          "the top bid and ask, ignoring dust orders on the top."
-                                          "(expressed in base currency). (Default is 0) ? >>> ",
+                                   prompt="How deep do you want to go into the order book for calculating "
+                                          "the top bid and ask, ignoring dust orders on the top "
+                                          "(expressed in base currency)? (Default is 0) >>> ",
                                    required_if=lambda: pure_market_making_config_map.get("jump_orders_enabled").value,
                                    type_str="decimal",
                                    default=0)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:

- Minor edit to the current prompt

![image](https://user-images.githubusercontent.com/50150287/66451559-8ab74400-ea8f-11e9-9607-c7d8781d9c40.png)

- Corrected both parameters `jump_orders_enabled` and `jump_orders_depth` that has the same prompt when configured

`jump_orders_enabled`
<img width="458" alt="jump1" src="https://user-images.githubusercontent.com/50150287/66476102-55c6e380-eac7-11e9-9523-68908b1f9d91.PNG">

`jump_orders_depth`
<img width="473" alt="jump2" src="https://user-images.githubusercontent.com/50150287/66476111-595a6a80-eac7-11e9-8888-0fd55c4f9ed2.PNG">


- Updated documentation for pure market making