### PR TITLE
fix / incorrect cancelled state in IDEXInFlightOrder

### DIFF
--- a/hummingbot/market/idex/idex_in_flight_order.pyx
+++ b/hummingbot/market/idex/idex_in_flight_order.pyx
@@ -63,12 +63,12 @@ cdef class IDEXInFlightOrder(InFlightOrderBase):
 
     @property
     def is_cancelled(self) -> bool:
-        return self.last_state in {"canceled"}
+        return self.last_state in {"cancelled"}
 
     @property
     def is_failure(self) -> bool:
         # Currently not in use
-        return self.last_state in {"canceled"}
+        return self.last_state in {"cancelled"}
 
     def to_json(self) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Fix incorrect order status string for cancelled orders

Order status string definitions according to IDEX is as follows:
`cancelled, complete, open`

