### PR TITLE
fix / docker profile app

### DIFF
--- a/hummingbot/__init__.py
+++ b/hummingbot/__init__.py
@@ -84,7 +84,7 @@ def is_independent_package() -> bool:
     global _independent_package
     import os
     if _independent_package is None:
-        _independent_package = (os.path.basename(sys.executable) != "python")
+        _independent_package = not os.path.basename(sys.executable).startswith("python")
     return _independent_package
 
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
#940 
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This fixes #940, in which Hummingbot uses the wrong app data directory in the Docker distribution.

The cause of the issue was due to the current Docker image using "python3" to start Hummingbot, instead of the usual "python" invocation. Hummingbot's independent package code treats anything other than "python" in `sys.executable` as if it's running from a setup package, and thus would use a different OS-dependent app profile directory.