### PR TITLE
Fix / Fix trade performance in paper trade

### DIFF
--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -161,22 +161,22 @@ class HistoryCommand:
                 self.market_trading_pair_tuples
             )
             trade_performance_status_line = []
-            market_df_data = []
+            market_df_data: Set[Tuple[str, str, float, float, str, str]] = set()
             market_df_columns = ["Market", "Trading_Pair", "Start_Price", "End_Price",
                                  "Total_Value_Delta", "Profit"]
 
             for market_trading_pair_tuple, trading_pair_stats in market_trading_pair_stats.items():
-                market_df_data.append([
+                market_df_data.add((
                     market_trading_pair_tuple.market.display_name,
                     market_trading_pair_tuple.trading_pair.upper(),
                     float(trading_pair_stats["starting_quote_rate"]),
                     float(trading_pair_stats["end_quote_rate"]),
                     f"{trading_pair_stats['trading_pair_delta']:.8f} {primary_quote_asset}",
                     f"{trading_pair_stats['trading_pair_delta_percentage']:.3f} %"
-                ])
+                ))
 
             inventory_df: pd.DataFrame = self.balance_comparison_data_frame(market_trading_pair_stats)
-            market_df: pd.DataFrame = pd.DataFrame(data=market_df_data, columns=market_df_columns)
+            market_df: pd.DataFrame = pd.DataFrame(data=list(market_df_data), columns=market_df_columns)
             portfolio_delta: Decimal = trade_performance_stats["portfolio_delta"]
             portfolio_delta_percentage: Decimal = trade_performance_stats["portfolio_delta_percentage"]
 

--- a/hummingbot/client/performance_analysis.py
+++ b/hummingbot/client/performance_analysis.py
@@ -1,10 +1,10 @@
 import logging
+from collections import defaultdict
 from decimal import Decimal
 from typing import (
     Tuple,
     Dict,
-    List
-)
+    List)
 from hummingbot.client.data_type.currency_amount import CurrencyAmount
 from hummingbot.core.event.events import TradeType
 from hummingbot.core.utils.exchange_rate_conversion import ExchangeRateConversion
@@ -149,14 +149,17 @@ class PerformanceAnalysis:
         """
         market_trading_pair_stats: Dict[MarketTradingPairTuple, Dict[str, Decimal]] = {}
         for market_trading_pair_tuple in market_trading_pair_tuples:
-            asset_stats: Dict[str, Decimal] = {
-                market_trading_pair_tuple.base_asset.upper(): {"spent": s_decimal_0, "acquired": s_decimal_0},
-                market_trading_pair_tuple.quote_asset.upper(): {"spent": s_decimal_0, "acquired": s_decimal_0}
-            }
+            asset_stats: Dict[str, Dict[str, Decimal]] = defaultdict(
+                lambda: {"spent": s_decimal_0, "acquired": s_decimal_0}
+            )
+            asset_stats[market_trading_pair_tuple.base_asset.upper()] = {"spent": s_decimal_0, "acquired": s_decimal_0}
+            asset_stats[market_trading_pair_tuple.quote_asset.upper()] = {"spent": s_decimal_0, "acquired": s_decimal_0}
+
             queried_trades: List[TradeFill] = TradeFill.get_trades(self.sql_manager.get_shared_session(),
                                                                    start_time=analysis_start_time,
                                                                    market=market_trading_pair_tuple.market.display_name,
-                                                                   strategy=current_startegy_name)
+                                                                   strategy=current_startegy_name,
+                                                                   trading_pair=market_trading_pair_tuple.trading_pair)
             if not queried_trades:
                 market_trading_pair_stats[market_trading_pair_tuple] = {
                     "starting_quote_rate": market_trading_pair_tuple.get_mid_price(),

--- a/hummingbot/model/trade_fill.py
+++ b/hummingbot/model/trade_fill.py
@@ -65,7 +65,7 @@ class TradeFill(HummingbotBase):
     def get_trades(sql_session: Session,
                    strategy: str = None,
                    market: str = None,
-                   symbol: str = None,
+                   trading_pair: str = None,
                    base_asset: str = None,
                    quote_asset: str = None,
                    trade_type: str = None,
@@ -78,8 +78,8 @@ class TradeFill(HummingbotBase):
             filters.append(TradeFill.strategy == strategy)
         if market is not None:
             filters.append(TradeFill.market == market)
-        if symbol is not None:
-            filters.append(TradeFill.symbol == symbol)
+        if trading_pair is not None:
+            filters.append(TradeFill.symbol == trading_pair)
         if base_asset is not None:
             filters.append(TradeFill.base_asset == base_asset)
         if quote_asset is not None:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
https://github.com/CoinAlpha/hummingbot/issues/974
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/6393/error-running-performance-analysis-while-in-paper-trade-arbitrage-strategy

**A description of the changes proposed in the pull request**:
Fix issues in trade analysis where the asset is initialized with current trading pair but the trades being analyzed can include other trading pair, which caused key error during processing. 
