### PR TITLE
fix/binance_trading_pair_fetcher

### DIFF
--- a/hummingbot/core/utils/trading_pair_fetcher.py
+++ b/hummingbot/core/utils/trading_pair_fetcher.py
@@ -46,6 +46,11 @@ class TradingPairFetcher:
                         data = await response.json()
                         trading_pair_structs = data.get("symbols")
                         raw_trading_pairs = list(map(lambda details: details.get("symbol"), trading_pair_structs))
+                        # Binance API has an error where they have a symbol called 123456
+                        # The symbol endpoint is
+                        # https://api.binance.com/api/v1/exchangeInfo
+                        if "123456" in raw_trading_pairs:
+                            raw_trading_pairs.remove("123456")
                         return [BinanceMarket.convert_from_exchange_trading_pair(p) for p in raw_trading_pairs]
                     except Exception:
                         pass


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
https://github.com/CoinAlpha/hummingbot/issues/1119
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/6635/bug-arbitrage-initial-configuration-primary-market-trading-pair-accepting-decimal-value

**A description of the changes proposed in the pull request**:
The binance trading pair fetcher was broken with respect to the symbols. So it was treating invalid values as valid markets before.