### PR TITLE
Feat/encrypt secure configurations with a password

### DIFF
--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -48,10 +48,10 @@ class CmdlineParser(ThrowingArgumentParser):
                           type=str,
                           required=False,
                           help="Specify the wallet public key you would like to use.")
-        self.add_argument("--wallet-password", "-p",
+        self.add_argument("--config-password", "--wallet-password", "-p",
                           type=str,
                           required=False,
-                          help="Specify the password if you need to unlock your wallet.")
+                          help="Specify the password to unlock your encrypted files and wallets.")
 
 
 async def quick_start():
@@ -61,21 +61,22 @@ async def quick_start():
         strategy = args.strategy
         config_file_name = args.config_file_name
         wallet = args.wallet
-        wallet_password = args.wallet_password
+        password = args.config_password
 
         await create_yml_files()
         init_logging("hummingbot_logs.yml")
         read_configs_from_yml()
         hb = HummingbotApplication.main_application()
 
+        in_memory_config_map.get("password").value = password
         in_memory_config_map.get("strategy").value = strategy
         in_memory_config_map.get("strategy").validate(strategy)
         in_memory_config_map.get("strategy_file_path").value = config_file_name
         in_memory_config_map.get("strategy_file_path").validate(config_file_name)
 
-        if wallet and wallet_password:
+        if wallet and password:
             global_config_map.get("wallet").value = wallet
-            hb.acct = unlock_wallet(public_key=wallet, password=wallet_password)
+            hb.acct = unlock_wallet(public_key=wallet, password=password)
 
         if not hb.config_complete:
             config_map = load_required_configs()

--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -30,6 +30,7 @@ from bin.hummingbot import (
     detect_available_port,
     main as normal_start,
 )
+from hummingbot.client.config.config_helpers import write_config_to_yml
 
 
 class CmdlineParser(ThrowingArgumentParser):
@@ -94,6 +95,7 @@ async def quick_start():
                          override_log_level=log_level,
                          dev_mode=dev_mode,
                          strategy_file_path=config_file_name)
+            await write_config_to_yml()
             hb.start(log_level)
 
             tasks: List[Coroutine] = [hb.run()]

--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -4,5 +4,6 @@
 /binance_secret.py
 /api_secrets.py
 /*secret*
+*encrypted*
 *key*
 *.yml

--- a/documentation/docs/operation/client.md
+++ b/documentation/docs/operation/client.md
@@ -28,7 +28,7 @@ bin/hummingbot.py
 
 ### Trading Strategy Autostart
 
-Hummingbot can automatically start the execution of a previously configured trading strategy upon launch without requiring the Hummingbot interface `config` and `start` commands.  Any parameters that are required for `config` can be passed into the Hummingbot launch command.
+Hummingbot can automatically start the execution of a previously configured trading strategy upon launch without requiring the Hummingbot interface `config` and `start` commands.  Any parameters that are required for `config` can be passed into the Hummingbot launch command. Note, config-password (or wallet-password) is the password used for decrypting encrypted configuration and key files and must be supplied. 
 
 **Launch command from docker**
 
@@ -36,8 +36,8 @@ Hummingbot can automatically start the execution of a previously configured trad
 docker run -it \
 -e STRATEGY=${STRATEGY} \
 -e CONFIG_FILE_NAME=${CONFIG_FILENAME} \
+-e CONFIG_PASSWORD=${CONFIG_PASSWORD} \
 -e WALLET=${WALLET} \
--e WALLET_PASSWORD=${WALLET_PASSWORD} \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
@@ -48,8 +48,8 @@ coinalpha/hummingbot:latest
 docker run -it \
 -e STRATEGY=discovery \
 -e CONFIG_FILE_NAME=conf_discovery_strategy_1.yml \
+-e CONFIG_PASSWORD=<INSERT_CONFIG_PASSWORD> \
 -e WALLET=<INSERT_WALLET_ADDRESS> \
--e WALLET_PASSWORD=<INSERT_WALLET_PASSWORD> \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
@@ -70,16 +70,16 @@ docker run -it -d \...
 bin/hummingbot_quickstart.py \
 --strategy ${STRATEGY} \
 --config-file-name ${CONFIG_FILENAME} \
+--config-password ${CONFIG-PASSWORD}
 --wallet ${WALLET} \
---wallet-password ${WALLET-PASSWORD}
 ```
 
 ```bash tab="Sample entry"
 bin/hummingbot_quickstart.py \
 --strategy discovery \
 --config-file-name conf_discovery_strategy_0.yml \
+--config-password <INSERT_CONFIG_PASSWORD>
 --wallet <INSERT_WALLET_ADDRESS> \
---wallet-password <INSERT_WALLET_PASSWORD>
 ```
 
 

--- a/documentation/docs/quickstart/3-configure-bot.md
+++ b/documentation/docs/quickstart/3-configure-bot.md
@@ -62,7 +62,16 @@ Now, let's walk through the process of configuring a basic market making bot.
 
 #### a) Enter `config` to start the configuration walkthrough
 
-We'll create a configuration for the `pure market making` strategy which makes a market on a single trading pair.
+If you never entered your password to HB before, the system will prompt 
+```
+Enter your new password >>> ****
+
+Please reenter your password >>> ****
+```
+
+This password will be used to encrypt sensitive configuration settings e.g. api keys, secrets and wallet private keys. Please note, for security reason, the system does not store your password anywhere, so in case of forgotten password, there is no way to recover it.
+
+Next, we'll create a configuration for the `pure market making` strategy which makes a market on a single trading pair.
 
 !!! warning
     Values of parameters from here on are indicative for illustrative purposes only; this is not financial advice.

--- a/hummingbot/client/command/config_command.py
+++ b/hummingbot/client/command/config_command.py
@@ -12,7 +12,8 @@ from hummingbot.core.utils.wallet_setup import (
     create_and_save_wallet,
     import_and_save_wallet,
     list_wallets,
-    unlock_wallet
+    unlock_wallet,
+    save_wallet
 )
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.in_memory_config_map import in_memory_config_map
@@ -25,7 +26,7 @@ from hummingbot.client.config.config_helpers import (
     copy_strategy_template,
 )
 from hummingbot.core.utils.async_utils import safe_ensure_future
-
+from hummingbot.client.config.config_crypt import list_encrypted_file_paths, decrypt_file
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
@@ -140,8 +141,7 @@ class ConfigCommand:
         choice = await self.app.prompt(prompt=global_config_map.get("wallet").prompt)
         if choice == "import":
             private_key = await self.app.prompt(prompt="Your wallet private key >>> ", is_password=True)
-            password = await self.app.prompt(prompt="A password to protect your wallet key >>> ", is_password=True)
-
+            password = in_memory_config_map["password"].value
             try:
                 self.acct = import_and_save_wallet(password, private_key)
                 self._notify("Wallet %s imported into hummingbot" % (self.acct.address,))
@@ -150,7 +150,7 @@ class ConfigCommand:
                 result = await self._create_or_import_wallet()
                 return result
         elif choice == "create":
-            password = await self.app.prompt(prompt="A password to protect your wallet key >>> ", is_password=True)
+            password = in_memory_config_map["password"].value
             self.acct = create_and_save_wallet(password)
             self._notify("New wallet %s created" % (self.acct.address,))
         else:
@@ -173,16 +173,29 @@ class ConfigCommand:
                 public_key = wallets[0]
             else:
                 public_key = await self.app.prompt(prompt="Which wallet would you like to import ? >>> ")
-            password = await self.app.prompt(prompt="Enter your password >>> ", is_password=True)
+            password = in_memory_config_map["password"].value
             try:
                 acct = unlock_wallet(public_key=public_key, password=password)
                 self._notify("Wallet %s unlocked" % (acct.address,))
                 self.acct = acct
                 return self.acct.address
-            except Exception:
-                self._notify("Cannot unlock wallet. Please try again.")
-                result = await self._unlock_wallet()
-                return result
+            except ValueError as err:
+                if str(err) != "MAC mismatch":
+                    raise err
+                self._notify("The wallet was locked by a different password.")
+                old_password = await self.app.prompt(prompt="Please enter the password >>> ", is_password=True)
+                try:
+                    acct = unlock_wallet(public_key=public_key, password=old_password)
+                    self._notify("Wallet %s unlocked" % (acct.address,))
+                    save_wallet(acct, password)
+                    self._notify(f"Wallet {acct.address} is now saved with your main password.")
+                    self.acct = acct
+                    return self.acct.address
+                except ValueError as err:
+                    if str(err) != "MAC mismatch":
+                        raise err
+                    self._notify("Cannot unlock wallet. Please try again.")
+                    return await self._unlock_wallet()
         else:
             value = await self._create_or_import_wallet()
             return value
@@ -209,6 +222,48 @@ class ConfigCommand:
 
         return strategy_path
 
+    async def _one_password_config(self,  # type: HummingbotApplication
+                                   ):
+        """
+        Special handler function to handle one password unlocking all secure conf variable and wallets
+            - let a user creates a new password if there is no existing encrypted_files or key_files.
+            - verify the entered password is valid by trying to unlock files.
+        """
+        encrypted_files = list_encrypted_file_paths()
+        wallets = list_wallets()
+        password_valid = False
+        err_msg = "Invalid password, please try again."
+        if not encrypted_files and not wallets:
+            password = await self.app.prompt(prompt="Enter your new password >>> ", is_password=True)
+            re_password = await self.app.prompt(prompt="Please reenter your password >>> ", is_password=True)
+            if password == re_password:
+                password_valid = True
+            else:
+                err_msg = "Passwords entered do not match, please try again."
+        else:
+            password = await self.app.prompt(prompt="Enter your password >>> ", is_password=True)
+            if encrypted_files:
+                try:
+                    decrypt_file(encrypted_files[0], password)
+                    password_valid = True
+                except ValueError as err:
+                    if str(err) != "MAC mismatch":
+                        raise err
+            else:
+                for wallet in wallets:
+                    try:
+                        unlock_wallet(public_key=wallet, password=password)
+                        password_valid = True
+                        break
+                    except ValueError as err:
+                        if str(err) != "MAC mismatch":
+                            raise err
+        if password_valid:
+            return password
+        else:
+            self._notify(err_msg)
+            return await self._one_password_config()
+
     async def prompt_single_variable(self,  # type: HummingbotApplication
                                      cvar: ConfigVar,
                                      requirement_overwrite: bool = False) -> Any:
@@ -220,6 +275,8 @@ class ConfigCommand:
         :return: a validated user input or the variable's default value
         """
         if cvar.required or requirement_overwrite:
+            if cvar.key == "password":
+                return await self._one_password_config()
             if cvar.key == "strategy_file_path":
                 val = await self._import_or_create_strategy_config()
             elif cvar.key == "wallet":

--- a/hummingbot/client/config/config_crypt.py
+++ b/hummingbot/client/config/config_crypt.py
@@ -1,0 +1,125 @@
+from eth_account import Account
+from hummingbot.core.utils.wallet_setup import get_key_file_path
+import json
+import os
+from eth_keyfile.keyfile import (
+    Random,
+    get_default_work_factor_for_kdf,
+    _pbkdf2_hash,
+    DKLEN,
+    encode_hex_no_prefix,
+    _scrypt_hash,
+    SCRYPT_R,
+    SCRYPT_P,
+    big_endian_to_int,
+    encrypt_aes_ctr,
+    keccak,
+    int_to_big_endian
+)
+from hummingbot.client.settings import ENCYPTED_CONF_PREFIX, ENCYPTED_CONF_POSTFIX
+
+
+def list_encrypted_file_paths():
+    file_paths = []
+    for f in os.listdir(get_key_file_path()):
+        f_path = os.path.join(get_key_file_path(), f)
+        if os.path.isfile(f_path) and f.startswith(ENCYPTED_CONF_PREFIX) and f.endswith(ENCYPTED_CONF_POSTFIX):
+            file_paths.append(f_path)
+    return file_paths
+
+
+def get_encrypted_config_path(config_var):
+    return "%s%s%s%s" % (get_key_file_path(), ENCYPTED_CONF_PREFIX, config_var.key, ENCYPTED_CONF_POSTFIX)
+
+
+def encrypted_config_file_exists(config_var):
+    return os.path.exists(get_encrypted_config_path(config_var))
+
+
+def encrypt_n_save_config_value(config_var, password):
+    """
+    encrypt configuration value and store in a file, file name is derived from config_var key (in conf folder)
+    """
+    password_bytes = password.encode()
+    message = config_var.value.encode()
+    encrypted = _create_v3_keyfile_json(message, password_bytes)
+    file_path = get_encrypted_config_path(config_var)
+    with open(file_path, 'w+') as f:
+        f.write(json.dumps(encrypted))
+
+
+def decrypt_config_value(config_var, password):
+    if not encrypted_config_file_exists(config_var):
+        return None
+    file_path = get_encrypted_config_path(config_var)
+    return decrypt_file(file_path, password)
+
+
+def decrypt_file(file_path, password):
+    with open(file_path, 'r') as f:
+        encrypted = f.read()
+    secured_value = Account.decrypt(encrypted, password)
+    return secured_value.decode()
+
+
+def _create_v3_keyfile_json(message_to_encrypt, password, kdf="pbkdf2", work_factor=None):
+    """
+    Encrypt message by a given password.
+    Most of this code is copied from eth_key_file.key_file, removed address and is from json result.
+    """
+    salt = Random.get_random_bytes(16)
+
+    if work_factor is None:
+        work_factor = get_default_work_factor_for_kdf(kdf)
+
+    if kdf == 'pbkdf2':
+        derived_key = _pbkdf2_hash(
+            password,
+            hash_name='sha256',
+            salt=salt,
+            iterations=work_factor,
+            dklen=DKLEN,
+        )
+        kdfparams = {
+            'c': work_factor,
+            'dklen': DKLEN,
+            'prf': 'hmac-sha256',
+            'salt': encode_hex_no_prefix(salt),
+        }
+    elif kdf == 'scrypt':
+        derived_key = _scrypt_hash(
+            password,
+            salt=salt,
+            buflen=DKLEN,
+            r=SCRYPT_R,
+            p=SCRYPT_P,
+            n=work_factor,
+        )
+        kdfparams = {
+            'dklen': DKLEN,
+            'n': work_factor,
+            'r': SCRYPT_R,
+            'p': SCRYPT_P,
+            'salt': encode_hex_no_prefix(salt),
+        }
+    else:
+        raise NotImplementedError("KDF not implemented: {0}".format(kdf))
+
+    iv = big_endian_to_int(Random.get_random_bytes(16))
+    encrypt_key = derived_key[:16]
+    ciphertext = encrypt_aes_ctr(message_to_encrypt, encrypt_key, iv)
+    mac = keccak(derived_key[16:32] + ciphertext)
+
+    return {
+        'crypto': {
+            'cipher': 'aes-128-ctr',
+            'cipherparams': {
+                'iv': encode_hex_no_prefix(int_to_big_endian(iv)),
+            },
+            'ciphertext': encode_hex_no_prefix(ciphertext),
+            'kdf': kdf,
+            'kdfparams': kdfparams,
+            'mac': encode_hex_no_prefix(mac),
+        },
+        'version': 3,
+    }

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -32,6 +32,12 @@ from hummingbot.client.settings import (
     TOKEN_ADDRESSES_FILE_PATH,
 )
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.client.config.config_crypt import (
+    encrypt_n_save_config_value,
+    decrypt_config_value,
+    get_encrypted_config_path,
+    encrypted_config_file_exists
+)
 
 # Use ruamel.yaml to preserve order and comments in .yml file
 yaml_parser = ruamel.yaml.YAML()
@@ -218,6 +224,11 @@ def read_configs_from_yml(strategy_file_path: Optional[str] = None):
 
                 val_in_file = data.get(key)
                 cvar.value = parse_cvar_value(cvar, val_in_file)
+                if cvar.is_secure:
+                    if encrypted_config_file_exists(cvar):
+                        password = in_memory_config_map.get("password").value
+                        if password is not None:
+                            cvar.value = decrypt_config_value(cvar, password)
                 if val_in_file is not None and not cvar.validate(val_in_file):
                     raise ValueError("Invalid value %s for config variable %s" % (val_in_file, cvar.key))
 
@@ -251,7 +262,14 @@ async def save_to_yml(yml_path: str, cm: Dict[str, ConfigVar]):
             data = yaml_parser.load(stream) or {}
             for key in cm:
                 cvar = cm.get(key)
-                if type(cvar.value) == Decimal:
+                if cvar.is_secure:
+                    if cvar.value is not None and not encrypted_config_file_exists(cvar):
+                        from hummingbot.client.config.in_memory_config_map import in_memory_config_map
+                        password = in_memory_config_map.get("password").value
+                        encrypt_n_save_config_value(cvar, password)
+                    if key in data:
+                        data.pop(key)
+                elif type(cvar.value) == Decimal:
                     data[key] = float(cvar.value)
                 else:
                     data[key] = cvar.value

--- a/hummingbot/client/config/in_memory_config_map.py
+++ b/hummingbot/client/config/in_memory_config_map.py
@@ -27,6 +27,10 @@ def default_strategy_conf_path_prompt():
 # These configs are never saved and prompted every time
 in_memory_config_map = {
     # Always required
+    "password":
+        ConfigVar(key="password",
+                  prompt="Password please >>> ",
+                  is_secure=True),
     "strategy":
         ConfigVar(key="strategy",
                   prompt="What is your market making strategy? >>> ",

--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -14,6 +14,8 @@ trading_pair_fetcher = TradingPairFetcher.get_instance()
 # Global static values
 KEYFILE_PREFIX = "key_file_"
 KEYFILE_POSTFIX = ".json"
+ENCYPTED_CONF_PREFIX = "encrypted_"
+ENCYPTED_CONF_POSTFIX = ".json"
 GLOBAL_CONFIG_PATH = "conf/conf_global.yml"
 TOKEN_ADDRESSES_FILE_PATH = realpath(join(__file__, "../../wallet/ethereum/erc20_tokens.json"))
 DEFAULT_KEY_FILE_PATH = "conf/"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

Related Clubhouse Story: 4535, 6716
A description of the changes proposed in the pull request:

- Added config_crypt to handle message encryption and decryption using a password.
Added password variable to in memory configuration, this will ask a user every time they configure settings.
- For a new user, ask for a new password, encrypt all secure conf variables into files.
- For an existing user without existing wallet, ask for a new password, encrypt all existing secure conf variables into files.
- For an existing user with existing wallet, ask for a password which can unlock at least one of the wallets.
- When the system encounters a wallet which cannot be unlocked with the password, it asks for the old password to unlock the key then re-encrypts it (and save the key file) with the new password.
- Added --config-password (alias to --wallet-password) or -p to hummingbot_quickstart, this argument must be supplied.