### PR TITLE
docs / troubleshooting discovery with paper trade

### DIFF
--- a/documentation/docs/support/troubleshooting/general.md
+++ b/documentation/docs/support/troubleshooting/general.md
@@ -170,21 +170,3 @@ ValueError: Unable to convert 'BTC' to 'BTC'. Aborting.
 
 In this case, BTC is not yet added to the list of exchange rate class. See [this page](/utilities/exchange-rates/#exchange-rate-class) the correct format on adding exchange rate.
 
-#### Discovery strategy error with paper trading mode
-
-Error appears both in logs and right pane if you are running discovery strategy with paper trade enabled.
-
-```
-hummingbot.client.hummingbot_application - ERROR - Error in check_discovery_strategy_ready_loop: 'NoneType' object has no attribute 'all_markets_ready'
-Traceback (most recent call last):
-  File "/hummingbot/strategy/discovery/start.py", line 52, in check_discovery_strategy_ready_loop
-    if self.strategy.all_markets_ready:
-AttributeError: 'NoneType' object has no attribute 'all_markets_ready'
-
-  File "paper_trade_market.pyx", line 242, in hummingbot.market.paper_trade.paper_trade_market.PaperTradeMarket.ready.__get__
-  File "paper_trade_market.pyx", line 206, in hummingbot.market.paper_trade.paper_trade_market.PaperTradeMarket.init_paper_trade_market
-  File "paper_trade_market.pyx", line 214, in hummingbot.market.paper_trade.paper_trade_market.PaperTradeMarket.split_trading_pair
-```
-
-In this case, disabling paper trade mode will fix the problem. See [this page](https://docs.hummingbot.io/utilities/paper-trade/) on how to use paper trade.
-


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

- Removed instructions to disable paper trading mode when running discovery strategy

After performing more tests and triaging, found out that the error we've been getting is not because of paper trading enabled when running discovery strategy. It's because of the new trading pair in Binance. Ran the strategy on a different market and worked fine with paper trading mode.