### PR TITLE
fix/ exchange rate conversion convert token value error

### DIFF
--- a/hummingbot/core/utils/exchange_rate_conversion.py
+++ b/hummingbot/core/utils/exchange_rate_conversion.py
@@ -196,7 +196,8 @@ class ExchangeRateConversion:
         from_currency = from_currency.upper()
         to_currency = to_currency.upper()
         # assume WETH and ETH are equal value
-        if from_currency == "ETH" and to_currency == "WETH" or from_currency == "WETH" and to_currency == "ETH":
+        if from_currency == "ETH" and to_currency == "WETH" or from_currency == "WETH" and to_currency == "ETH" \
+                or from_currency == to_currency:
             return amount
         from_currency_usd_rate = exchange_rate.get(from_currency.upper(), NaN)
         to_currency_usd_rate = exchange_rate.get(to_currency.upper(), NaN)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Addresses the following issue with Performance Analysis. Bug only occurs when the quote asset in use is `USD/USDT`

```
Traceback (most recent call last):
  File "/Users/daniel/Documents/hummingbot/hummingbot/client/command/history_command.py", line 168, in trade_performance_report
    raw_queried_trades,
  File "/Users/daniel/Documents/hummingbot/hummingbot/client/performance_analysis.py", line 245, in calculate_trade_performance
    combined_acquired, quote_asset, primary_quote_asset, source="default"
  File "/Users/daniel/Documents/hummingbot/hummingbot/core/utils/exchange_rate_conversion.py", line 178, in convert_token_value_decimal
    return Decimal(repr(self.convert_token_value(float(amount), from_currency, to_currency, source)))
  File "/Users/daniel/Documents/hummingbot/hummingbot/core/utils/exchange_rate_conversion.py", line 204, in convert_token_value
    raise ValueError(f"Unable to convert '{from_currency}' to '{to_currency}'. Aborting.")
ValueError: Unable to convert 'USD' to 'USD'. Aborting.
```