### PR TITLE
docs / rework quickstart in general docs

### DIFF
--- a/documentation/docs/bounties/active/harmony.md
+++ b/documentation/docs/bounties/active/harmony.md
@@ -11,7 +11,7 @@ $ONE Makers will run from July 1, 2019 to October 31, 2019, split into 4 monthly
 * July 1st to July 31st
 * August 1st to August 31st
 * September 1st to September 30th
-* **October 1st to October 31st (current)**
+* October 1st to October 31st
 
 Each period begins at 12am UTC on the 1st of the month and ends at 12am UTC time on the 1st of the following month.
 

--- a/documentation/docs/installation/cloud.md
+++ b/documentation/docs/installation/cloud.md
@@ -1,4 +1,4 @@
-# Install Hummingbot in the Cloud
+# Setup a Cloud Server
 
 Using Hummingbot as a long running service can be achieved with the help of cloud platforms such as Google Cloud Platform, Amazon Web Services, and Microsoft Azure. You may read our blog about running [Hummingbot on different cloud providers](https://www.hummingbot.io/blog/2019-06-cloud-providers/).
 

--- a/documentation/docs/installation/via-docker/linux.md
+++ b/documentation/docs/installation/via-docker/linux.md
@@ -5,66 +5,13 @@ You can install Docker and/or Hummingbot by selecting ***either*** of the follow
 1. **Easy Install**: download and use automated install scripts.
 2. **Manual Installation**: run install commands manually.
 
-## Existing Docker Installation
-
-If you already have Docker installed, use the following commands to install and start Hummingbot:
-
-#### Install tmux
-
-!!! note
-    To learn more about `tmux` please visit [getting-started-with-tmux](https://linuxize.com/post/getting-started-with-tmux/).
-
-```bash tab="Ubuntu / Debian"
-sudo apt-get update
-sudo apt-get install -y tmux
-```
-
-```bash tab="CentOS"
-sudo yum -y install tmux
-```
-
-
-#### Run Hummingbot
-
-Open a new `tmux` window:
-
-```
-tmux
-```
-
-Install and run Hummingbot:
-
-```bash tab="Option 1: Easy Install"
-# 1) Download Hummingbot install script
-wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh
-
-# 2) Enable script permissions
-chmod a+x create.sh
-
-# 3) Run installation
-./create.sh
-```
-
-```bash tab="Option 2: Manual Installation"
-# 1) Create folder for your new instance
-mkdir hummingbot_files
-
-# 2) Create folders for log and config files
-mkdir hummingbot_files/hummingbot_conf && mkdir hummingbot_files/hummingbot_logs
-
-# 3) Launch a new instance of hummingbot
-docker run -it \
---name hummingbot-instance \
---mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
---mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
-coinalpha/hummingbot:latest
-```
-
 ## Ubuntu
 
 *Supported versions: 16.04 LTS, 18.04 LTS, 19.04*
 
 #### Step 1: Install Docker
+
+Skip this step if you already have Docker installed. Run the following commands:
 
 ```bash tab="Option 1: Easy Install"
 # 1) Download Docker install script
@@ -75,8 +22,6 @@ chmod a+x install-docker-ubuntu.sh
 
 # 3) Run installation
 ./install-docker-ubuntu.sh
-
-# **Note**: the script will close the terminal window
 ```
 
 ```bash tab="Option 2: Manual Installation"
@@ -105,13 +50,7 @@ exit
 
 #### Step 2: Install Hummingbot
 
-Open a new `tmux` window:
-
-```
-tmux
-```
-
-Install and run Hummingbot:
+Run the following commands:
 
 ```bash tab="Option 1: Easy Install"
 # 1) Download Hummingbot install script
@@ -120,7 +59,7 @@ wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installa
 # 2) Enable script permissions
 chmod a+x create.sh
 
-# 3) Run installation
+# 3) Create a hummingbot instance
 ./create.sh
 ```
 
@@ -145,6 +84,8 @@ coinalpha/hummingbot:latest
 
 #### Step 1: Install Docker
 
+Skip this step if you already have Docker installed. Run the following commands:
+
 ```bash tab="Option 1: Easy Install"
 # 1) Download Docker install script
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/install-docker/install-docker-debian.sh
@@ -154,8 +95,6 @@ chmod a+x install-docker-debian.sh
 
 # 3) Run installation
 ./install-docker-debian.sh
-
-# **Note**: the script will close the terminal window
 ```
 
 ```bash tab="Option 2: Manual Installation"
@@ -186,13 +125,7 @@ exit
 
 #### Step 2: Install Hummingbot
 
-Open a new `tmux` window:
-
-```
-tmux
-```
-
-Install and run Hummingbot:
+Run the following commands:
 
 ```bash tab="Option 1: Easy Install"
 # 1) Download Hummingbot install script
@@ -201,7 +134,7 @@ wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installa
 # 2) Enable script permissions
 chmod a+x create.sh
 
-# 3) Run installation
+# 3) Create a hummingbot instance
 ./create.sh
 ```
 
@@ -226,6 +159,8 @@ coinalpha/hummingbot:latest
 
 #### Step 1: Install Docker
 
+Skip this step if you already have Docker installed. Run the following commands:
+
 ```bash tab="Option 1: Easy Install"
 # 1) Download Docker install script
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/install-docker/install-docker-centos.sh
@@ -235,8 +170,6 @@ chmod a+x install-docker-centos.sh
 
 # 3) Run installation
 ./install-docker-centos.sh
-
-# **Note**: the script will close the terminal window
 ```
 
 ```bash tab="Option 2: Manual Installation"
@@ -265,13 +198,7 @@ exit
 
 #### Step 2: Install Hummingbot
 
-Open a new `tmux` window:
-
-```
-tmux
-```
-
-Install and run Hummingbot:
+Run the following commands:
 
 ```bash tab="Option 1: Easy Install"
 # 1) Download Hummingbot install script
@@ -280,7 +207,7 @@ wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installa
 # 2) Enable script permissions
 chmod a+x create.sh
 
-# 3) Run installation
+# 3) Create a hummingbot instance
 ./create.sh
 ```
 

--- a/documentation/docs/installation/via-docker/macOS.md
+++ b/documentation/docs/installation/via-docker/macOS.md
@@ -1,4 +1,4 @@
-# MacOS Installation Using Docker
+# macOS Installation Using Docker
 
 ## Step 1. Install Docker
 

--- a/documentation/docs/operation/running-multiple-bots.md
+++ b/documentation/docs/operation/running-multiple-bots.md
@@ -36,23 +36,12 @@ conda activate hummingbot
 
 ### Running in the background (from source)
 
-!!! note
-    The screen package is pre-installed on most Linux distros nowadays. To learn more about `screen` please visit [how-to-use-linux-screen](https://linuxize.com/post/how-to-use-linux-screen/). You can check if it is installed on your system by typing:
-    ```
-    screen --version
-    ```
-If not installed here's how to install screen
+Use either `tmux` or `screen` to run multiple bots installed from source. Check out these external links how to use them.
 
-```bash tab="Ubuntu / Debian"
-sudo apt-get update
-sudo apt-get install -y screen
-```
+* [Getting started with Tmux](https://linuxize.com/post/getting-started-with-tmux/)
+* [How to use Linux Screen](https://linuxize.com/post/how-to-use-linux-screen/)
 
-```bash tab="CentOS"
-sudo yum -y install screen
-```
-
-To run an instance in the background, run either of the following commands: `screen` or `screen -S $NAME`, where `$NAME` is what you wish to call this background instance. Use the latter to be more explicit if you want to run multiple bots.
+When using screen to run an instance in the background, run either of the following commands: `screen` or `screen -S $NAME`, where `$NAME` is what you wish to call this background instance. Use the latter to be more explicit if you want to run multiple bots.
 
 Navigate to the folder where your separate Hummingbot is installed, then start the bot like normal.
 

--- a/documentation/docs/quickstart/2-install.md
+++ b/documentation/docs/quickstart/2-install.md
@@ -13,20 +13,6 @@ If you don't already have Docker, we show you how to install Docker for each pla
 
 ### Linux/Cloud
 
-Install `tmux` to allow you to easily run Hummingbot remotely:
-
-!!! note
-    To learn more about `tmux` please visit [getting started with tmux](https://linuxize.com/post/getting-started-with-tmux/).
-
-```bash tab="Ubuntu / Debian"
-sudo apt-get update
-sudo apt-get install -y tmux
-```
-
-```bash tab="CentOS"
-sudo yum -y install tmux
-```
-
 Install Docker:
 ```bash
 # 1) Download Docker install script
@@ -84,11 +70,6 @@ hummingbot_files       # Top level folder for hummingbot-related files
 
 
 ### Linux/Cloud
-
-Open a new Bash window and run `tmux` to create a new process:
-```
-tmux
-```
 
 Aftewards, run the following commands:
 ```bash

--- a/documentation/docs/quickstart/2-install.md
+++ b/documentation/docs/quickstart/2-install.md
@@ -16,7 +16,6 @@ For Linux we highlight the Docker image method for new users since it contains a
 
 Docker is an open source containerization product that pre-packages all dependencies into a single container, greatly simplifying the installation process.
 
-Install Docker:
 ```bash
 # 1) Download Docker install script
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/install-docker/install-docker-ubuntu.sh
@@ -32,6 +31,8 @@ chmod a+x install-docker-ubuntu.sh
 
 !!! warning "Restart Terminal"
     The above commands will close your terminal/bash window in order to enable the correct permissions for the `docker` command. Close and restart your bash/terminal window if it did not close automatically.
+
+We also have instructions for installing Docker on [Debian](/installation/via-docker/linux/#debian) and [CentOS](/installation/via-docker/linux/#centos).
 
 
 ### Step 2: Install Hummingbot

--- a/documentation/docs/quickstart/2-install.md
+++ b/documentation/docs/quickstart/2-install.md
@@ -1,17 +1,20 @@
 # [Quickstart] Install Hummingbot
 
-!!! note
-    You can now install `Hummingbot` using GUI Installer on [Windows](https://docs.hummingbot.io/installation/from-binary/windows/), [MacOS](https://docs.hummingbot.io/installation/from-binary/macos/) and coming soon to [Linux](https://hummingbot.io/download/).
+Below, we show you how to easily install Hummingbot using our installation scripts for each supported platform.
 
-Below, we show you how to install Hummingbot using our installation scripts for each supported platform. We highlight the Docker image method for new users since it contains all necessary dependencies.
+For more detailed instructions, refer to our [User Manual](/installation/index). For developers who would like to install from source:
 
-If you would like to install from source or see the detailed installation instructions, see [Installation](/installation) in the [User Manual](https://docs.hummingbot.io/manual/).
+- [Linux Source Installation](/installation/from-source.linux)
+- [macOS Source Installation](installation/from-source/macOS)
+- [Windows Source Installation](installation/from-source/windows)
 
-## Step 1: Install Docker
+## Linux/Cloud
 
-If you don't already have Docker, we show you how to install Docker for each platform. Docker is an open source containerization product that pre-packages all dependencies into a single container, greatly simplifying the installation process.
+For Linux we highlight the Docker image method for new users since it contains all necessary dependencies.
 
-### Linux/Cloud
+### Step 1: Install Docker
+
+Docker is an open source containerization product that pre-packages all dependencies into a single container, greatly simplifying the installation process.
 
 Install Docker:
 ```bash
@@ -30,29 +33,10 @@ chmod a+x install-docker-ubuntu.sh
 !!! warning "Restart Terminal"
     The above commands will close your terminal/bash window in order to enable the correct permissions for the `docker` command. Close and restart your bash/terminal window if it did not close automatically.
 
-### MacOS
 
-You can install Docker by [downloading an installer](https://docs.docker.com/v17.12/docker-for-mac/install/) from the official page. After you have downloaded and installed Docker, restart your system if necessary.
+### Step 2: Install Hummingbot
 
-### Windows
-
-Download the latest version Docker Toolbox .exe file at the following link: [Docker Toolbox Releases](https://github.com/docker/toolbox/releases/).
-
-![Docker Download](/assets/img/docker_toolbox_download.PNG)
-
-Locate the installer in the downloads folder and run a full installation with included VirtualBox and Git for Windows. (Git is the default shell used by Docker)
-
-![Docker Installation](/assets/img/docker_toolbox_install.PNG)
-
-By default, a shortcut to the Docker Quickstart terminal will be created on your desktop. You can open Docker Toolbox using this shortcut.
-
-![Docker Startup](/assets/img/docker_toolbox_startup.PNG)
-
-
-## Step 2: Install Hummingbot
-
-### Using Automated Docker Scripts
-We have created helper scripts that simplify the process of installing and running Hummingbot with Docker:
+We have created automated docker scripts that simplify the process of installing and running Hummingbot with Docker:
 
 * `create.sh`: Creates a new instance of Hummingbot
 * `start.sh`: Starts Hummingbot
@@ -65,15 +49,10 @@ hummingbot_files       # Top level folder for hummingbot-related files
 └── hummingbot_logs    # Maps to hummingbot's logs/ folder, which stores log files
 ```
 
-!!! warning
-    When you update Hummingbot, use the `update.sh` helper script. Do not delete these folders; otherwise, your configuration info may be lost.
+To download the scripts and create a Hummingbot instance, run the following commands:
 
-
-### Linux/Cloud
-
-Aftewards, run the following commands:
 ```bash
-# 1) Download Hummingbot helper scripts
+# 1) Download hummingbot helper scripts
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh
@@ -81,56 +60,20 @@ wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installa
 # 2) Enable script permissions
 chmod a+x *.sh
 
-# 3) Run install script
-./create.sh
-```
-
-Afterwards, you should see the Hummingbot client interface. Proceed to [Configure a Bot](/quickstart/3-configure-bot).
-
-### MacOS
-
-Open a Terminal window and run the following commands:
-```bash
-# 1) Download Hummingbot helper scripts
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh -o create.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh -o start.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh -o update.sh
-
-# 2) Enable script permissions
-chmod a+x *.sh
-
-# 3) Run install script
+# 3) Run create.sh script to create hummingbot instance
 ./create.sh
 ```
 
 Afterwards, you should see the Hummingbot client interface. Proceed to [Configure a Bot](/quickstart/3-configure-bot).
 
 
-### Windows
+## Windows and MacOS
 
-Open Docker Toolbox using the Docker Quickstart desktop shortcut. You should see the following screen:
+Setup and install package to install on local computer can be downloaded from our official website:
 
-![Docker Ready](/assets/img/docker_toolbox_cmdline.PNG)
+- [Download the Hummingbot client](https://hummingbot.io/download/)
 
-From inside the Docker Toolbox window, run the following commands:
+You may also refer to our User Manual for more information.
 
-```bash
-# 1) Navigate to root folder
-cd ~
-
-# 2) Download Hummingbot helper scripts
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh -o create.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh -o start.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh -o update.sh
-
-# 3) Enable script permissions
-chmod a+x *.sh
-
-# 4) Run install script
-./create.sh
-```
-
-Afterwards, you should see the Hummingbot client interface. Proceed to [Configure a Bot](/quickstart/3-configure-bot).
-
----
-# Next: [Configure Your First Trading Bot](/quickstart/3-configure-bot)
+- [Windows Binary Installation](/installation/from-binary/windows)
+- [MacOS Binary Installation](installation/from-binary/macos)

--- a/documentation/docs/quickstart/2-install.md
+++ b/documentation/docs/quickstart/2-install.md
@@ -25,8 +25,6 @@ chmod a+x install-docker-ubuntu.sh
 
 # 3) Run installation
 ./install-docker-ubuntu.sh
-
-# Note: The script will close the terminal window
 ```
 
 !!! warning "Restart Terminal"
@@ -68,7 +66,7 @@ chmod a+x *.sh
 Afterwards, you should see the Hummingbot client interface. Proceed to [Configure a Bot](/quickstart/3-configure-bot).
 
 
-## Windows and MacOS
+## Windows and macOS
 
 Setup and install package to install on local computer can be downloaded from our official website:
 
@@ -77,4 +75,4 @@ Setup and install package to install on local computer can be downloaded from ou
 You may also refer to our User Manual for more information.
 
 - [Windows Binary Installation](/installation/from-binary/windows)
-- [MacOS Binary Installation](installation/from-binary/macos)
+- [macOS Binary Installation](installation/from-binary/macos)

--- a/documentation/docs/quickstart/3-configure-bot.md
+++ b/documentation/docs/quickstart/3-configure-bot.md
@@ -9,20 +9,27 @@ If you have successfully installed Hummingbot using our install scripts, you sho
 First, let's walk through the design of the Hummingbot client interface:
 
 * Left top pane: where the responses to your commands are printed
-* Left bottom pane: where you input [commands](https://docs.hummingbot.io/operation/client/#client-commands) to control your bot
+* Left bottom pane: where you input [commands](/operation/client/#user-interface) to control your bot
 * Right pane: where logs of live trading bot activity are printed
 
 **Enter `help` to see a list of commands:**
-```
->>> help
-help    Print a list of commands
-start   Start market making with Hummingbot
-config  Add your personal credentials e.g. exchange API keys
-status  Get current bot status
-bounty  Participate in hummingbot's liquidity bounty programs
 
-etc...
 ```
+bounty              Participate in hummingbot's liquidity bounty programs 
+config              Add your personal credentials e.g. exchange API keys  
+exit                Securely exit the command line                        
+export_private_key  Print your account private key                        
+export_trades       Export your trades to a csv file                      
+get_balance         Print balance of a certain currency                   
+help                Print a list of commands                              
+history             Get your bot's past trades and performance analytics  
+list                List global objects                                   
+paper_trade         Enable / Disable paper trade mode.                    
+start               Start market making with Hummingbot                   
+status              Get current bot status                                
+stop                Stop the bot's active strategy
+```
+
 ## Step 2: Enable Paper Trading Mode (Optional)
 
 You can run Hummingbot and simulate trading strategies without executing and placing actual trades. Run command `paper_trade` at the beginning to enable this feature.
@@ -39,21 +46,7 @@ Your configuration is incomplete. Would you like to proceed and finish all neces
 For more information about this feature, see [Paper Trading Mode](/utilities/paper-trade) in the User Manual. To perform actual trading, proceed to the next step.
 
 
-## Step 3: Register for Liquidity Bounties (Optional)
-
-Liquidity Bounties allow you to earn rewards by running market making bots for specific tokens and/or exchanges.
-
-Hummingbot enters into partnerships with token issuers and exchanges to administer bounty programs that reward Hummingbot users based on their volume of filled market maker orders. For more information, please see [Bounties FAQ](/bounties/faq).
-
-**Enter `bounty --register` to start the registration process:**
-
-1. Agree to the Terms & Conditions
-2. Allow us to collect your trading data for verification purposes
-3. Enter your Ethereum wallet address
-4. Enter your email address
-5. Confirm information and finalize
-
-## Step 4: Configure a market making bot
+## Step 3: Configure a market making bot
 
 Now, let's walk through the process of configuring a basic market making bot.
 
@@ -62,7 +55,8 @@ Now, let's walk through the process of configuring a basic market making bot.
 
 #### a) Enter `config` to start the configuration walkthrough
 
-If you never entered your password to HB before, the system will prompt 
+If setting up Hummingbot for the first time, the system will prompt:
+
 ```
 Enter your new password >>> ****
 
@@ -71,7 +65,7 @@ Please reenter your password >>> ****
 
 This password will be used to encrypt sensitive configuration settings e.g. api keys, secrets and wallet private keys. Please note, for security reason, the system does not store your password anywhere, so in case of forgotten password, there is no way to recover it.
 
-Next, we'll create a configuration for the `pure market making` strategy which makes a market on a single trading pair.
+Next, we'll create a configuration for the [pure market making](/strategies/pure-market-making) strategy which makes a market on a single trading pair.
 
 !!! warning
     Values of parameters from here on are indicative for illustrative purposes only; this is not financial advice.
@@ -86,7 +80,7 @@ create
 
 #### b) Select the exchange and trading pair
 
-Next, select which exchange and trading pair you want to use. Note that you may need an exchange account and inventory of crypto assets deposited on the exchange. You can view more information [here](/connectors/index) about the exchanges Hummingbot currently supports.
+Next, select which exchange and trading pair you want to use. Note that you may need an exchange account and inventory of crypto assets deposited on the exchange. You can view more information in [Connectors Overview](https://docs.hummingbot.io/connectors/) about the exchanges Hummingbot currently supports.
 
 You can select a centralized exchange like Binance:
 ```
@@ -160,8 +154,8 @@ Here's an [inventory skew calculator](https://docs.google.com/spreadsheets/d/16o
 
 Now that you have set up how your market making bot will behave, it's time to provide it with the necessary API keys (for centralized exchanges) or wallet/node info (for decentralized exchanges) that it needs to operate:
 
-!!! note "Copying and pasting in Windows"
-    If you are using a Windows machine, you may need to activate copying and pasting on Docker Toolbox. Please see [this page](/support/how-to/#how-do-i-copy-and-paste-in-docker-toolbox-windows) for instructions on how to activate this.
+!!! note "Copying and Pasting"
+    Our Get Help section contains answers to some of the common how-to questions like [How do I copy and paste in Docker Toolbox?](/support/how-to/#how-do-i-copy-and-paste-in-docker-toolbox-windows) and [How do I paste items from clipboard in PuTTY?](support/how-to/#how-do-i-paste-items-from-clipboard-in-putty)
 
 If you selected a centralized exchange like Binance in Step 3(b), you will need to :
 ```
@@ -190,7 +184,8 @@ Which Ethereum node would you like your client to connect to? >>>
 [ENTER ADDRESS OF YOUR ETHEREUM NODE]
 ```
 
-See [Ethereum wallet](/installation/wallet) and [Ethereum node](/installation/node/node) for more information.
+More information in User Manual about [Ethereum wallet](/installation/wallet) and [Ethereum node](/installation/node/node).
+
 
 #### f) Enter kill switch parameters
 
@@ -212,7 +207,7 @@ At what profit/loss rate would you like the bot to stop? (e.g. -0.05 equals 5% l
 -0.05
 ```
 
-## Step 5: Adjusting Parameters
+## Step 4: Adjusting Parameters
 
 If you want to reconfigure the bot from the beginning, type `config` and reply `y` to the question `Would you like to reconfigure the bot? (y/n) >>>?`. This will prompt all questions during initial set up.
 

--- a/documentation/docs/quickstart/4-run-bot.md
+++ b/documentation/docs/quickstart/4-run-bot.md
@@ -1,6 +1,6 @@
 # [Quickstart] Run Your First Trading Bot
 
-Now that you have successfully [configured](/quickstart/3-configure-bot) a trading bot, you can start market making by running the `start` command.
+Now that you have successfully configured a trading bot, you can start market making by running the `start` command.
 
 !!! tip
     You can see your Hummingbot open orders in real-time on the exchange website as you run Hummingbot. Generally, we recommend having the exchange website in a browser alongside the running Hummingbot command line interface.
@@ -46,8 +46,7 @@ This command shows you:
 * **Inventory**: How your inventory has changed as a result of these trades
 * **Performance**: How much profit or loss your bot has made as a result of these trades
 
-!!! note "Performance"
-    The value of your starting inventory may change when you check your bot's status. See [this page](/support/faq/#why-does-my-starting-inventory-value-keep-changing) for more information.
+For more information on how Hummingbot calculates performance, refer to [Performance Analysis](/utilities/performance-analysis/).
 
 
 ## Step 4: Exit and restart Hummingbot
@@ -60,7 +59,7 @@ Hummingbot automatically cancels all outstanding orders and notifies you if it b
 
 #### b) Restart Hummingbot
 
-To restart Hummingbot, run the `start.sh` helper script from the command line. This starts and attaches the Docker container.
+To restart Hummingbot via Docker, run the `start.sh` helper script from the command line. This starts and attaches the Docker container.
 ```
 ./start.sh
 ```
@@ -80,7 +79,7 @@ By default, the auto-saved strategy configuration file is named `conf_pure_marke
 
 #### a) Import configuration
 
-Enter `config` to start the configuration process again, but select `import`:
+Enter `config` to start the configuration process again, enter your password, then select `import`:
 ```
 What is your market making strategy >>>
 pure_market_making

--- a/documentation/docs/quickstart/index.md
+++ b/documentation/docs/quickstart/index.md
@@ -43,7 +43,7 @@ For more information, see [Ethereum node](/installation/node/node). To get a fre
 
 We recommend that users run trading bots in the cloud, since bots require a stable network connection and can run 24/7.
 
-Follow the guide [Set up a cloud server](/installation/cloud) to set up a cloud server on your preferred cloud platform. Hummingbot is not resource-intensive so the lowest/free tiers should work.
+Follow the guide to [set up a cloud server](/installation/cloud) on your preferred cloud platform. Hummingbot is not resource-intensive so the lowest/free tiers should work.
 
 !!! tip
     Don't know which cloud platform to use? Read our [blog post](https://www.hummingbot.io/blog/2019-06-cloud-providers/) that compares and contrasts the different providers.


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

General/Quickstart
- Changed Docker method with setup/install package for Windows and macOS
- Added instructions on how to install Docker if using Debian or CentOS
- Removed tmux when installing Hummingbot via Docker
- Updated list of commands when sending `help` command in Hummingbot CLI
- Removed step to register for liquidity bounties
- Added link for performance analysis calculation
- Added step to enter password after restarting Hummingbot instance
- Other minor edits and removed dead links

User Manual/Installation
- Removed tmux when installing Hummingbot via Docker
- Added tmux for running multiple bots installed from source
- Removed "Existing Docker Installation" section in Install via Docker (Linux)
- Replaced with a one-liner in each Linux distro to skip installing Docker if already installed
- Other minor edits and removed dead links