### PR TITLE
refactor / update docker scripts to map data folder

### DIFF
--- a/documentation/docs/installation/updating.md
+++ b/documentation/docs/installation/updating.md
@@ -2,13 +2,18 @@
 
 ## Update via Docker
 
-We regularly update Hummingbot (see [Releases](/release-notes/)) and recommend users to regularly update their installations to get the latest version of the software.  
+We regularly update Hummingbot (see [Release Notes](/release-notes/)) and recommend users to regularly update their installations to get the latest version of the software.  
 
 Updating to the latest docker image (e.g. `coinalpha/hummingbot:latest`) requires users to (1) delete any instances of Hummingbot using that image, (2) delete the old image, and (3) recreate the Hummingbot instance:
 
 ```bash tab="Script"
+# 1) Download update script
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh
+
+# 2) Enable script permissions
 chmod a+x update.sh
+
+# 3) Run script to update hummingbot
 ./update.sh
 ```
 
@@ -33,7 +38,7 @@ coinalpha/hummingbot:latest
 
 Download the latest code from GitHub:
 
-```
+```bash
 # From the hummingbot root folder:
 git pull origin master
 
@@ -49,10 +54,14 @@ bin/hummingbot.py
 
 Alternatively, use our automated script:
 
-```
-# From the *root* folder:
+```bash
+# 1) Download update script to the *root* folder
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/install-from-source/update.sh
+
+# 2) Enable script permissions
 chmod a+x update.sh
+
+# 3) Run script to update hummingbot
 ./update.sh
 ```
 

--- a/documentation/docs/installation/updating.md
+++ b/documentation/docs/installation/updating.md
@@ -64,18 +64,3 @@ chmod a+x update.sh
 # 3) Run script to update hummingbot
 ./update.sh
 ```
-
-
-## Installing from specific version via Docker
-`$TAG` = Hummingbot version e.g. `version-0.16.0` For more information, visit the list of versions of [Hummingbot tags](https://hub.docker.com/r/coinalpha/hummingbot/tags).
-
-```
-$ ./create.sh 
-
-** ✏️  Creating a new Hummingbot instance **
-
-ℹ️  Press [enter] for default values.
-
-➡️  Enter Hummingbot version: [latest|development] (default = "latest")
-$TAG
-```

--- a/documentation/docs/installation/updating.md
+++ b/documentation/docs/installation/updating.md
@@ -24,6 +24,7 @@ docker run -it \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```
 

--- a/documentation/docs/installation/via-docker/linux.md
+++ b/documentation/docs/installation/via-docker/linux.md
@@ -67,14 +67,17 @@ chmod a+x create.sh
 # 1) Create folder for your new instance
 mkdir hummingbot_files
 
-# 2) Create folders for log and config files
-mkdir hummingbot_files/hummingbot_conf && mkdir hummingbot_files/hummingbot_logs
+# 2) Create folders for logs, config files and database file
+mkdir hummingbot_files/hummingbot_conf
+mkdir hummingbot_files/hummingbot_logs
+mkdir hummingbot_files/hummingbot_data
 
 # 3) Launch a new instance of hummingbot
 docker run -it \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```
 
@@ -142,14 +145,17 @@ chmod a+x create.sh
 # 1) Create folder for your new instance
 mkdir hummingbot_files
 
-# 2) Create folders for log and config files
-mkdir hummingbot_files/hummingbot_conf && mkdir hummingbot_files/hummingbot_logs
+# 2) Create folders for logs, config files and database file
+mkdir hummingbot_files/hummingbot_conf
+mkdir hummingbot_files/hummingbot_logs
+mkdir hummingbot_files/hummingbot_data
 
 # 3) Launch a new instance of hummingbot
 docker run -it \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```
 
@@ -215,14 +221,17 @@ chmod a+x create.sh
 # 1) Create folder for your new instance
 mkdir hummingbot_files
 
-# 2) Create folders for log and config files
-mkdir hummingbot_files/hummingbot_conf && mkdir hummingbot_files/hummingbot_logs
+# 2) Create folders for logs, config files and database file
+mkdir hummingbot_files/hummingbot_conf
+mkdir hummingbot_files/hummingbot_logs
+mkdir hummingbot_files/hummingbot_data
 
 # 3) Launch a new instance of hummingbot
 docker run -it \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```
 

--- a/documentation/docs/installation/via-docker/linux.md
+++ b/documentation/docs/installation/via-docker/linux.md
@@ -235,6 +235,26 @@ docker run -it \
 coinalpha/hummingbot:latest
 ```
 
+## Install a previous Hummingbot version
+
+A previous version can be installed when creating a Hummingbot instance.
+
+```bash
+# 1) Run the script to create a hummingbot instance
+./create.sh 
+
+# 2) Specify the version to be installed when prompted
+
+** ✏️  Creating a new Hummingbot instance **
+
+ℹ️  Press [enter] for default values.
+
+➡️  Enter Hummingbot version: [latest|development] (default = "latest")
+
+```
+
+ For example, enter `version-0.16.0`. The versions are listed here in [Hummingbot Tags](https://hub.docker.com/r/coinalpha/hummingbot/tags).
+
 ----
 
 ## Developer Notes

--- a/documentation/docs/installation/via-docker/macOS.md
+++ b/documentation/docs/installation/via-docker/macOS.md
@@ -39,3 +39,23 @@ docker run -it \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```
+
+## Install a previous Hummingbot version
+
+A previous version can be installed when creating a Hummingbot instance.
+
+```bash
+# 1) Run the script to create a hummingbot instance
+./create.sh 
+
+# 2) Specify the version to be installed when prompted
+
+** ✏️  Creating a new Hummingbot instance **
+
+ℹ️  Press [enter] for default values.
+
+➡️  Enter Hummingbot version: [latest|development] (default = "latest")
+
+```
+
+ For example, enter `version-0.16.0`. The versions are listed here in [Hummingbot Tags](https://hub.docker.com/r/coinalpha/hummingbot/tags).

--- a/documentation/docs/installation/via-docker/macOS.md
+++ b/documentation/docs/installation/via-docker/macOS.md
@@ -26,13 +26,16 @@ chmod a+x create.sh
 # 1) Create folder for your new instance
 mkdir hummingbot_files
 
-# 2) Create folders for log and config files
-mkdir hummingbot_files/hummingbot_conf && mkdir hummingbot_files/hummingbot_logs
+# 2) Create folders for logs, config files and database file
+mkdir hummingbot_files/hummingbot_conf
+mkdir hummingbot_files/hummingbot_logs
+mkdir hummingbot_files/hummingbot_data
 
 # 3) Launch a new instance of hummingbot
 docker run -it \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```

--- a/documentation/docs/installation/via-docker/windows.md
+++ b/documentation/docs/installation/via-docker/windows.md
@@ -70,3 +70,23 @@ docker run -it \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```
+
+## Install a previous Hummingbot version
+
+A previous version can be installed when creating a Hummingbot instance.
+
+```bash
+# 1) Run the script to create a hummingbot instance
+./create.sh 
+
+# 2) Specify the version to be installed when prompted
+
+** ✏️  Creating a new Hummingbot instance **
+
+ℹ️  Press [enter] for default values.
+
+➡️  Enter Hummingbot version: [latest|development] (default = "latest")
+
+```
+
+ For example, enter `version-0.16.0`. The versions are listed here in [Hummingbot Tags](https://hub.docker.com/r/coinalpha/hummingbot/tags).

--- a/documentation/docs/installation/via-docker/windows.md
+++ b/documentation/docs/installation/via-docker/windows.md
@@ -57,13 +57,16 @@ cd ~
 # 2) Create folder for your new instance
 mkdir hummingbot_files
 
-# 3) Create folders for log and config files
-mkdir hummingbot_files/hummingbot_conf && mkdir hummingbot_files/hummingbot_logs
+# 2) Create folders for logs, config files and database file
+mkdir hummingbot_files/hummingbot_conf
+mkdir hummingbot_files/hummingbot_logs
+mkdir hummingbot_files/hummingbot_data
 
-# 4) Launch a new instance of hummingbot
+# 3) Launch a new instance of hummingbot
 docker run -it \
 --name hummingbot-instance \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:latest
 ```

--- a/documentation/docs/quickstart/2-install.md
+++ b/documentation/docs/quickstart/2-install.md
@@ -38,14 +38,15 @@ We also have instructions for installing Docker on [Debian](/installation/via-do
 We have created automated docker scripts that simplify the process of installing and running Hummingbot with Docker:
 
 * `create.sh`: Creates a new instance of Hummingbot
-* `start.sh`: Starts Hummingbot
+* `start.sh`: Starts a stopped Hummingbot instance
 * `update.sh`: Updates Hummingbot
 
-The scripts help you install an instance of Hummingbot and set up folders to house your logs and configuration files:
+The scripts help you install an instance of Hummingbot and set up folders to house your logs, configuration files and trades/orders database file:
 ```
-hummingbot_files       # Top level folder for hummingbot-related files
+hummingbot_files       # Default name of top level folder for hummingbot-related files
 ├── hummingbot_conf    # Maps to hummingbot's conf/ folder, which stores configuration files
-└── hummingbot_logs    # Maps to hummingbot's logs/ folder, which stores log files
+├── hummingbot_logs    # Maps to hummingbot's logs/ folder, which stores log files
+└── hummingbot_data    # Maps to hummingbot's data/ folder, which stores the SQLite database file
 ```
 
 To download the scripts and create a Hummingbot instance, run the following commands:

--- a/installation/docker-commands/create-web3.sh
+++ b/installation/docker-commands/create-web3.sh
@@ -45,6 +45,7 @@ echo "Your files will be saved to:"
 echo "=> instance folder:    $PWD/$FOLDER"
 echo "=> config files:       ├── $PWD/$FOLDER/hummingbot_conf"
 echo "=> log files:          └── $PWD/$FOLDER/hummingbot_logs"
+echo "=> data file:          └── $PWD/$FOLDER/hummingbot_data"
 echo
 pause Press [Enter] to continue
 #
@@ -62,4 +63,5 @@ docker run -it \
 --name $INSTANCE_NAME \
 --mount "type=bind,source=$(pwd)/$FOLDER/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/$FOLDER/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/$FOLDER/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:$TAG

--- a/installation/docker-commands/create.sh
+++ b/installation/docker-commands/create.sh
@@ -44,7 +44,8 @@ echo
 echo "Your files will be saved to:"
 echo "=> instance folder:    $PWD/$FOLDER"
 echo "=> config files:       ├── $PWD/$FOLDER/hummingbot_conf"
-echo "=> log files:          └── $PWD/$FOLDER/hummingbot_logs"
+echo "=> log files:          ├── $PWD/$FOLDER/hummingbot_logs"
+echo "=> data file:          └── $PWD/$FOLDER/hummingbot_data"
 echo
 pause Press [Enter] to continue
 #
@@ -55,10 +56,13 @@ pause Press [Enter] to continue
 # 1) Create folder for your new instance
 mkdir $FOLDER
 # 2) Create folders for log and config files
-mkdir $FOLDER/hummingbot_conf && mkdir $FOLDER/hummingbot_logs
+mkdir $FOLDER/hummingbot_conf
+mkdir $FOLDER/hummingbot_logs
+mkdir $FOLDER/hummingbot_data
 # 3) Launch a new instance of hummingbot
 docker run -it \
 --name $INSTANCE_NAME \
 --mount "type=bind,source=$(pwd)/$FOLDER/hummingbot_conf,destination=/conf/" \
 --mount "type=bind,source=$(pwd)/$FOLDER/hummingbot_logs,destination=/logs/" \
+--mount "type=bind,source=$(pwd)/$FOLDER/hummingbot_data,destination=/data/" \
 coinalpha/hummingbot:$TAG

--- a/installation/docker-commands/update-web3.sh
+++ b/installation/docker-commands/update-web3.sh
@@ -105,6 +105,7 @@ then
     --name ${INSTANCES[$j]} \
     --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_conf,destination=/conf/" \
     --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_logs,destination=/logs/" \
+    --mount "type=bind,source=$(pwd)/${FOLDERs[$j]}/hummingbot_data,destination=/data/" \
     coinalpha/hummingbot:$TAG
     j=$[$j+1]
   done

--- a/installation/docker-commands/update.sh
+++ b/installation/docker-commands/update.sh
@@ -104,6 +104,7 @@ then
     --name ${INSTANCES[$j]} \
     --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_conf,destination=/conf/" \
     --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_logs,destination=/logs/" \
+    --mount "type=bind,source=$(pwd)/${FOLDERs[$j]}/hummingbot_data,destination=/data/" \
     coinalpha/hummingbot:$TAG
     j=$[$j+1]
   done


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

- Added command in `create.sh` script to create directory `hummingbot_data`
- Added command in `create.sh` and `update.sh` script to map `data` to that directory
- Did the same for creating and updating scripts with web3
- Updated documentation (quickstart and user manual) in line with these changes
- Minor update to installing a previous version of Hummingbot