### PR TITLE
fix / remove radar tests

### DIFF
--- a/test/test_discovery_strategy.py
+++ b/test/test_discovery_strategy.py
@@ -10,7 +10,6 @@ import pandas as pd
 from typing import List
 import unittest
 from hummingsim.backtest.backtest_market import BacktestMarket
-from hummingbot.market.radar_relay.radar_relay_api_order_book_data_source import RadarRelayAPIOrderBookDataSource
 from hummingbot.market.bamboo_relay.bamboo_relay_api_order_book_data_source import BambooRelayAPIOrderBookDataSource
 from hummingbot.market.binance.binance_api_order_book_data_source import BinanceAPIOrderBookDataSource
 from hummingbot.market.ddex.ddex_api_order_book_data_source import DDEXAPIOrderBookDataSource
@@ -74,7 +73,6 @@ class DiscoveryUnitTest(unittest.TestCase):
 
     def test_market_info_spec(self):
         exchange_get_market_func_list = [
-            RadarRelayAPIOrderBookDataSource.get_active_exchange_markets,
             BambooRelayAPIOrderBookDataSource.get_active_exchange_markets,
             BinanceAPIOrderBookDataSource.get_active_exchange_markets,
             DDEXAPIOrderBookDataSource.get_active_exchange_markets


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/6953/skip-radar-tests-in-hummingbot

**A description of the changes proposed in the pull request**:
- This patch removes Radar Relay from being tested in the discovery strategy unit tests - since Radar Relay has moved on to a different API recently.