### PR TITLE
fix `currency` to `base_currency`

### DIFF
--- a/hummingbot/market/liquid/liquid_market.pyx
+++ b/hummingbot/market/liquid/liquid_market.pyx
@@ -521,7 +521,7 @@ cdef class LiquidMarket(MarketBase):
         for product in products:
             try:
                 trading_pair = product.get("trading_pair")
-                currency = product.get("currency")
+                currency = product.get("base_currency")
 
                 # Find the corresponding rule based on currency
                 rule = trading_rules.get(currency)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1331 
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Change `currency` in trading rules parsing to `base_currency`. This fix is now running for BTCIDRT on Liquid Exchange.