### PR TITLE
Fix / fetching nonexisting orders (IDEX)

### DIFF
--- a/hummingbot/market/idex/idex_market.pyx
+++ b/hummingbot/market/idex/idex_market.pyx
@@ -995,7 +995,11 @@ cdef class IDEXMarket(MarketBase):
                 cancellation_results = await safe_gather(*tasks, return_exceptions=True)
                 for cid, cr in zip(client_order_ids, cancellation_results):
                     if isinstance(cr, Exception):
-                        continue
+                        if "order not found" in str(cr).lower():
+                            order_id_set.remove(cid)
+                            successful_cancellations.append(CancellationResult(cid, True))
+                        else:
+                            continue
                     if isinstance(cr, dict) and cr.get("success") == 1:
                         order_id_set.remove(cid)
                         successful_cancellations.append(CancellationResult(cid, True))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: 1281
- Related Clubhouse Story: 6969


**A description of the changes proposed in the pull request**:
Fix the attempted fetching of nonexistent orders on **_IDEX_**.
- if Hummingbot attempts to update status of a tracked nonexisting order, it will now remove it from tracking
- if Hummingbot attempts to delete a nonexisting order, it will now correctly detect that it already does not exist and consider it a successful delete