### PR TITLE
Feat/handle crossed orders on Bamboo Relay

### DIFF
--- a/hummingbot/core/cpp/OrderBookEntry.cpp
+++ b/hummingbot/core/cpp/OrderBookEntry.cpp
@@ -29,7 +29,7 @@ bool operator<(OrderBookEntry const &a, OrderBookEntry const &b) {
     return a.price < b.price;
 }
 
-void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook, int dex) {
+void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook, const int &dex) {
     if (dex != 0) {
         truncateOverlapEntriesDex(bidBook, askBook);
     } else {

--- a/hummingbot/core/cpp/OrderBookEntry.cpp
+++ b/hummingbot/core/cpp/OrderBookEntry.cpp
@@ -29,7 +29,35 @@ bool operator<(OrderBookEntry const &a, OrderBookEntry const &b) {
     return a.price < b.price;
 }
 
-void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook) {
+void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook, int dex) {
+    if (dex != 0) {
+        truncateOverlapEntriesDex(bidBook, askBook);
+    } else {
+        truncateOverlapEntriesCentralised(bidBook, askBook);
+    }
+}
+
+void truncateOverlapEntriesDex(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook) {
+    std::set<OrderBookEntry>::reverse_iterator bidIterator = bidBook.rbegin();
+    std::set<OrderBookEntry>::iterator askIterator = askBook.begin();
+    while (bidIterator != bidBook.rend() && askIterator != askBook.end()) {
+        const OrderBookEntry& topBid = *bidIterator;
+        const OrderBookEntry& topAsk = *askIterator;
+        if (topBid.price >= topAsk.price) {
+            if (topBid.amount*topBid.price > topAsk.amount*topAsk.price) {
+                askBook.erase(askIterator++);
+            } else {
+                std::set<OrderBookEntry>::iterator eraseIterator = (std::next(bidIterator)).base();
+                bidIterator++;
+                bidBook.erase(eraseIterator);
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook) {
     std::set<OrderBookEntry>::reverse_iterator bidIterator = bidBook.rbegin();
     std::set<OrderBookEntry>::iterator askIterator = askBook.begin();
     while (bidIterator != bidBook.rend() && askIterator != askBook.end()) {

--- a/hummingbot/core/cpp/OrderBookEntry.h
+++ b/hummingbot/core/cpp/OrderBookEntry.h
@@ -16,7 +16,9 @@ class OrderBookEntry {
         OrderBookEntry(const OrderBookEntry &other);
         OrderBookEntry &operator=(const OrderBookEntry &other);
         friend bool operator<(OrderBookEntry const &a, OrderBookEntry const &b);
-        friend void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
+        friend void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook, int dex);
+        friend void truncateOverlapEntriesDex(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
+        friend void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
 
         double getPrice();
         double getAmount();

--- a/hummingbot/core/cpp/OrderBookEntry.h
+++ b/hummingbot/core/cpp/OrderBookEntry.h
@@ -16,7 +16,7 @@ class OrderBookEntry {
         OrderBookEntry(const OrderBookEntry &other);
         OrderBookEntry &operator=(const OrderBookEntry &other);
         friend bool operator<(OrderBookEntry const &a, OrderBookEntry const &b);
-        friend void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook, int dex);
+        friend void truncateOverlapEntries(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook, const int &dex);
         friend void truncateOverlapEntriesDex(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
         friend void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
 

--- a/hummingbot/core/data_type/OrderBookEntry.pxd
+++ b/hummingbot/core/data_type/OrderBookEntry.pxd
@@ -13,4 +13,4 @@ cdef extern from "../cpp/OrderBookEntry.h":
         double getAmount()
         int64_t getUpdateId()
 
-    void truncateOverlapEntries(set[OrderBookEntry] &bid_book, set[OrderBookEntry] &ask_book, bint dex)
+    void truncateOverlapEntries(set[OrderBookEntry] &bid_book, set[OrderBookEntry] &ask_book, const bint &dex)

--- a/hummingbot/core/data_type/OrderBookEntry.pxd
+++ b/hummingbot/core/data_type/OrderBookEntry.pxd
@@ -13,4 +13,4 @@ cdef extern from "../cpp/OrderBookEntry.h":
         double getAmount()
         int64_t getUpdateId()
 
-    void truncateOverlapEntries(set[OrderBookEntry] &bid_book, set[OrderBookEntry] &ask_book)
+    void truncateOverlapEntries(set[OrderBookEntry] &bid_book, set[OrderBookEntry] &ask_book, bint dex)

--- a/hummingbot/core/data_type/order_book.pxd
+++ b/hummingbot/core/data_type/order_book.pxd
@@ -16,6 +16,7 @@ cdef class OrderBook(PubSub):
     cdef int64_t _last_diff_uid
     cdef double _best_bid
     cdef double _best_ask
+    cdef bint _dex
 
     cdef c_apply_diffs(self, vector[OrderBookEntry] bids, vector[OrderBookEntry] asks, int64_t update_id)
     cdef c_apply_snapshot(self, vector[OrderBookEntry] bids, vector[OrderBookEntry] asks, int64_t update_id)

--- a/hummingbot/core/data_type/order_book.pyx
+++ b/hummingbot/core/data_type/order_book.pyx
@@ -105,6 +105,9 @@ cdef class OrderBook(PubSub):
             self._ask_book.insert(ask)
             if not (ask.getPrice() >= best_ask_price):
                 best_ask_price = ask.getPrice()
+        
+        if self._dex:
+            truncateOverlapEntries(self._bid_book, self._ask_book, self._dex)
 
         # Record the current best prices, for faster c_get_price() calls.
         self._best_bid = best_bid_price

--- a/hummingbot/market/bamboo_relay/bamboo_relay_market.pyx
+++ b/hummingbot/market/bamboo_relay/bamboo_relay_market.pyx
@@ -845,6 +845,8 @@ cdef class BambooRelayMarket(MarketBase):
                     # Market orders don't care about price
                     if not price.is_nan() and current_price > price:
                         raise StopIteration
+                    if current_price not in active_asks:
+                        continue
                     for order_hash in active_asks[current_price]:
                         if order_hash in self._filled_order_hashes:
                             continue
@@ -861,6 +863,8 @@ cdef class BambooRelayMarket(MarketBase):
                     # Market orders don't care about price
                     if not price.is_nan() and current_price < price:
                         raise StopIteration
+                    if current_price not in active_asks:
+                        continue
                     for order_hash in active_bids[current_price]:
                         if order_hash in self._filled_order_hashes:
                             continue

--- a/hummingbot/market/bamboo_relay/bamboo_relay_order_book.pyx
+++ b/hummingbot/market/bamboo_relay/bamboo_relay_order_book.pyx
@@ -28,6 +28,9 @@ cdef class BambooRelayOrderBook(OrderBook):
         if _rrob_logger is None:
             _rrob_logger = logging.getLogger(__name__)
         return _rrob_logger
+    
+    def __init__(self):
+        super().__init__(dex=True)
 
     @classmethod
     def snapshot_message_from_exchange(cls,

--- a/test/integration/test_order_book.py
+++ b/test/integration/test_order_book.py
@@ -24,6 +24,15 @@ class OrderBookUnitTest(unittest.TestCase):
         self.assertEqual(best_bid,[3.,1.,3.])
         self.assertEqual(best_ask,[4.,1.,1.])
 
+        new_ask = np.array([[2,0.1,5]])
+        new_bid = np.array([[3.5,1,5]])
+        self.order_book_dex.apply_numpy_diffs(new_bid,new_ask)
+        bids,asks = self.order_book_dex.snapshot
+        best_bid = bids.iloc[0].tolist()
+        best_ask = asks.iloc[0].tolist()
+        self.assertEqual(best_bid,[3.5,1.,5.])
+        self.assertEqual(best_ask,[4.,1.,1.])
+
 
 def main():
     logging.basicConfig(level=logging.INFO)

--- a/test/integration/test_order_book.py
+++ b/test/integration/test_order_book.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+import logging
+import unittest
+from hummingbot.core.data_type.order_book import OrderBook
+import numpy as np
+
+
+class OrderBookUnitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.order_book_dex = OrderBook(dex=True)
+    
+    def test_truncate_overlap_entries_dex(self):
+        bids_array = np.array([[1,1,1],[2,1,2],[3,1,3],[50,0.01,4]],dtype=np.float64)
+        asks_array = np.array([[4,1,1],[5,1,2],[6,1,3],[7,1,4]],dtype=np.float64)
+        self.order_book_dex.apply_numpy_snapshot(bids_array, asks_array)
+        bids,asks = self.order_book_dex.snapshot
+        best_bid = bids.iloc[0].tolist()
+        best_ask = asks.iloc[0].tolist()
+        self.assertEqual(best_bid,[3.,1.,3.])
+        self.assertEqual(best_ask,[4.,1.,1.])
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story: 7060


**A description of the changes proposed in the pull request**:
- Change the way OrderBook deals with crossed orders if dex flag is True.
- Set BambooRelayOrderBook to have dex=True.
- Add unit test for this feature

When the order book is crossed over, e.g. best bid > best ask, compare the values (amount * price) of the top orders on both sides of the order book. Erase the order that is smaller in value, and continue comparing and erasing until the two sides no longer cross.