### PR TITLE
fix / add keybindings to help with windows scrolling issue

### DIFF
--- a/hummingbot/client/ui/keybindings.py
+++ b/hummingbot/client/ui/keybindings.py
@@ -13,6 +13,10 @@ from prompt_toolkit.search import (
     SearchDirection,
 )
 
+from hummingbot.client.ui.scroll_handlers import (
+    scroll_down,
+    scroll_up,
+)
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
 
@@ -62,5 +66,21 @@ def load_key_bindings(hb) -> KeyBindings:
         current_buffer.cursor_position = 0
         current_buffer.start_selection()
         current_buffer.cursor_position = len(current_buffer.text)
+
+    @bindings.add("c-d")
+    def scroll_down_output(event):
+        event.app.layout.current_window = hb.app.output_field.window
+        event.app.layout.focus = hb.app.output_field.buffer
+        scroll_down(event, hb.app.output_field.window, hb.app.output_field.buffer)
+        event.app.layout.current_window = hb.app.input_field.window
+        event.app.layout.focus = hb.app.input_field.buffer
+
+    @bindings.add("c-e")
+    def scroll_up_output(event):
+        event.app.layout.current_window = hb.app.output_field.window
+        event.app.layout.focus = hb.app.output_field.buffer
+        scroll_up(event, hb.app.output_field.window, hb.app.output_field.buffer)
+        event.app.layout.current_window = hb.app.input_field.window
+        event.app.layout.focus = hb.app.input_field.buffer
 
     return bindings

--- a/hummingbot/client/ui/scroll_handlers.py
+++ b/hummingbot/client/ui/scroll_handlers.py
@@ -1,0 +1,54 @@
+from prompt_toolkit.layout.containers import Window
+from prompt_toolkit.buffer import Buffer
+from typing import Optional
+
+
+def scroll_down(event, window: Optional[Window] = None, buffer: Optional[Buffer] = None):
+    w = window or event.app.layout.current_window
+    b = buffer or event.app.current_buffer
+
+    if w and w.render_info:
+        info = w.render_info
+        ui_content = info.ui_content
+
+        # Height to scroll.
+        scroll_height = info.window_height // 2
+
+        # Calculate how many lines is equivalent to that vertical space.
+        y = b.document.cursor_position_row + 1
+        height = 0
+        while y < ui_content.line_count:
+            line_height = info.get_height_for_line(y)
+
+            if height + line_height < scroll_height:
+                height += line_height
+                y += 1
+            else:
+                break
+
+        b.cursor_position = b.document.translate_row_col_to_index(y, 0)
+
+
+def scroll_up(event, window: Optional[Window] = None, buffer: Optional[Buffer] = None):
+    w = window or event.app.layout.current_window
+    b = buffer or event.app.current_buffer
+
+    if w and w.render_info:
+        info = w.render_info
+
+        # Height to scroll.
+        scroll_height = info.window_height // 2
+
+        # Calculate how many lines is equivalent to that vertical space.
+        y = max(0, b.document.cursor_position_row - 1)
+        height = 0
+        while y > 0:
+            line_height = info.get_height_for_line(y)
+
+            if height + line_height < scroll_height:
+                height += line_height
+                y -= 1
+            else:
+                break
+
+        b.cursor_position = b.document.translate_row_col_to_index(y, 0)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**Optional**:
- Related Github issue: https://github.com/CoinAlpha/hummingbot/issues/1259
- Related Clubhouse Story:

**A description of the changes proposed in the pull request**:
- While we are waiting for a fix from `prompt-toolkit` for the scrolling bug, I added two keys:
 [CTRL + E] for scrolling up output pane and [CTRL + D] for scrolling down the output pane. Users can check their log files for log pane info.