### PR TITLE
fix / docs build: revert dependencies versions

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=1.0
-mkdocs-material
-pymdown-extensions>=6.3
-markdown>=3.2
+mkdocs=1.0.4
+mkdocs-material=4.6.0
+pymdown-extensions=6.2.1
+markdown=3.1.1


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:

- Over the weekend, there was an update to Material for MkDocs that requires markdown 3.2
- However, markdown 3.2 is currently not available on netlify, resulting in build errors.
- reverting to last working versions, until netlify supports MD 3.2