### PR TITLE
fix / order book segfault

### DIFF
--- a/hummingbot/core/cpp/.gitignore
+++ b/hummingbot/core/cpp/.gitignore
@@ -1,0 +1,2 @@
+/*.o
+/TestOrderBookEntry

--- a/hummingbot/core/cpp/OrderBookEntry.cpp
+++ b/hummingbot/core/cpp/OrderBookEntry.cpp
@@ -48,8 +48,8 @@ void truncateOverlapEntriesDex(std::set<OrderBookEntry> &bidBook, std::set<Order
                 askBook.erase(askIterator++);
             } else {
                 std::set<OrderBookEntry>::iterator eraseIterator = (std::next(bidIterator)).base();
-                bidIterator++;
                 bidBook.erase(eraseIterator);
+                bidIterator++;
             }
         } else {
             break;
@@ -63,13 +63,14 @@ void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::s
     while (bidIterator != bidBook.rend() && askIterator != askBook.end()) {
         const OrderBookEntry& topBid = *bidIterator;
         const OrderBookEntry& topAsk = *askIterator;
+        printf("Comparing top bid %.2f to top ask %.2f\n", topBid.getPrice(), topAsk.getPrice());
         if (topBid.price >= topAsk.price) {
             if (topBid.updateId > topAsk.updateId) {
                 askBook.erase(askIterator++);
             } else {
                 std::set<OrderBookEntry>::iterator eraseIterator = (std::next(bidIterator)).base();
-                bidIterator++;
                 bidBook.erase(eraseIterator);
+                bidIterator++;
             }
         } else {
             break;
@@ -77,11 +78,11 @@ void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::s
     }
 }
 
-double OrderBookEntry::getPrice() {
+double OrderBookEntry::getPrice() const {
     return this->price;
 }
 
-double OrderBookEntry::getAmount() {
+double OrderBookEntry::getAmount() const {
     return this->amount;
 }
 

--- a/hummingbot/core/cpp/OrderBookEntry.cpp
+++ b/hummingbot/core/cpp/OrderBookEntry.cpp
@@ -87,6 +87,6 @@ double OrderBookEntry::getAmount() const {
     return this->amount;
 }
 
-int64_t OrderBookEntry::getUpdateId() {
+int64_t OrderBookEntry::getUpdateId() const {
     return this->updateId;
 }

--- a/hummingbot/core/cpp/OrderBookEntry.cpp
+++ b/hummingbot/core/cpp/OrderBookEntry.cpp
@@ -47,9 +47,10 @@ void truncateOverlapEntriesDex(std::set<OrderBookEntry> &bidBook, std::set<Order
             if (topBid.amount*topBid.price > topAsk.amount*topAsk.price) {
                 askBook.erase(askIterator++);
             } else {
+                // There is no need to move the bid iterator, since its base
+                // always points to the end() iterator.
                 std::set<OrderBookEntry>::iterator eraseIterator = (std::next(bidIterator)).base();
                 bidBook.erase(eraseIterator);
-                bidIterator++;
             }
         } else {
             break;
@@ -63,14 +64,14 @@ void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::s
     while (bidIterator != bidBook.rend() && askIterator != askBook.end()) {
         const OrderBookEntry& topBid = *bidIterator;
         const OrderBookEntry& topAsk = *askIterator;
-        printf("Comparing top bid %.2f to top ask %.2f\n", topBid.getPrice(), topAsk.getPrice());
         if (topBid.price >= topAsk.price) {
             if (topBid.updateId > topAsk.updateId) {
                 askBook.erase(askIterator++);
             } else {
+                // There is no need to move the bid iterator, since its base
+                // always points to the end() iterator.
                 std::set<OrderBookEntry>::iterator eraseIterator = (std::next(bidIterator)).base();
                 bidBook.erase(eraseIterator);
-                bidIterator++;
             }
         } else {
             break;

--- a/hummingbot/core/cpp/OrderBookEntry.h
+++ b/hummingbot/core/cpp/OrderBookEntry.h
@@ -22,7 +22,7 @@ class OrderBookEntry {
 
         double getPrice() const;
         double getAmount() const;
-        int64_t getUpdateId();
+        int64_t getUpdateId() const;
 };
 
 #endif

--- a/hummingbot/core/cpp/OrderBookEntry.h
+++ b/hummingbot/core/cpp/OrderBookEntry.h
@@ -20,8 +20,8 @@ class OrderBookEntry {
         friend void truncateOverlapEntriesDex(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
         friend void truncateOverlapEntriesCentralised(std::set<OrderBookEntry> &bidBook, std::set<OrderBookEntry> &askBook);
 
-        double getPrice();
-        double getAmount();
+        double getPrice() const;
+        double getAmount() const;
         int64_t getUpdateId();
 };
 

--- a/hummingbot/core/cpp/TestOrderBookEntry.cpp
+++ b/hummingbot/core/cpp/TestOrderBookEntry.cpp
@@ -1,0 +1,34 @@
+//
+// Created by Martin Kou on 2/14/20.
+//
+
+#include <cstdio>
+#include <set>
+#include "OrderBookEntry.h"
+
+typedef std::set<OrderBookEntry> OrderBookSide;
+
+void testEmptyOrderBooks();
+
+int main(const int argc, const char **argv) {
+    testEmptyOrderBooks();
+    return 0;
+}
+
+void testEmptyOrderBooks() {
+    OrderBookSide bidsBook;
+    OrderBookSide asksBook;
+    OrderBookSide::iterator asksIterator = asksBook.begin();
+    OrderBookSide::reverse_iterator bidsIterator = bidsBook.rbegin();
+
+    printf("*** testEmptyOrderBooks(): Stage 1 ***\n");
+    printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
+    printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+
+    printf("\n*** testEmptyOrderBooks(): Stage 2 ***\n");
+    bidsBook.insert(OrderBookEntry(100.0, 1.0, 1));
+    bidsBook.insert(OrderBookEntry(99.9, 2.0, 1));
+    bidsBook.insert(OrderBookEntry(99.8, 4.0, 1));
+    printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
+    printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+}

--- a/hummingbot/core/cpp/TestOrderBookEntry.cpp
+++ b/hummingbot/core/cpp/TestOrderBookEntry.cpp
@@ -9,10 +9,10 @@
 
 typedef std::set<OrderBookEntry> OrderBookSide;
 
-void testEmptyOrderBooks();
+void testOverlappingOrderBooks();
 
 int main(const int argc, const char **argv) {
-    testEmptyOrderBooks();
+    testOverlappingOrderBooks();
     return 0;
 }
 
@@ -32,18 +32,18 @@ void printTopPrices(const OrderBookSide &bidsBook, const OrderBookSide &asksBook
     printf("current top bid: %.2f, top ask: %.2f\n", topBid, topAsk);
 }
 
-void testEmptyOrderBooks() {
+void testOverlappingOrderBooks() {
     OrderBookSide bidsBook;
     OrderBookSide asksBook;
     OrderBookSide::iterator asksIterator = asksBook.begin();
     OrderBookSide::reverse_iterator bidsIterator = bidsBook.rbegin();
 
-    printf("*** testEmptyOrderBooks(): Stage 1 ***\n");
+    printf("*** testOverlappingOrderBooks(): Stage 1 ***\n");
     printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
     printTopPrices(bidsBook, asksBook);
 
-    printf("\n*** testEmptyOrderBooks(): Stage 2 ***\n");
+    printf("\n*** testOverlappingOrderBooks(): Stage 2 ***\n");
     bidsBook.insert(OrderBookEntry(100.0, 1.0, 1));
     bidsBook.insert(OrderBookEntry(99.9, 2.0, 1));
     bidsBook.insert(OrderBookEntry(99.8, 4.0, 1));
@@ -52,7 +52,7 @@ void testEmptyOrderBooks() {
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
     printTopPrices(bidsBook, asksBook);
 
-    printf("\n*** testEmptyOrderBooks(): Stage 3 ***\n");
+    printf("\n*** testOverlappingOrderBooks(): Stage 3 ***\n");
     bidsBook.insert(OrderBookEntry(100.0, 4.0, 2));
     bidsBook.insert(OrderBookEntry(100.1, 2.0, 2));
     bidsBook.insert(OrderBookEntry(100.9, 1.5, 2));
@@ -69,7 +69,7 @@ void testEmptyOrderBooks() {
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
     printTopPrices(bidsBook, asksBook);
 
-    printf("\n*** testEmptyOrderBooks(): Stage 4 ***\n");
+    printf("\n*** testOverlappingOrderBooks(): Stage 4 ***\n");
     bidsBook.insert(OrderBookEntry(100.91, 3.0, 3));
     asksBook.insert(OrderBookEntry(100.89, 1.0, 4));
     asksBook.insert(OrderBookEntry(100.88, 0.8, 4));

--- a/hummingbot/core/cpp/TestOrderBookEntry.cpp
+++ b/hummingbot/core/cpp/TestOrderBookEntry.cpp
@@ -29,6 +29,28 @@ void testEmptyOrderBooks() {
     bidsBook.insert(OrderBookEntry(100.0, 1.0, 1));
     bidsBook.insert(OrderBookEntry(99.9, 2.0, 1));
     bidsBook.insert(OrderBookEntry(99.8, 4.0, 1));
+    truncateOverlapEntriesCentralised(bidsBook, asksBook);
     printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+
+    printf("\n*** testEmptyOrderBooks(): Stage 3 ***\n");
+    bidsBook.insert(OrderBookEntry(100.0, 4.0, 2));
+    bidsBook.insert(OrderBookEntry(100.1, 2.0, 2));
+    bidsBook.insert(OrderBookEntry(100.9, 1.5, 2));
+    bidsBook.insert(OrderBookEntry(101.0, 0.1, 2));
+    asksBook.insert(OrderBookEntry(105.0, 100, 2));
+    asksBook.insert(OrderBookEntry(104.0, 50, 2));
+    asksBook.insert(OrderBookEntry(103.0, 20, 3));
+    asksBook.insert(OrderBookEntry(102.0, 10, 3));
+    asksBook.insert(OrderBookEntry(100.91, 1, 3));
+    truncateOverlapEntriesCentralised(bidsBook, asksBook);
+    asksIterator = asksBook.begin();
+    bidsIterator = bidsBook.rbegin();
+    printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
+    printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+
+    printf("\n*** testEmptyOrderBooks(): Stage 4 ***\n");
+    asksBook.insert(OrderBookEntry(100.89, 1.0, 4));
+    asksBook.insert(OrderBookEntry(100.88, 0.8, 4));
+    asksBook.insert(OrderBookEntry(100.86, 0.7, 4));
 }

--- a/hummingbot/core/cpp/TestOrderBookEntry.cpp
+++ b/hummingbot/core/cpp/TestOrderBookEntry.cpp
@@ -2,6 +2,7 @@
 // Created by Martin Kou on 2/14/20.
 //
 
+#include <cmath>
 #include <cstdio>
 #include <set>
 #include "OrderBookEntry.h"
@@ -15,6 +16,22 @@ int main(const int argc, const char **argv) {
     return 0;
 }
 
+void printTopPrices(const OrderBookSide &bidsBook, const OrderBookSide &asksBook) {
+    double topBid = nan("");
+    double topAsk = nan("");
+    OrderBookSide::iterator asksIterator = asksBook.begin();
+    OrderBookSide::reverse_iterator bidsIterator = bidsBook.rbegin();
+
+    if (asksIterator != asksBook.end()) {
+        topAsk = (*asksIterator).getPrice();
+    }
+    if (bidsIterator != bidsBook.rend()) {
+        topBid = (*bidsIterator).getPrice();
+    }
+
+    printf("current top bid: %.2f, top ask: %.2f\n", topBid, topAsk);
+}
+
 void testEmptyOrderBooks() {
     OrderBookSide bidsBook;
     OrderBookSide asksBook;
@@ -24,6 +41,7 @@ void testEmptyOrderBooks() {
     printf("*** testEmptyOrderBooks(): Stage 1 ***\n");
     printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+    printTopPrices(bidsBook, asksBook);
 
     printf("\n*** testEmptyOrderBooks(): Stage 2 ***\n");
     bidsBook.insert(OrderBookEntry(100.0, 1.0, 1));
@@ -32,6 +50,7 @@ void testEmptyOrderBooks() {
     truncateOverlapEntriesCentralised(bidsBook, asksBook);
     printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+    printTopPrices(bidsBook, asksBook);
 
     printf("\n*** testEmptyOrderBooks(): Stage 3 ***\n");
     bidsBook.insert(OrderBookEntry(100.0, 4.0, 2));
@@ -48,9 +67,14 @@ void testEmptyOrderBooks() {
     bidsIterator = bidsBook.rbegin();
     printf("Asks side iterator empty? %d\n", asksIterator == asksBook.end());
     printf("Bids side iterator empty? %d\n", bidsIterator == bidsBook.rend());
+    printTopPrices(bidsBook, asksBook);
 
     printf("\n*** testEmptyOrderBooks(): Stage 4 ***\n");
+    bidsBook.insert(OrderBookEntry(100.91, 3.0, 3));
     asksBook.insert(OrderBookEntry(100.89, 1.0, 4));
     asksBook.insert(OrderBookEntry(100.88, 0.8, 4));
     asksBook.insert(OrderBookEntry(100.86, 0.7, 4));
+    bidsBook.insert(OrderBookEntry(100.87, 1.1, 5));
+    truncateOverlapEntriesCentralised(bidsBook, asksBook);
+    printTopPrices(bidsBook, asksBook);
 }

--- a/hummingbot/core/cpp/compile.sh
+++ b/hummingbot/core/cpp/compile.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+g++ -c TestOrderBookEntry.cpp
+g++ -c OrderBookEntry.cpp
+g++ TestOrderBookEntry.o OrderBookEntry.o -o test

--- a/hummingbot/core/cpp/compile.sh
+++ b/hummingbot/core/cpp/compile.sh
@@ -2,4 +2,4 @@
 
 g++ -c -g TestOrderBookEntry.cpp
 g++ -c -g OrderBookEntry.cpp
-g++ TestOrderBookEntry.o OrderBookEntry.o -o test
+g++ TestOrderBookEntry.o OrderBookEntry.o -o TestOrderBookEntry

--- a/hummingbot/core/cpp/compile.sh
+++ b/hummingbot/core/cpp/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-g++ -c TestOrderBookEntry.cpp
-g++ -c OrderBookEntry.cpp
+g++ -c -g TestOrderBookEntry.cpp
+g++ -c -g OrderBookEntry.cpp
 g++ TestOrderBookEntry.o OrderBookEntry.o -o test

--- a/hummingbot/core/data_type/OrderBookEntry.pxd
+++ b/hummingbot/core/data_type/OrderBookEntry.pxd
@@ -11,6 +11,6 @@ cdef extern from "../cpp/OrderBookEntry.h":
         OrderBookEntry &operator=(const OrderBookEntry &other)
         double getPrice() const
         double getAmount() const
-        int64_t getUpdateId()
+        int64_t getUpdateId() const
 
     void truncateOverlapEntries(set[OrderBookEntry] &bid_book, set[OrderBookEntry] &ask_book, const bint &dex)

--- a/hummingbot/core/data_type/OrderBookEntry.pxd
+++ b/hummingbot/core/data_type/OrderBookEntry.pxd
@@ -9,8 +9,8 @@ cdef extern from "../cpp/OrderBookEntry.h":
         OrderBookEntry(double price, double amount, int64_t updateId)
         OrderBookEntry(const OrderBookEntry &other)
         OrderBookEntry &operator=(const OrderBookEntry &other)
-        double getPrice()
-        double getAmount()
+        double getPrice() const
+        double getAmount() const
         int64_t getUpdateId()
 
     void truncateOverlapEntries(set[OrderBookEntry] &bid_book, set[OrderBookEntry] &ask_book, const bint &dex)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
* This fixes an out-of-bound memory access in the `truncateOverlapEntriesDex()` and `truncateOverlapEntriesCentralised()` functions, due to previously incorrect understanding of how reverse iterators work in C++.
* Also, includes a C++ test case for the `OrderBookEntry` class - which can be compiled and tested under `valgrind` to verify that it's both functionally correct and doesn't do any out-of-bounds memory access.