### PR TITLE
fix / binance timestamp 2

### DIFF
--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -301,7 +301,7 @@ cdef class BinanceMarket(MarketBase):
                                           "Going to force update Binance server time offset...")
                     binance_time = BinanceTime.get_instance()
                     binance_time.clear_time_offset_ms_samples()
-                    await binance_time.update_server_time_offset()
+                    await binance_time.schedule_update_server_time_offset()
                 raise ex
 
     async def query_url(self, url, request_weight: int = 1) -> any:

--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -296,7 +296,7 @@ cdef class BinanceMarket(MarketBase):
                                                               timeout_seconds=self.API_CALL_TIMEOUT,
                                                               app_warning_msg=app_warning_msg)
             except Exception as ex:
-                if "Timestamp for this request was 1000ms ahead of the server" in str(ex):
+                if "Timestamp for this request" in str(ex):
                     self.logger().warning("Got Binance timestamp error. "
                                           "Going to force update Binance server time offset...")
                     binance_time = BinanceTime.get_instance()

--- a/hummingbot/market/binance/binance_time.py
+++ b/hummingbot/market/binance/binance_time.py
@@ -1,9 +1,11 @@
 import aiohttp
 import asyncio
+from collections import deque
 import logging
 import statistics
 import time
-from collections import deque
+from typing import Dict, Deque
+
 from hummingbot.logger import HummingbotLogger
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
@@ -30,33 +32,36 @@ class BinanceTime:
         return cls._bt_shared_instance
 
     def __init__(self, check_interval: float = 60.0):
-        self._time_offset_ms = deque([])
-        self._set_server_time_offset_task = None
-        self._started = False
-        self.SERVER_TIME_OFFSET_CHECK_INTERVAL = check_interval
-        self.median_window = 100
+        self._time_offset_ms: Deque[float] = deque([])
+        self._set_server_time_offset_task: asyncio.Task = None
+        self._started: bool = False
+        self._server_time_offset_check_interval = check_interval
+        self._median_window = 5
 
     @property
-    def started(self):
+    def started(self) -> bool:
         return self._started
 
     @property
-    def time_offset_ms(self):
+    def time_offset_ms(self) -> float:
         if not self._time_offset_ms:
-            return 0.0
+            return time.time() - time.perf_counter()
         return statistics.median(self._time_offset_ms)
 
-    def set_time_offset_ms(self, offset):
+    def add_time_offset_ms_sample(self, offset: float):
         self._time_offset_ms.append(offset)
-        if len(self._time_offset_ms) > self.median_window :
+        while len(self._time_offset_ms) > self._median_window:
             self._time_offset_ms.popleft()
 
-    def time(self):
-        return time.time() + self.time_offset_ms * 1e-3
+    def clear_time_offset_ms_samples(self):
+        self._time_offset_ms.clear()
+
+    def time(self) -> float:
+        return time.perf_counter() + self.time_offset_ms * 1e-3
 
     def start(self):
         if self._set_server_time_offset_task is None:
-            self._set_server_time_offset_task = safe_ensure_future(self.set_server_time_offset())
+            self._set_server_time_offset_task = safe_ensure_future(self.update_server_time_offset_loop())
             self._started = True
 
     def stop(self):
@@ -66,24 +71,25 @@ class BinanceTime:
             self._time_offset_ms.clear()
             self._started = False
 
-    async def set_server_time_offset(self):
+    async def update_server_time_offset_loop(self):
         while True:
-            try:
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(self.BINANCE_TIME_API) as resp:
-                        time_now_ms = time.time() * 1e3
-                        resp_data = await resp.json()
-                        binance_server_time = resp_data["serverTime"]
-                        time_after_ms = time.time() * 1e3
-                expected_server_time = int((time_after_ms + time_now_ms)//2)
-                time_offset =  binance_server_time - expected_server_time
-                self.set_time_offset_ms(time_offset)
+            await self.update_server_time_offset()
+            await asyncio.sleep(self._server_time_offset_check_interval)
 
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                self.logger().network(f"Error getting Binance server time.", exc_info=True,
-                                      app_warning_msg=f"Could not refresh Binance server time. "
-                                                      f"Check network connection.")
-
-            await asyncio.sleep(self.SERVER_TIME_OFFSET_CHECK_INTERVAL)
+    async def update_server_time_offset(self):
+        try:
+            local_before_ms: float = time.perf_counter() * 1e3
+            async with aiohttp.ClientSession() as session:
+                async with session.get(self.BINANCE_TIME_API) as resp:
+                    resp_data: Dict[str, float] = await resp.json()
+                    binance_server_time_ms: float = float(resp_data["serverTime"])
+                    local_after_ms: float = time.perf_counter() * 1e3
+            local_server_time_pre_image_ms: float = (local_before_ms + local_after_ms) / 2.0
+            time_offset_ms: float = binance_server_time_ms - local_server_time_pre_image_ms
+            self.add_time_offset_ms_sample(time_offset_ms)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().network(f"Error getting Binance server time.", exc_info=True,
+                                  app_warning_msg=f"Could not refresh Binance server time. "
+                                                  f"Check network connection.")

--- a/hummingbot/market/binance/binance_time.py
+++ b/hummingbot/market/binance/binance_time.py
@@ -4,7 +4,7 @@ from collections import deque
 import logging
 import statistics
 import time
-from typing import Dict, Deque
+from typing import Dict, Deque, Optional
 
 from hummingbot.logger import HummingbotLogger
 from hummingbot.core.utils.async_utils import safe_ensure_future
@@ -15,6 +15,7 @@ class BinanceTime:
     Used to monkey patch Binance client's time module to adjust request timestamp when needed
     """
     BINANCE_TIME_API = "https://api.binance.com/api/v1/time"
+    NaN = float("nan")
     _bt_logger = None
     _bt_shared_instance = None
 
@@ -33,10 +34,12 @@ class BinanceTime:
 
     def __init__(self, check_interval: float = 60.0):
         self._time_offset_ms: Deque[float] = deque([])
-        self._set_server_time_offset_task: asyncio.Task = None
+        self._set_server_time_offset_task: Optional[asyncio.Task] = None
         self._started: bool = False
         self._server_time_offset_check_interval = check_interval
         self._median_window = 5
+        self._last_update_local_time: float = self.NaN
+        self._scheduled_update_task: Optional[asyncio.Task] = None
 
     @property
     def started(self) -> bool:
@@ -71,6 +74,24 @@ class BinanceTime:
             self._time_offset_ms.clear()
             self._started = False
 
+    def schedule_update_server_time_offset(self) -> asyncio.Task:
+        # If an update task is already scheduled, don't do anything.
+        if self._scheduled_update_task is not None and not self._scheduled_update_task.done():
+            return self._scheduled_update_task
+
+        current_local_time: float = time.perf_counter()
+        if not (current_local_time - self._last_update_local_time < 5):
+            # If there was no recent update, schedule the server time offset update immediately.
+            self._scheduled_update_task = safe_ensure_future(self.update_server_time_offset())
+        else:
+            # If there was a recent update, schedule the server time offset update after 5 seconds.
+            async def update_later():
+                await asyncio.sleep(5.0)
+                await self.update_server_time_offset()
+            self._scheduled_update_task = safe_ensure_future(update_later())
+
+        return self._scheduled_update_task
+
     async def update_server_time_offset_loop(self):
         while True:
             await self.update_server_time_offset()
@@ -87,6 +108,7 @@ class BinanceTime:
             local_server_time_pre_image_ms: float = (local_before_ms + local_after_ms) / 2.0
             time_offset_ms: float = binance_server_time_ms - local_server_time_pre_image_ms
             self.add_time_offset_ms_sample(time_offset_ms)
+            self._last_update_local_time = time.perf_counter()
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/hummingbot/market/binance/binance_time.py
+++ b/hummingbot/market/binance/binance_time.py
@@ -45,7 +45,7 @@ class BinanceTime:
     @property
     def time_offset_ms(self) -> float:
         if not self._time_offset_ms:
-            return time.time() - time.perf_counter()
+            return (time.time() - time.perf_counter()) * 1e3
         return statistics.median(self._time_offset_ms)
 
     def add_time_offset_ms_sample(self, offset: float):

--- a/test/integration/test_binance_market.py
+++ b/test/integration/test_binance_market.py
@@ -539,15 +539,17 @@ class BinanceMarketUnitTest(unittest.TestCase):
         time_obj.start()
 
         try:
+            local_time_offset = (time.time() - time.perf_counter()) * 1e3
             with patch("hummingbot.market.binance.binance_time.time") as market_time:
                 def delayed_time():
-                    return time.time() - 30.0
-                market_time.time = delayed_time
+                    return time.perf_counter() - 30.0
+                market_time.perf_counter = delayed_time
                 self.run_parallel(asyncio.sleep(3.0))
-                time_offset = BinanceTime.get_instance().time_offset_ms
+                raw_time_offset = BinanceTime.get_instance().time_offset_ms
+                time_offset_diff = raw_time_offset - local_time_offset
                 # check if it is less than 5% off
-                self.assertTrue(time_offset > 10000)
-                self.assertTrue(abs(time_offset - 30.0 * 1e3) < 1.5 * 1e3)
+                self.assertTrue(time_offset_diff > 10000)
+                self.assertTrue(abs(time_offset_diff - 30.0 * 1e3) < 1.5 * 1e3)
         finally:
             time_obj._server_time_offset_check_interval = old_check_interval
             time_obj.stop()

--- a/test/integration/test_binance_market.py
+++ b/test/integration/test_binance_market.py
@@ -533,8 +533,8 @@ class BinanceMarketUnitTest(unittest.TestCase):
 
     def test_server_time_offset(self):
         time_obj: BinanceTime = binance_client_module.time
-        old_check_interval: float = time_obj.SERVER_TIME_OFFSET_CHECK_INTERVAL
-        time_obj.SERVER_TIME_OFFSET_CHECK_INTERVAL = 1.0
+        old_check_interval: float = time_obj._server_time_offset_check_interval
+        time_obj._server_time_offset_check_interval = 1.0
         time_obj.stop()
         time_obj.start()
 
@@ -549,7 +549,7 @@ class BinanceMarketUnitTest(unittest.TestCase):
                 self.assertTrue(time_offset > 10000)
                 self.assertTrue(abs(time_offset - 30.0 * 1e3) < 1.5 * 1e3)
         finally:
-            time_obj.SERVER_TIME_OFFSET_CHECK_INTERVAL = old_check_interval
+            time_obj._server_time_offset_check_interval = old_check_interval
             time_obj.stop()
             time_obj.start()
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1388 
- Related Clubhouse Story: 7455

**A description of the changes proposed in the pull request**:
This is an improved version of the Binance timestamp fix, built upon #1437. It has the following improvements

* Changed the time offset semantics to use `time.perf_counter()` as the local reference, instead of `time.time()` - to avoid problems with changing real-time clocks.
* Improved the exception catching in `binance_market.pyx` - apparently Binance has a few similar error messages for invalid timestamps, not all of which involve "1000ms ahead of the server".
* Fixed a systemic error in how the before-request time reference is recorded in Jack's patch... it must be before `session.get()` because the `get()` call is part of the roundtrip.
* Added more type hints and improved function / variable naming to make things easier to understand.
* Updated unit test case.