### PR TITLE
Fix / Coin Gecko and exchange rate conversion errors

### DIFF
--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -357,7 +357,10 @@ def default_min_quote(quote_asset):
 def minimum_order_amount(trading_pair):
     base_asset, quote_asset = trading_pair.split("-")
     default_quote_asset, default_amount = default_min_quote(quote_asset)
-    quote_amount = ExchangeRateConversion.get_instance().convert_token_value_decimal(default_amount,
-                                                                                     default_quote_asset,
-                                                                                     base_asset)
+    try:
+        quote_amount = ExchangeRateConversion.get_instance().convert_token_value_decimal(default_amount,
+                                                                                         default_quote_asset,
+                                                                                         base_asset)
+    except Exception:
+        quote_amount = Decimal('0')
     return round(quote_amount, 4)

--- a/hummingbot/data_feed/coin_gecko_data_feed.py
+++ b/hummingbot/data_feed/coin_gecko_data_feed.py
@@ -11,6 +11,7 @@ from hummingbot.core.utils import async_ttl_cache
 from hummingbot.data_feed.data_feed_base import DataFeedBase
 from hummingbot.logger import HummingbotLogger
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.data_feed.coin_cap_data_feed import CoinCapDataFeed
 
 
 class CoinGeckoDataFeed(DataFeedBase):
@@ -88,8 +89,9 @@ class CoinGeckoDataFeed(DataFeedBase):
 
     async def update_asset_prices(self, id_asset_map: Dict[str, str]):
         try:
-            all_ids: List[str] = list(id_asset_map.keys())
-            ids_chunks: List[List[str]] = [all_ids[x:x + 500] for x in range(0, len(all_ids), 500)]
+            await CoinCapDataFeed.get_instance().get_ready()
+            all_ids = [k for k, v in id_asset_map.items() if v in CoinCapDataFeed.get_instance().price_dict.keys()]
+            ids_chunks: List[List[str]] = [all_ids[x:x + 70] for x in range(0, len(all_ids), 70)]
             client: aiohttp.ClientSession = await self._http_client()
             price_url: str = f"{self.BASE_URL}/simple/price"
             price_dict: Dict[str, float] = {}
@@ -100,12 +102,15 @@ class CoinGeckoDataFeed(DataFeedBase):
                 try:
                     async with client.request("GET", price_url, params=params) as resp:
                         results: Dict[str, Dict[str, float]] = await resp.json()
+                        if 'error' in results:
+                            raise Exception(f"{results['error']}")
                         for id, usd_price in results.items():
                             asset: str = id_asset_map[id].upper()
                             price: float = float(usd_price.get("usd", 0.0))
                             price_dict[asset] = price
-                except Exception:
-                    self.logger().warning("Coin Gecko API request failed. Unable to get prices.")
+                except Exception as e:
+                    self.logger().warning(f"Coin Gecko API request failed. Exception: {str(e)}")
+                    raise e
                 await asyncio.sleep(0.1)
 
             self._price_dict = price_dict


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1469
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
- Reduce the number of ids in ids_chucks to 70
- Reduce the number of assets to query for the price to only those also existing in CoinMarketCap
- The assets that exist (have the same symbol) in both CoinGecko and CoinMarketCap are around 150. CoinGecko has over 6k symbols, while CMC is around 260.
- There are some coins that are not in CMC api return values for some reason, e.g. ONE. This stops the bot from running, add a check for when the rate conversion failed set the minimum order amount to 0.

This is a temporary fix, should work out a better solution.