### PR TITLE
Fix / inactive binance pairs shown in auto complete

### DIFF
--- a/hummingbot/core/utils/trading_pair_fetcher.py
+++ b/hummingbot/core/utils/trading_pair_fetcher.py
@@ -64,13 +64,7 @@ class TradingPairFetcher:
             async with client.get(BINANCE_ENDPOINT, timeout=API_CALL_TIMEOUT) as response:
                 if response.status == 200:
                     data = await response.json()
-                    trading_pair_structs = data.get("symbols")
-                    raw_trading_pairs = list(map(lambda details: details.get("symbol"), trading_pair_structs))
-                    # Binance API has an error where they have a symbol called 123456
-                    # The symbol endpoint is
-                    # https://api.binance.com/api/v1/exchangeInfo
-                    if "123456" in raw_trading_pairs:
-                        raw_trading_pairs.remove("123456")
+                    raw_trading_pairs = [d["symbol"] for d in data["symbols"] if d["status"] == "TRADING"]
                     trading_pair_list: List[str] = []
                     for raw_trading_pair in raw_trading_pairs:
                         converted_trading_pair: Optional[str] = \
@@ -307,28 +301,30 @@ class TradingPairFetcher:
         return []
 
     async def fetch_all(self):
-        binance_trading_pairs = await self.fetch_binance_trading_pairs()
+        tasks = [self.fetch_binance_trading_pairs(),
+                 self.fetch_bamboo_relay_trading_pairs(),
+                 self.fetch_coinbase_pro_trading_pairs(),
+                 self.fetch_dolomite_trading_pairs(),
+                 self.fetch_huobi_trading_pairs(),
+                 self.fetch_liquid_trading_pairs(),
+                 self.fetch_bittrex_trading_pairs(),
+                 self.fetch_kucoin_trading_pairs(),
+                 self.fetch_bitcoin_com_trading_pairs()]
+
         # Radar Relay has not yet been migrated to a new version
         # Endpoint needs to be updated after migration
         # radar_relay_trading_pairs = await self.fetch_radar_relay_trading_pairs()
-        bamboo_relay_trading_pairs = await self.fetch_bamboo_relay_trading_pairs()
-        coinbase_pro_trading_pairs = await self.fetch_coinbase_pro_trading_pairs()
-        dolomite_trading_pairs = await self.fetch_dolomite_trading_pairs()
-        huobi_trading_pairs = await self.fetch_huobi_trading_pairs()
-        liquid_trading_pairs = await self.fetch_liquid_trading_pairs()
-        bittrex_trading_pairs = await self.fetch_bittrex_trading_pairs()
-        kucoin_trading_pairs = await self.fetch_kucoin_trading_pairs()
-        bitcoin_com_trading_pairs = await self.fetch_bitcoin_com_trading_pairs()
+
+        results = await asyncio.gather(*tasks)
         self.trading_pairs = {
-            "binance": binance_trading_pairs,
-            "dolomite": dolomite_trading_pairs,
-            # "radar_relay": radar_relay_trading_pairs,
-            "bamboo_relay": bamboo_relay_trading_pairs,
-            "coinbase_pro": coinbase_pro_trading_pairs,
-            "huobi": huobi_trading_pairs,
-            "liquid": liquid_trading_pairs,
-            "bittrex": bittrex_trading_pairs,
-            "kucoin": kucoin_trading_pairs,
-            "bitcoin_com": bitcoin_com_trading_pairs
+            "binance": results[0],
+            "bamboo_relay": results[1],
+            "coinbase_pro": results[2],
+            "dolomite": results[3],
+            "huobi": results[4],
+            "liquid": results[5],
+            "bittrex": results[6],
+            "kucoin": results[7],
+            "bitcoin_com": results[8]
         }
         self.ready = True


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1476
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
- To filter for only trading status pairs
- Update fetch_all to take advantage of async loading