### PR TITLE
fix / coin gecko hotfix 2

### DIFF
--- a/hummingbot/data_feed/coin_gecko_data_feed.py
+++ b/hummingbot/data_feed/coin_gecko_data_feed.py
@@ -93,8 +93,8 @@ class CoinGeckoDataFeed(DataFeedBase):
     async def update_asset_prices(self, id_asset_map: Dict[str, str]):
         try:
             await CoinCapDataFeed.get_instance().get_ready()
-            all_ids = [k for k, v in id_asset_map.items() if v in CoinCapDataFeed.get_instance().price_dict.keys()]
-            ids_chunks: List[List[str]] = [all_ids[x:x + 70] for x in range(0, len(all_ids), 70)]
+            all_ids: List[str] = list(id_asset_map.keys())
+            ids_chunks: List[List[str]] = [all_ids[x:x + 500] for x in range(0, len(all_ids), 500)]
             client: aiohttp.ClientSession = await self._http_client()
             price_url: str = f"{self.BASE_URL}/simple/price"
             price_dict: Dict[str, float] = {}


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Another hot fix for Coin Gecko, since they no longer applied the 70 ids restriction on the API, we can use it like how we did before at 500. Not doing so causes some tokens (e.g. ONE) to be missing from the prices. 
This is a temporary fix, a better solution is in development.
