### PR TITLE
fix / error with update.sh script

### DIFF
--- a/installation/docker-commands/update.sh
+++ b/installation/docker-commands/update.sh
@@ -104,7 +104,7 @@ then
     --name ${INSTANCES[$j]} \
     --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_conf,destination=/conf/" \
     --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_logs,destination=/logs/" \
-    --mount "type=bind,source=$(pwd)/${FOLDERs[$j]}/hummingbot_data,destination=/data/" \
+    --mount "type=bind,source=$(pwd)/${FOLDERS[$j]}/hummingbot_data,destination=/data/" \
     coinalpha/hummingbot:$TAG
     j=$[$j+1]
   done


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

- Applied quick fix to the update.sh script due to error `invalid mount config for type "bind": bind source path does not exist: /home/ubuntu//hummingbot_data.`