### PR TITLE
fix / missing safe ensure

### DIFF
--- a/hummingbot/core/network_base.py
+++ b/hummingbot/core/network_base.py
@@ -119,7 +119,7 @@ class NetworkBase:
                 self.logger().error("Unexpected error starting or stopping network.", exc_info=True)
 
     def start(self):
-        self._check_network_task = asyncio.ensure_future(self._check_network_loop())
+        self._check_network_task = safe_ensure_future(self._check_network_loop())
         self._network_status = NetworkStatus.NOT_CONNECTED
         self._started = True
 


### PR DESCRIPTION
Added back a missing safe_ensure_future(), that was removed for debugging.

**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This is related to the memory leak fix in #1503. There was a debug statement left behind which removed a `safe_ensure_future()` in `network_base.pyx`. It should be restored back to its original state.