### PR TITLE
Fix / start stop start error

### DIFF
--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -52,6 +52,10 @@ class StartCommand:
             self.ev_loop.call_soon_threadsafe(self.start, log_level)
             return
 
+        if self.strategy_task is not None and not self.strategy_task.done():
+            self._notify('The bot is already running - please run "stop" first')
+            return
+
         is_valid = self.status()
         if not is_valid:
             return

--- a/hummingbot/client/ui/hummingbot_cli.py
+++ b/hummingbot/client/ui/hummingbot_cli.py
@@ -17,6 +17,17 @@ from hummingbot.client.ui.layout import (
     generate_layout,
 )
 from hummingbot.client.ui.style import load_style
+import logging
+
+
+# Monkey patching here as _handle_exception gets the UI hanged into Press ENTER screen mode
+def _handle_exception_patch(self, loop, context):
+    if "exception" in context:
+        logging.getLogger(__name__).error(f"Unhandled error in prompt_toolkit: {context.get('exception')}",
+                                          exc_info=True)
+
+
+Application._handle_exception = _handle_exception_patch
 
 
 class HummingbotCLI:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1519 
- Related Clubhouse Story: 7878, 7891


**A description of the changes proposed in the pull request**:
- Monkey patched prompt_toolkit Application._handle_exception to prevent screen hanged into waiting for user input
- Gave a warning message that the bot is already running when use inputs Start command (without stopping first)