### PR TITLE
feat / task leak diagnosis tool

### DIFF
--- a/hummingbot/core/management/console.py
+++ b/hummingbot/core/management/console.py
@@ -2,14 +2,55 @@
 
 import asyncio
 import aioconsole
+from collections.abc import MutableMapping as MutableMappingABC
+import json
 import logging
-from typing import Dict
+from typing import Iterator, MutableMapping, List, Dict
 
 
-async def start_management_console(local_vars: Dict = locals(),
+class MergedNamespace(MutableMappingABC):
+    def __init__(self, *mappings):
+        self._mappings: List[MutableMapping] = list(mappings)
+        self._local_namespace = {}
+
+    def __setitem__(self, k, v) -> None:
+        self._local_namespace[k] = v
+
+    def __delitem__(self, v) -> None:
+        for m in [self._local_namespace] + self._mappings:
+            if v in m:
+                del m[v]
+
+    def __getitem__(self, k):
+        for m in [self._local_namespace] + self._mappings:
+            if k in m:
+                return m[k]
+        raise KeyError(k)
+
+    def __len__(self) -> int:
+        return sum(len(m) for m in [self._local_namespace] + self._mappings)
+
+    def __iter__(self) -> Iterator[any]:
+        for mapping in [self._local_namespace] + self._mappings:
+            for k in mapping:
+                yield k
+
+    def __repr__(self) -> str:
+        dict_repr: Dict[str, any] = dict(self.items())
+        return f"{self.__class__.__name__}({json.dumps(dict_repr)})"
+
+
+def add_diagnosis_tools(local_vars: MutableMapping):
+    from .diagnosis import active_tasks
+    local_vars["active_tasks"] = active_tasks
+
+
+async def start_management_console(local_vars: MutableMapping,
                                    host: str = "localhost",
                                    port: int = 8211,
                                    banner: str = "hummingbot") -> asyncio.base_events.Server:
+    add_diagnosis_tools(local_vars)
+
     def factory_method(*args, **kwargs):
         from aioconsole.code import AsynchronousConsole
         return AsynchronousConsole(locals=local_vars, *args, **kwargs)

--- a/hummingbot/core/management/diagnosis.py
+++ b/hummingbot/core/management/diagnosis.py
@@ -20,7 +20,7 @@ def get_coro_name(coro: Union[Coroutine, Generator]) -> str:
 
 
 def get_wrapped_coroutine(t: asyncio.Task) -> Union[Coroutine, Generator]:
-    if "safe_ensure" in str(t):
+    if "safe_wrapper" in str(t):
         return t.get_coro().cr_frame.f_locals["c"]
     else:
         return t.get_coro()

--- a/hummingbot/core/management/diagnosis.py
+++ b/hummingbot/core/management/diagnosis.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+"""
+Debug console diagnosis tools.
+"""
+
+import asyncio
+import pandas as pd
+from typing import Coroutine, Generator, Union, List
+
+
+def get_coro_name(coro: Union[Coroutine, Generator]) -> str:
+    if hasattr(coro, '__qualname__') and coro.__qualname__:
+        coro_name = coro.__qualname__
+    elif hasattr(coro, '__name__') and coro.__name__:
+        coro_name = coro.__name__
+    else:
+        coro_name = f'<{type(coro).__name__} without __name__>'
+    return f'{coro_name}()'
+
+
+def get_wrapped_coroutine(t: asyncio.Task) -> Union[Coroutine, Generator]:
+    if "safe_ensure" in str(t):
+        return t.get_coro().cr_frame.f_locals["c"]
+    else:
+        return t.get_coro()
+
+
+def active_tasks() -> pd.DataFrame:
+    tasks: List[asyncio.Task] = [t for t in asyncio.Task.all_tasks() if not t.done()]
+    coroutines: List[Union[Coroutine, Generator]] = [get_wrapped_coroutine(t) for t in tasks]
+    func_names: List[str] = [get_coro_name(c) for c in coroutines]
+    retval: pd.DataFrame = pd.DataFrame([{"func_name": f, "coroutine": c, "task": t}
+                                         for f, c, t in zip(func_names, coroutines, tasks)],
+                                        columns=["func_name", "coroutine", "task"]).set_index("func_name")
+    retval.sort_index(inplace=True)
+    return retval


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:
https://app.clubhouse.io/coinalpha/story/8364/investigate-memory-leak-when-stopping-and-restarting-the-strategy

**A description of the changes proposed in the pull request**:
* This patch adds a tool, `active_tasks()`, in the debug console that cleanly lists out the actively running tasks in Hummingbot - which can be useful for debugging background task leaks.

In the debug console, it can be called up as a global function without needing any import. It outputs a nicely formatted table with the background task's function names in the indexing column.

<img width="1250" alt="Screen Shot 2020-04-30 at 6 30 01 PM" src="https://user-images.githubusercontent.com/304402/80774041-ae67d780-8b10-11ea-95c7-f92ebb539532.png">
