### PR TITLE
fix / duration in history output

### DIFF
--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -147,7 +147,7 @@ class HistoryCommand:
             trade_performance_status_line.extend(
                 ["", "  Performance:"] +
                 [f"    Started: {datetime.fromtimestamp(self.start_time//1e3)}"] +
-                [f"    Duration: {pd.Timestamp((time.time() - self.start_time/1e3), unit='s').strftime('%H:%M:%S')}"] +
+                [f"    Duration: {pd.Timedelta(seconds=abs(int(time.time() - self.start_time/1e3)))}"] +
                 [f"    Total Trade Value Delta: {portfolio_delta:.7g} {primary_quote_asset}"] +
                 [f"    Return %: {portfolio_delta_percentage:.4f} %"])
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

- Related Github issue: https://github.com/CoinAlpha/hummingbot/issues/1686
- Related Clubhouse Story: [8555](https://app.clubhouse.io/coinalpha/story/8555/add-number-of-days-to-history-duration)

**A description of the changes proposed in the pull request**:

Added no. of days the strategy has been running in duration when displaying the `history` command.

![pycharm64_BPnQCwlVna](https://user-images.githubusercontent.com/50150287/81144948-c4114d00-8fa7-11ea-89ff-5c2c8cd8e7a1.png)