### PR TITLE
Fixing mistaken assignment method

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -62,7 +62,7 @@ async def main():
         if global_config_map.get("debug_console").value:
             if not hasattr(__builtins__, "help"):
                 import _sitebuiltins
-                __builtins__.help = _sitebuiltins._Helper()
+                __builtins__["help"] = _sitebuiltins._Helper()
 
             from hummingbot.core.management.console import start_management_console
             management_port: int = detect_available_port(8211)


### PR DESCRIPTION
When `if not hasattr(__builtins__, "help"):` is true, the assignment of `__builtins__.help` will throw an error. `__builtins__["help"]` will properly set the dictionary value as desired.

**Before submitting this PR, please make sure**:
- [x ] Your code builds clean without any errors or warnings
- [x ] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
