### PR TITLE
fix / return tuple correctly instead of list

### DIFF
--- a/hummingbot/market/kraken/kraken_market.pyx
+++ b/hummingbot/market/kraken/kraken_market.pyx
@@ -194,7 +194,7 @@ cdef class KrakenMarket(MarketBase):
 
     @staticmethod
     def split_trading_pair(trading_pair: str) -> Tuple[str, str]:
-        return KrakenMarket.convert_from_exchange_trading_pair(trading_pair).split("-")
+        return tuple(KrakenMarket.convert_from_exchange_trading_pair(trading_pair).split("-"))
 
     @staticmethod
     def convert_from_exchange_trading_pair(exchange_trading_pair: str) -> Optional[str]:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: Resolves #1676 
- Related Clubhouse Story: 8494


**A description of the changes proposed in the pull request**:
Return tuple from Kraken split_trading_pair method, not list.