### PR TITLE
fix / kraken trading pair autocomplete

### DIFF
--- a/hummingbot/core/utils/trading_pair_fetcher.py
+++ b/hummingbot/core/utils/trading_pair_fetcher.py
@@ -265,9 +265,13 @@ class TradingPairFetcher:
                         from hummingbot.market.kraken.kraken_market import KrakenMarket
                         data: Dict[str, Any] = await response.json()
                         raw_pairs = data.get("result", [])
-                        converted_pairs = [KrakenMarket.convert_from_exchange_trading_pair(pair)
-                                           for pair in raw_pairs
-                                           if ".d" not in pair]
+                        converted_pairs: List[str] = []
+                        for pair in raw_pairs:
+                            if ".d" not in pair:
+                                try:
+                                    converted_pairs.append(KrakenMarket.convert_from_exchange_trading_pair(pair))
+                                except IOError:
+                                    pass
                         return [item for item in converted_pairs]
         except Exception:
             pass


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: fixes #1693 
- Related Clubhouse Story: 8691


**A description of the changes proposed in the pull request**:
This allows the trading_pair_fetcher to ignore Kraken trading pairs that hb cannot convert from API to hb format. This means Kraken trading pair auto-complete now works (as does any strategy that relies on trading_pair_fetcher).