### PR TITLE
fix / paper trade price decimal precision

### DIFF
--- a/hummingbot/market/paper_trade/paper_trade_market.pyx
+++ b/hummingbot/market/paper_trade/paper_trade_market.pyx
@@ -912,7 +912,7 @@ cdef class PaperTradeMarket(MarketBase):
                 precision_quantum = Decimal(0)
             return max(precision_quantum, decimals_quantum)
         else:
-            return Decimal(f"1e-8")
+            return Decimal(f"1e-10")
 
     cdef object c_get_order_size_quantum(self,
                                          str trading_pair,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

Adjusted the price precision in `c_get_order_price_quantum()` for markets that have 10 decimal values which were having problems in order creation like this one below.

<img width="286" alt="pycharm64_gb9jQHlrg8" src="https://user-images.githubusercontent.com/50150287/81897697-c3049f00-95e9-11ea-8f7a-4fb1e00e0d3e.png">