### PR TITLE
doc/update broken links on release notes

### DIFF
--- a/documentation/docs/release-notes/0.10.0.md
+++ b/documentation/docs/release-notes/0.10.0.md
@@ -30,7 +30,7 @@ We invested considerable time during this release to refactor the strategy and m
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 Below are the main ones that we fixed in this release:
 

--- a/documentation/docs/release-notes/0.11.0.md
+++ b/documentation/docs/release-notes/0.11.0.md
@@ -16,7 +16,7 @@ Over time, we will add more content to the other sections.
 
 ![](/assets/img/simple_trade.png)
 
-We added a new strategy: [Simple Trade](/strategies/simple-trade). 
+We added a new strategy: [Simple Trade](https://docs.hummingbot.io/developers/tutorial/simple-trade/). 
 
 This strategy gives users a starter template upon which to customize their own strategies.
 
@@ -34,7 +34,7 @@ We have integrated the price feed from [CoinGecko](https://www.coingecko.com/en)
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Bots will now respect the minimum order size on IDEX and not try to place orders smaller than minimum order size
 * Refactored the strategy classes to move redundant code to the strategy base classes

--- a/documentation/docs/release-notes/0.12.0.md
+++ b/documentation/docs/release-notes/0.12.0.md
@@ -6,11 +6,11 @@
 
 The pure market making strategy now includes a feature that modifies the size of your bid/ask orders in order to maintain a target ratio of base to quote asset.  For example, if you are trading ETH-USDT and are targeting a 50%/50% ratio of ETH to USDT, if the value of your ETH holdings accounts for more than 50% of your current portfolio, the bid (buy ETH) size will be reduced while the ask (sell ETH) size will be increased.
 
-Read more about this feature [here](/strategies/pure-market-making/#inventory-based-dynamic-order-sizing).
+Read more about this feature [here](https://docs.hummingbot.io/strategies/advanced-mm/inventory-skew/).
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed bug that shows all trades as "sell" in trade history.
 * Fixed bug preventing restarting of a bot in telegram after kill switch is triggered.

--- a/documentation/docs/release-notes/0.13.0.md
+++ b/documentation/docs/release-notes/0.13.0.md
@@ -4,7 +4,7 @@
 
 ## 🏆 Introducing the liquidity bounty leader board!
 
-The first liquidity bounty leaderboard is out!! Check out the [Harmony $ONE Makers leader board](https://hummingbot.io/bounties/harmony-leaderboard/).
+The first liquidity bounty leaderboard is out!! Check out the Harmony $ONE Makers leader board.
 
 * Real-time bounty program statistics
 * List of reward tiers
@@ -21,7 +21,7 @@ As part of our ongoing efforts to make the Hummingbot code base more understanda
 
 * Developer documentation for [cross exchange market making](/developers/strategies/cross-exchange-market-making/)
 * Developer documentation for [adding exchange connectors](/developers/connectors/)
-* Extensive comments in the strategy code files: [arbitrage](https://github.com/CoinAlpha/hummingbot/tree/master/hummingbot/strategy/arbitrage), [cross exchange market making](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/strategy/cross_exchange_market_making), and [discovery](https://github.com/CoinAlpha/hummingbot/tree/master/hummingbot/strategy/discovery)
+* Extensive comments in the strategy code files: [arbitrage](https://github.com/CoinAlpha/hummingbot/tree/master/hummingbot/strategy/arbitrage), [cross exchange market making](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/strategy/cross_exchange_market_making), and discovery
 
 ## 💻 Autostart a strategy on launch with new CLI launch commands
 
@@ -31,11 +31,11 @@ For more details, see here: [trading strategy autostart](https://docs.hummingbot
 
 ## Add use of API key for IDEX connector
 
-On Friday August 23, IDEX released updates to its servers requiring authentication/use of API keys to access its APIs.  For more information, see [IDEX API key](/connectors/idex/#api-key).
+On Friday August 23, IDEX released updates to its servers requiring authentication/use of API keys to access its APIs.  For more information, see IDEX API key.
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Remove quantity limit on `export trades` function.
 * Fix DEX zero balance bug caused by a delay in receiving balance update following order cancellation.

--- a/documentation/docs/release-notes/0.14.0.md
+++ b/documentation/docs/release-notes/0.14.0.md
@@ -17,14 +17,14 @@ Hummingbot now support [Huobi Global](https://www.hbg.com)!  You can read more a
 Our efforts to make the Hummingbot code base more understandable and easier to use for developers continues, with additional documentation for strategies:
 
 * Developer documentation for [arbitrage strategy](/developers/strategies/arbitrage/).
-* Developer documentation for [discovery strategy](/developers/strategies/discovery/).
+* Developer documentation for discovery strategy.
 
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Remove bounty status from Hummingbot client to optimize server performance; users should instead use the [Harmony $ONE Makers leadboard](https://hummingbot.io/liquidity-bounties/harmony/) to look up their bounty information.
+* Remove bounty status from Hummingbot client to optimize server performance; users should instead use the Harmony $ONE Makers leadboard to look up their bounty information.
 * Fix discovery strategy currency symbol input formatting.
 * Fix IDEX repeated `cancelled order` notifications when running `stop`.
 

--- a/documentation/docs/release-notes/0.15.0.md
+++ b/documentation/docs/release-notes/0.15.0.md
@@ -6,7 +6,7 @@
 
 This often asked for, long-awaited feature is now released!  Users can now run Hummingbot and simulate trading strategies without executing and placing actual trades.
 
-For more information on how to configure and use this strategy, see [Paper Trading Mode](/operation/paper-trade).
+For more information on how to configure and use this strategy, see [Paper Trading Mode](https://docs.hummingbot.io/operation/commands/paper-trade/).
 
 ## 📊 Improvements to the **pure market making** strategy
 
@@ -33,7 +33,7 @@ We implemented a number of changes to the cross exchange market making strategy 
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Remove requirements to maintain Ethereum balance to be eligibe to receive bounties
 * Fix telegram `history`, which was truncating data: [#743](https://github.com/CoinAlpha/hummingbot/issues/743)

--- a/documentation/docs/release-notes/0.16.0.md
+++ b/documentation/docs/release-notes/0.16.0.md
@@ -7,19 +7,19 @@
 
 Great news! We're happy to announce that Harmony Protocol has decided to extend the $ONE Makers program to October and beyond! Users can continue to earn rewards by market making for Harmony's ONE token on any supported exchanges where it trades. 
 
-We will keep the [rewards schedule](/bounties/active/harmony/#october-2019) the same for October.
+We will keep the rewards schedule the same for October.
 
 ## 🏃 Penny jumping mode in **pure_market_making** strategy
 
 After you have placed an order, have you seen other orders respond by making their price slightly better than yours? This is called penny-jumping, and it can be a good way to ensure that your orders have the highest probability of being filled while maximizing the profit upon a fill.
 
-With pure market making strategy (in single order mode), users now have the option to automatically adjust the prices to just above top bid and just below top ask. See [this page](https://docs.hummingbot.io/strategies/pure-market-making/#penny-jumping-mode) for more information.
+With pure market making strategy (in single order mode), users now have the option to automatically adjust the prices to just above top bid and just below top ask. See [this page](https://docs.hummingbot.io/strategies/advanced-mm/order-optimization/) for more information.
 
 ## 💵 Transaction costs in **pure_market_making** strategy
 
 We have conformed how transaction costs are handled across all strategies. By default, the pure market making strategy now incorporates transaction costs like exchange trading fees and gas costs into order prices. 
 
-This is a configurable parameter, so users can turn this behavior off if they like. See [this page](/strategies/pure-market-making/#adding-transaction-costs-to-prices).
+This is a configurable parameter, so users can turn this behavior off if they like. See [this page](https://docs.hummingbot.io/strategies/advanced-mm/add-transaction-costs/).
 
 ## 📝 More developer documentation
 
@@ -32,7 +32,7 @@ As part of our ongoing efforts to make the Hummingbot code base more understanda
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed assets showing 0 value in Huobi: [#826](https://github.com/CoinAlpha/hummingbot/issues/826)
 * Fixed Discovery strategy not showing profitability and optimization for Huobi: [#825](https://github.com/CoinAlpha/hummingbot/issues/825)

--- a/documentation/docs/release-notes/0.17.0.md
+++ b/documentation/docs/release-notes/0.17.0.md
@@ -12,15 +12,15 @@ Read more about how to use Bittrex connector with Hummingbot in the [User Manual
 
 ## 📊 New performance analysis calculation
 
-We redesigned how Hummingbot analyzes performance so that events unrelated to Hummingbot’s actions (e.g. deposits, withdrawals, manual trades) do not impact the performance calculation; percentage profit is now based solely on assets spent and acquired from trading. Refer to our document in [Performance Analysis](/operation/performance-analysis) for more information.
+We redesigned how Hummingbot analyzes performance so that events unrelated to Hummingbot’s actions (e.g. deposits, withdrawals, manual trades) do not impact the performance calculation; percentage profit is now based solely on assets spent and acquired from trading. Refer to our document in [Performance Analysis](https://docs.hummingbot.io/operation/commands/history/) for more information.
 
 
 ## 📝 More developer documentation
 
 We published a developer tutorial on building custom strategies and documentation for the **Perform Trade** strategy.
 
-* [Developer Tutorial](/developers/strategies/tutorial)
-* [Perform Trade Strategy](/developers/strategies/perform-trade)
+* [Developer Tutorial](https://docs.hummingbot.io/developers/tutorial/)
+* [Perform Trade Strategy](https://docs.hummingbot.io/developers/tutorial/perform-trade/)
 
 
 ## 📚Log file management / data storage
@@ -31,7 +31,7 @@ We published a developer tutorial on building custom strategies and documentatio
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed IDEX minimum ETH wallet check: [#845](https://github.com/CoinAlpha/hummingbot/issues/845)
 * Fixed bug related to paper trading mode account balance: [#843](https://github.com/CoinAlpha/hummingbot/issues/843)

--- a/documentation/docs/release-notes/0.18.0.md
+++ b/documentation/docs/release-notes/0.18.0.md
@@ -16,19 +16,19 @@ The connector is now available in Hummingbot and should work with existing strat
 Hummingbot can now be installed easily on Windows and macOS using a setup/install package that is available for download and will be updated with every new version release.
 
 Follow the links below for more information:
-* [Install via Binary on Windows](/installation/from-binary/windows/)
-* [Install via Binary on macOS](/installation/from-binary/macos/)
+* [Install via Binary on Windows](https://docs.hummingbot.io/installation/download/windows/)
+* [Install via Binary on macOS](https://docs.hummingbot.io/installation/download/macos/)
 
 
 ## 🤓 Developer usability
 
-* Developer documentation for [Simple Trade](/developers/strategies/simple-trade)
+* Developer documentation for [Simple Trade](https://docs.hummingbot.io/developers/tutorial/simple-trade/)
 * Added missing templates for dev strategies: [#960](https://github.com/CoinAlpha/hummingbot/pull/960)
 
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Failed to submit cancel orders in Huobi: [#750](https://github.com/CoinAlpha/hummingbot/issues/750)
 * Added trading pair fetcher in Bittrex to prevent issues related to entering incorrect pair format: [#985](https://github.com/CoinAlpha/hummingbot/issues/985)

--- a/documentation/docs/release-notes/0.19.0.md
+++ b/documentation/docs/release-notes/0.19.0.md
@@ -19,7 +19,7 @@
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed orders getting stuck in Bittrex when hedging price moves too fast: [#1042](https://github.com/CoinAlpha/hummingbot/issues/1042)
 * Fixed issues with starting arbitrage strategy using incorrect trading pair: [#1062](https://github.com/CoinAlpha/hummingbot/pull/1062)

--- a/documentation/docs/release-notes/0.20.0.md
+++ b/documentation/docs/release-notes/0.20.0.md
@@ -3,7 +3,7 @@
 🚀 Welcome to `hummingbot` version 0.20.0! In this release, we mainly addressed a number of bugs. Separately from the `hummingbot` client, the team has been hard at work on the Liquidity Mining infrastructure, with campaigns on target for a mid-February launch.
 
 ## 🤖 UI Update
-* We have added a feature that allows you to encrypt and decrypt your exchange API keys. Please review `Step 3: Configure a market making bot` in our [Quickstart guide](https://docs.hummingbot.io/quickstart/3-configure-bot/) for more details.
+* We have added a feature that allows you to encrypt and decrypt your exchange API keys. Please review `Step 3: Configure a market making bot` in our [Quickstart guide](https://docs.hummingbot.io/quickstart/configure/) for more details.
 
 ## 🌊⛏ Liquidity mining update
 
@@ -12,7 +12,7 @@ In mid February 2020, we plan to launch liquidity mining campaigns for our launc
 Also, we recently released a blog explaining how liquidity mining rewards are calculated on our new platform. For more information, read through our blog posts:
 
 * [Liquidity Mining Launch Update](https://hummingbot.io/blog/2019-12-liquidity-mining-launch/) 
-* [Demystifying Liquidity Mining Rewards](https://hummingbot.io/blog/2019-12-liquidity-mining-rewards/))
+* [Demystifying Liquidity Mining Rewards](https://hummingbot.io/blog/2019-12-liquidity-mining-rewards/)
 
 ## 🔗 Connectors update
 
@@ -27,7 +27,7 @@ Also, we recently released a blog explaining how liquidity mining rewards are ca
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed price calculation when trading BUSD stablecoin: [#1120](https://github.com/CoinAlpha/hummingbot/issues/1120)
 * Fixed unexpected keyword argument 'trading_pairs' in Bamboo Relay: [#1113](https://github.com/CoinAlpha/hummingbot/issues/1113)

--- a/documentation/docs/release-notes/0.21.0.md
+++ b/documentation/docs/release-notes/0.21.0.md
@@ -10,7 +10,7 @@ We are officially announcing the TWAP custom strategy, a common algorithmic exec
 
 ## 🐞 Other bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed bug triggering kill switch due to inventory changes outside of trades: [#1145](https://github.com/CoinAlpha/hummingbot/issues/1145) 
 * Fixed default value not working for some parameters with pure market making strategy: [#1085](https://github.com/CoinAlpha/hummingbot/issues/1085)

--- a/documentation/docs/release-notes/0.22.0.md
+++ b/documentation/docs/release-notes/0.22.0.md
@@ -7,7 +7,7 @@
 
 By default, pure market making strategy uses the order book’s mid price to calculate limit order prices. We added a feature that allows you to use another mid price from external sources such as another exchange, data feed, or an external API.
 
-You may read through [External Pricing Source Configuration](/strategies/pure-market-making/#external-pricing-source-configuration) in the user manual for more information.
+You may read through [External Pricing Source Configuration](https://docs.hummingbot.io/strategies/advanced-mm/price-source/) in the user manual for more information.
 
 
 ## 🔗 Radar Relay upgrade to 0x v3
@@ -19,16 +19,16 @@ The Radar Relay connector is broken right now because they recently moved their 
 
 Here we list recent major changes to Hummingbot docs:
 
-* Added [Liquidity Mining FAQ](/liquidity-mining/faq/) and list of upcoming campaigns
+* Added [Liquidity Mining FAQ](https://docs.hummingbot.io/faq/liquidity-mining/) and list of upcoming campaigns
 * Added External Pricing Source Configuration in Pure Market Making strategy
-* Added steps in Troubleshooting section on [how to locate the data folder](/support/questions/#locate-data-folder-or-hummingbot_tradessqlite-when-running-hummingbot-via-docker) where hummingbot_trades.sqlite folder is stored when running via Docker
-* Added information in Troubleshooting section about Binance [HTTP status 429 and 418 return codes](/support/troubleshooting/binance/#http-status-429-and-418-return-codes)
+* Added steps in Troubleshooting section on [how to locate the data folder](https://docs.hummingbot.io/faq/troubleshooting/) where hummingbot_trades.sqlite folder is stored when running via Docker
+* Added information in Troubleshooting section about Binance [HTTP status 429 and 418 return codes](https://docs.hummingbot.io/faq/troubleshooting/)
 * Removed Bitcoin.com Exchange since this is no longer supported
 
 
 ## 🐞 Other bug fixes
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed issue on Windows when running pure market making strategy on multiple orders mode: [#1261](https://github.com/CoinAlpha/hummingbot/issues/1261)
 * Fixed generic syntax on trading pair symbols not working: [#1264](https://github.com/CoinAlpha/hummingbot/issues/1264)

--- a/documentation/docs/release-notes/0.23.0.md
+++ b/documentation/docs/release-notes/0.23.0.md
@@ -12,13 +12,13 @@ We are excited to launch the Liquidity Mining Open Beta today! During the 4-week
 ### 🧪 User testing during open beta
 We are inviting interested users to join our dedicated user testing program during the Open Beta period. Testers will receive **0.1 ETH** for their time. 
 
-For users who want to participate, please fill out this [form](https://docs.google.com/forms/u/1/d/e/1FAIpQLSfw9XOv_xAi2IqTmjsebJhjAIa6vewS0wFS0j4TsxeDRbsm5Q/viewform?usp=send_form). We’ll reach out to you soon!
+For users who want to participate, please fill out this form. We’ll reach out to you soon!
 
 Please refer to the following links and resources for more information:
 
 * [Hummingbot Miners](https://miners.hummingbot.io)
-* [Participation Guide](https://docs.hummingbot.io/liquidity-mining/guide/)
-* [Liquidity Mining FAQs](https://docs.hummingbot.io/liquidity-mining/faq/)
+* [Participation Guide](https://docs.hummingbot.io/liquidity-mining/)
+* [Liquidity Mining FAQs](https://docs.hummingbot.io/faq/liquidity-mining/)
 * [Liquidity Mining Policy](https://hummingbot.io/liquidity-mining-policy/)
 
 
@@ -65,7 +65,7 @@ Here we list other recent major changes to Hummingbot docs:
 
 ## 🐞 Other bug fixes
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed error when exporting trades in Windows: [#1302](https://github.com/CoinAlpha/hummingbot/issues/1302)
 * Fixed bug losing track of orders on Coinbase Pro: [#1357](https://github.com/CoinAlpha/hummingbot/issues/1357)

--- a/documentation/docs/release-notes/0.24.0.md
+++ b/documentation/docs/release-notes/0.24.0.md
@@ -29,7 +29,7 @@ Here we list other recent major changes to Hummingbot docs:
 
 ## 🐞 Other bug fixes
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed error when exporting trades in Windows: [#1302](https://github.com/CoinAlpha/hummingbot/issues/1302)
 * Added reduced polling logic for Binance API limit: [#1379](https://github.com/CoinAlpha/hummingbot/issues/1379)

--- a/documentation/docs/release-notes/0.4.0.md
+++ b/documentation/docs/release-notes/0.4.0.md
@@ -6,7 +6,7 @@
 
 Hummingbot now supports [Coinbase Pro](/connectors/coinbase)! One of the most liquid exchanges and also one of the few centralized exchanges with DAI trading pairs, Coinbase Pro is our 2nd centralized exchange connector. Users can now run the **cross-exchange market making** and **arbitrage** strategies using Coinbase Pro vs decentralized exchanges or Coinbase Pro vs Binance.
 
-We are still working out some kinks with this connector, so please consult the [Known Issues](/support/tips-issues) page before using this connector.
+We are still working out some kinks with this connector, so please consult the Known Issues page before using this connector.
 
 ## 💻 Command line interface (CLI) improvements
 
@@ -14,7 +14,7 @@ As part of ongoing work to improve the user interface, we made a number of misce
 
 * Trades are now a global object, so you can use `list trades` in order to see a list of past trades performed by the bot
 * Added a `export_private_key` command to export the private key of Ethereum wallets created in Hummingbot
-* Added instructions to help users [import and export wallets](/installation/wallet)
+* Added instructions to help users [import and export wallets](https://docs.hummingbot.io/advanced/wallet/)
 * Added a warning to inform users when they have insufficient ETH in their wallet to fund gas costs
 * Fixed a bug that prevented editing of certain strategy configuration settings
 

--- a/documentation/docs/release-notes/0.5.0.md
+++ b/documentation/docs/release-notes/0.5.0.md
@@ -27,14 +27,14 @@ New documentation in this release includes:
 
 * [Strategies](/strategies): diagrams and explanations of Hummingbot's strategies
 * [Debug console](/developers/debug): how to use the debug console to inspect your bot in real-time
-* [Known issues](/support/issues): list of currently outstanding issues and their resolution status
+* Known issues: list of currently outstanding issues and their resolution status
 * [Windows installation](/installation/docker/windows): how to install Hummingbot on Windows
-* [Exchange rates](/utilities/exchange-rates): how to use the exchange rates utility class to resolve price differences between stablecoins
-* [Wallet import/export](/installation/wallet): how to import and export Ethereum wallets
+* [Exchange rates](https://docs.hummingbot.io/advanced/exchange-rates/): how to use the exchange rates utility class to resolve price differences between stablecoins
+* [Wallet import/export](https://docs.hummingbot.io/advanced/wallet/): how to import and export Ethereum wallets
 
 ## 🐞 Bug fixes and miscellaneous updates
 
-We fixed a number of bugs in this release. Thanks 🙏 all the bug reporters who took part in our [bug bounty program](bounties/bug-bounty-program)!
+We fixed a number of bugs in this release. Thanks 🙏 all the bug reporters who took part in our bug bounty program!
 
 * Fixed a bug in which Coinbase Pro orders were failing due to overly high precision in the order amount field ([bug bounty recipient](https://github.com/CoinAlpha/hummingbot/issues/106))
 * Fixed an bug in which the bug prints excessive `Maker order size must be greater than 0` log messages ([bug bounty recipient](https://github.com/CoinAlpha/hummingbot/issues/118))

--- a/documentation/docs/release-notes/0.7.0.md
+++ b/documentation/docs/release-notes/0.7.0.md
@@ -6,7 +6,7 @@
 
 ![pure market making](/assets/img/pure_mm.png)
 
-We have added the first version of a [pure market making strategy](/strategies/pure-market-making/), so all three strategies described in our [whitepaper](/whitepaper/) have now been released into production.
+We have added the first version of a [pure market making strategy](/strategies/pure-market-making/), so all three strategies described in our [whitepaper](https://hummingbot.io/hummingbot.pdf) have now been released into production.
 
 Please note that this initial release contains a naive implementation that simply sets and maintains a constant spread around a trading pair's mid price. **Note that this is intended to be a basic template that users can test and customize. Running the strategy with substantial capital without additional modifications will likely lose money**.
 
@@ -26,7 +26,7 @@ In order to make log messages more actionable and relevant to users, we have mad
 
 ## 🔍 Improved `discovery` strategy
 
-We made a number of improvements to the [discovery](/strategies/discovery) to make it easier for users to use. For example, users can now automatically scan for arbitrage opportunities across all possible trading pairs, though it still takes a long time to process. We will continue to improve this function in order to help users identify the best trading pairs and markets in which to run Hummingbot.
+We made a number of improvements to the discovery to make it easier for users to use. For example, users can now automatically scan for arbitrage opportunities across all possible trading pairs, though it still takes a long time to process. We will continue to improve this function in order to help users identify the best trading pairs and markets in which to run Hummingbot.
 
 ## ⚙️ Started configurability initiative
 

--- a/documentation/docs/release-notes/0.8.0.md
+++ b/documentation/docs/release-notes/0.8.0.md
@@ -33,7 +33,7 @@ We anticipate that the IDEX connector will be incorporated into the `master` bra
 
 ## 🐞 Bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 Below are the main ones that we fixed in this release:
 

--- a/documentation/docs/release-notes/0.9.0.md
+++ b/documentation/docs/release-notes/0.9.0.md
@@ -4,7 +4,7 @@
 
 ## 🏃 Earn rewards from trading with Liquidity bounties
 
-Liquidity bounties are live! We have partnered with Harmony Protocol to launch the [$ONE Makers program](/bounties/active/harmony/), which gives ETH-based rewards for Hummingbot users who provide liquidity to Harmony's $ONE token. 
+Liquidity bounties are live! We have partnered with Harmony Protocol to launch the $ONE Makers program, which gives ETH-based rewards for Hummingbot users who provide liquidity to Harmony's $ONE token. 
 
 ![](/assets/img/bounty-register.png)
 
@@ -22,7 +22,7 @@ Today, we're happy to announce that the IDEX market connector is ready for use, 
 
 The [pure market making strategy](/strategies/pure-market-making/) now allows you to place multiple levels of orders on each side of the order book. This allows market makers to set different tiers of orders with different spreads and order amounts. 
 
-For information on how to use this new feature, please see the [Multiple Orders configuration](/strategies/pure-market-making/#multiple-order-configuration) section.
+For information on how to use this new feature, please see the [Multiple Orders configuration](https://docs.hummingbot.io/strategies/advanced-mm/multiple-orders/) section.
 
 ## 📈 Performance analysis in `history` command
 
@@ -30,7 +30,7 @@ Tracking profits and losses is an essential part of trading. The `history` comma
 
 ## 🐞 Bug fixes and miscellaneous updates
 
-Thanks to everyone who reported bugs! **Note that we pay [bug bounties](/bounties/bug-bounty-program) to anyone who reports a bug that we end up fixing.**
+Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 Below are the main ones that we fixed in this release:
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
- Update / re-route broken links
Example of release note 0.17.0 
![17 0](https://user-images.githubusercontent.com/57189990/81901149-a455d680-95f0-11ea-9669-7d32f06c132b.PNG)
- convert deprecated links to normal text
Example: Bug bounties
![bug bounties](https://user-images.githubusercontent.com/57189990/81901181-addf3e80-95f0-11ea-8913-a1b604dd2bc2.PNG)
