### PR TITLE
fix / starting_balances not being populated with all assets

### DIFF
--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from collections import defaultdict
 
 import pandas as pd
 import threading
@@ -44,16 +45,18 @@ class HistoryCommand:
         self.trade_performance_report()
 
     def balance_snapshot(self,  # type: HummingbotApplication
-                         ) -> Dict[str, Dict[str, Decimal]]:
-        snapshot: Dict[str, Any] = {}
+                         starting_balances: bool = False) -> Dict[str, Dict[str, Decimal]]:
+        snapshot: Dict[str, Any] = defaultdict(dict)
         for market_name in self.markets:
             balance_dict = self.markets[market_name].get_all_balances()
             balance_dict = {k.upper(): v for k, v in balance_dict.items()}
 
+            if starting_balances:
+                for asset in balance_dict:
+                    snapshot[asset][market_name] = Decimal(balance_dict[asset])
+
             for asset in self.assets:
                 asset = asset.upper()
-                if asset not in snapshot:
-                    snapshot[asset] = {}
                 if asset in balance_dict:
                     snapshot[asset][market_name] = Decimal(balance_dict[asset])
                 else:

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -45,21 +45,18 @@ class HistoryCommand:
         self.trade_performance_report()
 
     def balance_snapshot(self,  # type: HummingbotApplication
-                         starting_balances: bool = False) -> Dict[str, Dict[str, Decimal]]:
+                         ) -> Dict[str, Dict[str, Decimal]]:
         snapshot: Dict[str, Any] = defaultdict(dict)
         for market_name in self.markets:
             balance_dict = self.markets[market_name].get_all_balances()
             balance_dict = {k.upper(): v for k, v in balance_dict.items()}
 
-            if starting_balances:
-                for asset in balance_dict:
-                    snapshot[asset][market_name] = Decimal(balance_dict[asset])
+            for asset in balance_dict:
+                snapshot[asset][market_name] = Decimal(balance_dict[asset])
 
             for asset in self.assets:
                 asset = asset.upper()
-                if asset in balance_dict:
-                    snapshot[asset][market_name] = Decimal(balance_dict[asset])
-                else:
+                if asset not in balance_dict:
                     snapshot[asset][market_name] = Decimal("0")
         return snapshot
 

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -108,7 +108,7 @@ class StartCommand:
                          f"Run `status` command to query the progress.")
             self.logger().info("start command initiated.")
             if not self.starting_balances:
-                self.starting_balances = await self.wait_till_ready(self.balance_snapshot)
+                self.starting_balances = await self.wait_till_ready(self.balance_snapshot, starting_balances=True)
 
             if self._trading_required:
                 self.kill_switch = KillSwitch(self)

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -108,7 +108,7 @@ class StartCommand:
                          f"Run `status` command to query the progress.")
             self.logger().info("start command initiated.")
             if not self.starting_balances:
-                self.starting_balances = await self.wait_till_ready(self.balance_snapshot, starting_balances=True)
+                self.starting_balances = await self.wait_till_ready(self.balance_snapshot)
 
             if self._trading_required:
                 self.kill_switch = KillSwitch(self)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1782 
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Previously starting_balances would only be populated with the base and quote assets of the first strategy to be started once HB client was opened. Now it is populated with all assets available. This allows for the history command to function as expected even if trading pair is changed without closing the client.