### PR TITLE
docs / update hanging_orders_enabled statement

### DIFF
--- a/documentation/docs/strategies/advanced-mm/hanging-orders.md
+++ b/documentation/docs/strategies/advanced-mm/hanging-orders.md
@@ -23,7 +23,7 @@ Suppose you are market making for the `ETH-USDT` pair with a mid-market price of
 
 Now suppose that a market taker (someone taking a position in the market) thinks the price of Ethereum will rise, so they fill your ask order 202 ($t_1$). 
 
-At the next order refresh cycle, normally Hummingbot would cancel the 198 USD bid order and create 2 new bid and ask orders. However, if `hanging_orders_enabled` is set to False, the bid order is not cancelled and stays on the order book until it is filled. Note that if an open hanging order spread exceeds the `hanging_orders_cancel_pct` parameter, the hanging order will be canceled.
+At the next order refresh cycle, normally Hummingbot would cancel the 198 USD bid order and create 2 new bid and ask orders. However, if `hanging_orders_enabled` is set to True, the bid order is not cancelled and stays on the order book until it is filled. Note that if an open hanging order spread exceeds the `hanging_orders_cancel_pct` parameter, the hanging order will be canceled.
 
 ###Example 2 (Advanced)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
Current documentation states that 
if `hanging_orders_enabled` is set to `False`, the bid order is not cancelled and stays on the order book until it is filled.
where it should be
if `hanging_orders_enabled` is set to `True`, the bid order is not cancelled and stays on the order book until it is filled.

![image](https://user-images.githubusercontent.com/53868268/84424197-ba55b780-abed-11ea-90ce-adb3c2981e8d.png)
