### PR TITLE
(fix) correct argument to paper connector's c_cancel method

### DIFF
--- a/hummingbot/market/paper_trade/paper_trade_market.pyx
+++ b/hummingbot/market/paper_trade/paper_trade_market.pyx
@@ -894,7 +894,7 @@ cdef class PaperTradeMarket(MarketBase):
             LimitOrders *limit_orders_map_ptr = (address(self._bid_limit_orders)
                                                  if is_maker_buy
                                                  else address(self._ask_limit_orders))
-        self.c_cancel_order_from_orders_map(limit_orders_map_ptr, trading_pair_str, client_order_id)
+        self.c_cancel_order_from_orders_map(limit_orders_map_ptr, trading_pair_str, False, client_order_id)
 
     cdef object c_get_fee(self,
                           str base_asset,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1653, #1805
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This PR solves all issues with abnormal order cancellation of multiple orders in paper-trade mode.