### PR TITLE
Fix / show full api key on reconnect

### DIFF
--- a/hummingbot/client/command/connect_command.py
+++ b/hummingbot/client/command/connect_command.py
@@ -47,7 +47,7 @@ class ConnectCommand:
             api_key_config = [c for c in exchange_configs if "api_key" in c.key][0]
             api_key = Security.decrypted_value(api_key_config.key)
             answer = await self.app.prompt(prompt=f"Would you like to replace your existing {exchange} API key "
-                                                  f"...{api_key[-4:]} (Yes/No)? >>> ")
+                                                  f"{api_key} (Yes/No)? >>> ")
             if self.app.to_stop_config:
                 self.app.to_stop_config = False
                 return
@@ -128,7 +128,7 @@ class ConnectCommand:
         to_connect = True
         if ether_wallet is not None:
             answer = await self.app.prompt(prompt=f"Would you like to replace your existing Ethereum wallet "
-                                                  f"...{ether_wallet[-4:]} (Yes/No)? >>> ")
+                                                  f"{ether_wallet} (Yes/No)? >>> ")
             if self.app.to_stop_config:
                 self.app.to_stop_config = False
                 return
@@ -160,7 +160,7 @@ class ConnectCommand:
         to_connect = True
         if celo_address is not None:
             answer = await self.app.prompt(prompt=f"Would you like to replace your existing Celo account address "
-                                                  f"...{celo_address} (Yes/No)? >>> ")
+                                                  f"{celo_address} (Yes/No)? >>> ")
             if answer.lower() not in ("yes", "y"):
                 to_connect = False
         if to_connect:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story: 8586


**A description of the changes proposed in the pull request**:
- Show API key or address when reconnecting to existing exchange/ethereum/celo connection.
- The second part of the clubhouse story was done in a separate PR and is already merged in development. 