### PR TITLE
fix / pmm incorrect inventory skew status

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -46,6 +46,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         int64_t _logging_options
     cdef object c_get_mid_price(self)
     cdef object c_create_base_proposal(self)
+    cdef tuple c_get_adjusted_available_balance(self, list orders)
     cdef c_apply_order_levels_modifiers(self, object proposal)
     cdef c_apply_price_band(self, object proposal)
     cdef c_apply_ping_pong(self, object proposal)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
This fixes an issue with the pure market making strategy's status message, in which the inventory skew section of it uses an incorrect and different calculation compared to the actual strategy execution logic. This is highly misleading to users and may cause unexpected trades to happen due to misguided configurations.