### PR TITLE
docs / celo-arb minimum instance type

### DIFF
--- a/documentation/docs/installation/cloud.md
+++ b/documentation/docs/installation/cloud.md
@@ -12,6 +12,9 @@ As of **version 0.28.0** installing Docker takes up around 500 MB of storage spa
 
 These instances are pre-loaded with system files that takes up around 1.2 GB so we recommend having at least **8 GB of storage space** in your cloud server.
 
+!!! note "Exception for celo-arb strategy"
+      Running a [Celo Arbitrage](/strategies/celo-arb/) strategy requires a minimum of `t2.medium` AWS instance type for improved performance.
+
 Below, we show you how to set up a new Virtual Machine Instance on each major cloud platform.
 
 ## Google Cloud Platform

--- a/documentation/docs/strategies/celo-arb/quickstart.md
+++ b/documentation/docs/strategies/celo-arb/quickstart.md
@@ -12,7 +12,7 @@ Follow the instructions at [Installation - Cloud Server Guide - AWS](/installati
 
 ### Instance type
 
-While the free `t2.micro` tier may be sufficient to run `celo-arb`, we recommend a `t2.small` instance as the minimum instance type.
+While the free `t2.micro` tier may be sufficient to run `celo-arb`, we recommend a `t2.medium` instance as the minimum instance type for improved performance.
 
 ### Storage
 By default, AWS instances come with 8 GB of storage. We recommend that you increase storage to at least 16 GB to install the Docker version along with the Celo node.


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story: https://app.clubhouse.io/coinalpha/story/8502/task-4-build-and-deploy-continual-testing-infrastructure#activity-9326

**A description of the changes proposed in the pull request**:

Changed minimum instance type of running `celo-arb` and ultra-light node from `t2.small` to `t2.medium`.

<img width="800" alt="lnE3tLuEia" src="https://user-images.githubusercontent.com/50150287/86087389-adcecb80-bad6-11ea-8502-13d7f76bf2c1.png">
<img width="800" alt="6hTUqu1y2S" src="https://user-images.githubusercontent.com/50150287/86087403-b0312580-bad6-11ea-8f65-9707b6f17dff.png">
