### PR TITLE
fix / add missing fiat currencies in Binance

### DIFF
--- a/hummingbot/market/binance/binance_market.pyx
+++ b/hummingbot/market/binance/binance_market.pyx
@@ -72,7 +72,7 @@ from hummingbot.core.utils.estimate_fee import estimate_fee
 
 s_logger = None
 s_decimal_0 = Decimal(0)
-TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(BTC|ETH|BNB|XRP|USDT|USDC|USDS|TUSD|PAX|TRX|BUSD|NGN|RUB|TRY|EUR|IDRT)$")
+TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(BTC|ETH|BNB|XRP|USDT|USDC|USDS|TUSD|PAX|TRX|BUSD|NGN|RUB|TRY|EUR|IDRT|ZAR|UAH|GBP|BKRW|BIDR)$")
 BROKER_ID = "x-XEKWYICX"
 
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

One user reported that BTC-ZAR and BTC-GBP are missing from our trading pair list. Checked for other missing fiat currencies and added them as well.