### PR TITLE
Refactor / Keep Limit orders as limit, not makers and market orders as market, not takers.

### DIFF
--- a/hummingbot/strategy/celo_arb/celo_arb.pyx
+++ b/hummingbot/strategy/celo_arb/celo_arb.pyx
@@ -149,10 +149,6 @@ cdef class CeloArbStrategy(StrategyBase):
         return self._sb_order_tracker.active_asks
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_limit_orders
-
-    @property
     def in_flight_cancels(self) -> Dict[str, float]:
         return self._sb_order_tracker.in_flight_cancels
 

--- a/hummingbot/strategy/celo_arb/celo_arb.pyx
+++ b/hummingbot/strategy/celo_arb/celo_arb.pyx
@@ -150,7 +150,7 @@ cdef class CeloArbStrategy(StrategyBase):
 
     @property
     def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:

--- a/hummingbot/strategy/dev_0_hello_world/dev_0_hello_world.pyx
+++ b/hummingbot/strategy/dev_0_hello_world/dev_0_hello_world.pyx
@@ -76,8 +76,8 @@ cdef class HelloWorldStrategy(StrategyBase):
         return self._sb_order_tracker.active_asks
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:

--- a/hummingbot/strategy/dev_1_get_order_book/dev_1_get_order_book.pyx
+++ b/hummingbot/strategy/dev_1_get_order_book/dev_1_get_order_book.pyx
@@ -76,7 +76,7 @@ cdef class GetOrderBookStrategy(StrategyBase):
 
     @property
     def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:

--- a/hummingbot/strategy/dev_2_perform_trade/dev_2_perform_trade.pyx
+++ b/hummingbot/strategy/dev_2_perform_trade/dev_2_perform_trade.pyx
@@ -88,8 +88,8 @@ cdef class PerformTradeStrategy(StrategyBase):
         return self._sb_order_tracker.active_asks
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:
@@ -154,7 +154,7 @@ cdef class PerformTradeStrategy(StrategyBase):
         StrategyBase.c_tick(self, timestamp)
         cdef:
             bint should_report_warnings = self._logging_options & self.OPTION_LOG_STATUS_REPORT
-            list active_maker_orders = self.active_maker_orders
+            list active_maker_orders = self.active_limit_orders
 
         try:
             if not self._all_markets_ready:

--- a/hummingbot/strategy/dev_4_twap/dev_4_twap.pyx
+++ b/hummingbot/strategy/dev_4_twap/dev_4_twap.pyx
@@ -114,8 +114,8 @@ cdef class Dev4TwapTradeStrategy(StrategyBase):
         return self._sb_order_tracker.active_asks
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:
@@ -280,7 +280,7 @@ cdef class Dev4TwapTradeStrategy(StrategyBase):
             int64_t last_tick = <int64_t>(self._last_timestamp // self._status_report_interval)
             bint should_report_warnings = ((current_tick > last_tick) and
                                            (self._logging_options & self.OPTION_LOG_STATUS_REPORT))
-            list active_maker_orders = self.active_maker_orders
+            list active_maker_orders = self.active_limit_orders
 
         try:
             if not self._all_markets_ready:

--- a/hummingbot/strategy/dev_5_vwap/dev_5_vwap.pyx
+++ b/hummingbot/strategy/dev_5_vwap/dev_5_vwap.pyx
@@ -121,8 +121,8 @@ cdef class Dev5TwapTradeStrategy(StrategyBase):
         return self._sb_order_tracker.active_asks
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:
@@ -308,7 +308,7 @@ cdef class Dev5TwapTradeStrategy(StrategyBase):
             int64_t last_tick = <int64_t>(self._last_timestamp // self._status_report_interval)
             bint should_report_warnings = ((current_tick > last_tick) and
                                            (self._logging_options & self.OPTION_LOG_STATUS_REPORT))
-            list active_maker_orders = self.active_maker_orders
+            list active_maker_orders = self.active_limit_orders
 
         try:
             if not self._all_markets_ready:

--- a/hummingbot/strategy/dev_simple_trade/dev_simple_trade.pyx
+++ b/hummingbot/strategy/dev_simple_trade/dev_simple_trade.pyx
@@ -110,8 +110,8 @@ cdef class SimpleTradeStrategy(StrategyBase):
         return self._sb_order_tracker.active_asks
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        return self._sb_order_tracker.active_limit_orders
 
     @property
     def in_flight_cancels(self) -> Dict[str, float]:
@@ -276,7 +276,7 @@ cdef class SimpleTradeStrategy(StrategyBase):
             int64_t last_tick = <int64_t>(self._last_timestamp // self._status_report_interval)
             bint should_report_warnings = ((current_tick > last_tick) and
                                            (self._logging_options & self.OPTION_LOG_STATUS_REPORT))
-            list active_maker_orders = self.active_maker_orders
+            list active_maker_orders = self.active_limit_orders
 
         try:
             if not self._all_markets_ready:

--- a/hummingbot/strategy/order_tracker.pxd
+++ b/hummingbot/strategy/order_tracker.pxd
@@ -6,18 +6,18 @@ from hummingbot.core.time_iterator cimport TimeIterator
 
 cdef class OrderTracker(TimeIterator):
     cdef:
-        dict _tracked_maker_orders
-        dict _tracked_taker_orders
+        dict _tracked_limit_orders
+        dict _tracked_market_orders
         dict _order_id_to_market_pair
-        dict _shadow_tracked_maker_orders
+        dict _shadow_tracked_limit_orders
         dict _shadow_order_id_to_market_pair
         object _shadow_gc_requests
         object _in_flight_cancels
         object _in_flight_pending_created
 
-    cdef dict c_get_maker_orders(self)
-    cdef dict c_get_taker_orders(self)
-    cdef dict c_get_shadow_maker_orders(self)
+    cdef dict c_get_limit_orders(self)
+    cdef dict c_get_market_orders(self)
+    cdef dict c_get_shadow_limit_orders(self)
     cdef bint c_has_in_flight_cancel(self, str order_id)
     cdef bint c_check_and_track_cancel(self, str order_id)
     cdef object c_get_market_pair_from_order_id(self, str order_id)

--- a/hummingbot/strategy/order_tracker.pyx
+++ b/hummingbot/strategy/order_tracker.pyx
@@ -26,67 +26,67 @@ cdef class OrderTracker(TimeIterator):
 
     def __init__(self):
         super().__init__()
-        self._tracked_maker_orders = {}
-        self._tracked_taker_orders = {}
+        self._tracked_limit_orders = {}
+        self._tracked_market_orders = {}
         self._order_id_to_market_pair = {}
-        self._shadow_tracked_maker_orders = {}
+        self._shadow_tracked_limit_orders = {}
         self._shadow_order_id_to_market_pair = {}
         self._shadow_gc_requests = deque()
         self._in_flight_pending_created = set()
         self._in_flight_cancels = OrderedDict()
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        maker_orders = []
-        for market_pair, orders_map in self._tracked_maker_orders.items():
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        limit_orders = []
+        for market_pair, orders_map in self._tracked_limit_orders.items():
             for limit_order in orders_map.values():
                 if self.c_has_in_flight_cancel(limit_order.client_order_id):
                     continue
-                maker_orders.append((market_pair.market, limit_order))
-        return maker_orders
+                limit_orders.append((market_pair.market, limit_order))
+        return limit_orders
 
     @property
-    def shadow_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        maker_orders = []
-        for market_pair, orders_map in self._shadow_tracked_maker_orders.items():
+    def shadow_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        limit_orders = []
+        for market_pair, orders_map in self._shadow_tracked_limit_orders.items():
             for limit_order in orders_map.values():
                 if self.c_has_in_flight_cancel(limit_order.client_order_id):
                     continue
-                maker_orders.append((market_pair.market, limit_order))
-        return maker_orders
+                limit_orders.append((market_pair.market, limit_order))
+        return limit_orders
 
     @property
     def market_pair_to_active_orders(self) -> Dict[MarketTradingPairTuple, List[LimitOrder]]:
         market_pair_to_orders = {}
-        market_pairs = self._tracked_maker_orders.keys()
+        market_pairs = self._tracked_limit_orders.keys()
         for market_pair in market_pairs:
-            maker_orders = []
-            for limit_order in self._tracked_maker_orders[market_pair].values():
+            limit_orders = []
+            for limit_order in self._tracked_limit_orders[market_pair].values():
                 if self.c_has_in_flight_cancel(limit_order.client_order_id):
                     continue
-                maker_orders.append(limit_order)
-            market_pair_to_orders[market_pair] = maker_orders
+                limit_orders.append(limit_order)
+            market_pair_to_orders[market_pair] = limit_orders
         return market_pair_to_orders
 
     @property
     def active_bids(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return [(market, limit_order) for market, limit_order in self.active_maker_orders if limit_order.is_buy]
+        return [(market, limit_order) for market, limit_order in self.active_limit_orders if limit_order.is_buy]
 
     @property
     def active_asks(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return [(market, limit_order) for market, limit_order in self.active_maker_orders if not limit_order.is_buy]
+        return [(market, limit_order) for market, limit_order in self.active_limit_orders if not limit_order.is_buy]
 
     @property
-    def tracked_taker_orders(self) -> List[Tuple[MarketBase, MarketOrder]]:
-        return [(market_trading_pair_tuple[0], order) for market_trading_pair_tuple, order_map in self._tracked_taker_orders.items()
-                for order in order_map.values()]
+    def tracked_market_orders(self) -> List[Tuple[MarketBase, MarketOrder]]:
+        return [(market_trading_pair_tuple[0], order) for market_trading_pair_tuple, order_map
+                in self._tracked_market_orders.items() for order in order_map.values()]
 
     @property
-    def tracked_taker_orders_data_frame(self) -> List[pd.DataFrame]:
-        market_orders = [[market_trading_pair_tuple.market.display_name, market_trading_pair_tuple.trading_pair, order_id, order.amount,
-                          pd.Timestamp(order.timestamp, unit='s', tz='UTC').strftime('%Y-%m-%d %H:%M:%S')
-                          ]
-                         for market_trading_pair_tuple, order_map in self._tracked_taker_orders.items()
+    def tracked_market_orders_data_frame(self) -> List[pd.DataFrame]:
+        market_orders = [[market_trading_pair_tuple.market.display_name, market_trading_pair_tuple.trading_pair,
+                          order_id, order.amount,
+                          pd.Timestamp(order.timestamp, unit='s', tz='UTC').strftime('%Y-%m-%d %H:%M:%S')]
+                         for market_trading_pair_tuple, order_map in self._tracked_market_orders.items()
                          for order_id, order in order_map.items()]
 
         return pd.DataFrame(data=market_orders, columns=["market", "trading_pair", "order_id", "quantity", "timestamp"])
@@ -103,14 +103,14 @@ cdef class OrderTracker(TimeIterator):
         TimeIterator.c_tick(self, timestamp)
         self.c_check_and_cleanup_shadow_records()
 
-    cdef dict c_get_maker_orders(self):
-        return self._tracked_maker_orders
+    cdef dict c_get_limit_orders(self):
+        return self._tracked_limit_orders
 
-    cdef dict c_get_taker_orders(self):
-        return self._tracked_taker_orders
+    cdef dict c_get_market_orders(self):
+        return self._tracked_market_orders
 
-    cdef dict c_get_shadow_maker_orders(self):
-        return self._shadow_tracked_maker_orders
+    cdef dict c_get_shadow_limit_orders(self):
+        return self._shadow_tracked_limit_orders
 
     cdef bint c_has_in_flight_cancel(self, str order_id):
         return self._in_flight_cancels.get(order_id, NaN) + self.CANCEL_EXPIRY_DURATION > self._current_timestamp
@@ -147,23 +147,23 @@ cdef class OrderTracker(TimeIterator):
         return self._shadow_order_id_to_market_pair.get(order_id)
 
     cdef LimitOrder c_get_limit_order(self, object market_pair, str order_id):
-        return self._tracked_maker_orders.get(market_pair, {}).get(order_id)
+        return self._tracked_limit_orders.get(market_pair, {}).get(order_id)
 
     cdef object c_get_market_order(self, object market_pair, str order_id):
-        return self._tracked_taker_orders.get(market_pair, {}).get(order_id)
+        return self._tracked_market_orders.get(market_pair, {}).get(order_id)
 
     cdef LimitOrder c_get_shadow_limit_order(self, str order_id):
         cdef:
             object market_pair = self._shadow_order_id_to_market_pair.get(order_id)
 
-        return self._shadow_tracked_maker_orders.get(market_pair, {}).get(order_id)
+        return self._shadow_tracked_limit_orders.get(market_pair, {}).get(order_id)
 
     cdef c_start_tracking_limit_order(self, object market_pair, str order_id, bint is_buy, object price,
                                       object quantity):
-        if market_pair not in self._tracked_maker_orders:
-            self._tracked_maker_orders[market_pair] = {}
-        if market_pair not in self._shadow_tracked_maker_orders:
-            self._shadow_tracked_maker_orders[market_pair] = {}
+        if market_pair not in self._tracked_limit_orders:
+            self._tracked_limit_orders[market_pair] = {}
+        if market_pair not in self._shadow_tracked_limit_orders:
+            self._shadow_tracked_limit_orders[market_pair] = {}
 
         cdef:
             LimitOrder limit_order = LimitOrder(order_id,
@@ -173,16 +173,16 @@ cdef class OrderTracker(TimeIterator):
                                                 market_pair.quote_asset,
                                                 price,
                                                 quantity)
-        self._tracked_maker_orders[market_pair][order_id] = limit_order
-        self._shadow_tracked_maker_orders[market_pair][order_id] = limit_order
+        self._tracked_limit_orders[market_pair][order_id] = limit_order
+        self._shadow_tracked_limit_orders[market_pair][order_id] = limit_order
         self._order_id_to_market_pair[order_id] = market_pair
         self._shadow_order_id_to_market_pair[order_id] = market_pair
 
     cdef c_stop_tracking_limit_order(self, object market_pair, str order_id):
-        if market_pair in self._tracked_maker_orders and order_id in self._tracked_maker_orders[market_pair]:
-            del self._tracked_maker_orders[market_pair][order_id]
-            if len(self._tracked_maker_orders[market_pair]) < 1:
-                del self._tracked_maker_orders[market_pair]
+        if market_pair in self._tracked_limit_orders and order_id in self._tracked_limit_orders[market_pair]:
+            del self._tracked_limit_orders[market_pair][order_id]
+            if len(self._tracked_limit_orders[market_pair]) < 1:
+                del self._tracked_limit_orders[market_pair]
             self._shadow_gc_requests.append((
                 self._current_timestamp + self.SHADOW_MAKER_ORDER_KEEP_ALIVE_DURATION,
                 market_pair,
@@ -195,9 +195,9 @@ cdef class OrderTracker(TimeIterator):
             del self._in_flight_cancels[order_id]
 
     cdef c_start_tracking_market_order(self, object market_pair, str order_id, bint is_buy, object quantity):
-        if market_pair not in self._tracked_taker_orders:
-            self._tracked_taker_orders[market_pair] = {}
-        self._tracked_taker_orders[market_pair][order_id] = MarketOrder(
+        if market_pair not in self._tracked_market_orders:
+            self._tracked_market_orders[market_pair] = {}
+        self._tracked_market_orders[market_pair][order_id] = MarketOrder(
             order_id,
             market_pair.trading_pair,
             is_buy,
@@ -209,10 +209,10 @@ cdef class OrderTracker(TimeIterator):
         self._order_id_to_market_pair[order_id] = market_pair
 
     cdef c_stop_tracking_market_order(self, object market_pair, str order_id):
-        if market_pair in self._tracked_taker_orders and order_id in self._tracked_taker_orders[market_pair]:
-            del self._tracked_taker_orders[market_pair][order_id]
-            if len(self._tracked_taker_orders[market_pair]) < 1:
-                del self._tracked_taker_orders[market_pair]
+        if market_pair in self._tracked_market_orders and order_id in self._tracked_market_orders[market_pair]:
+            del self._tracked_market_orders[market_pair][order_id]
+            if len(self._tracked_market_orders[market_pair]) < 1:
+                del self._tracked_market_orders[market_pair]
         if order_id in self._order_id_to_market_pair:
             del self._order_id_to_market_pair[order_id]
 
@@ -222,11 +222,11 @@ cdef class OrderTracker(TimeIterator):
 
         while len(self._shadow_gc_requests) > 0 and self._shadow_gc_requests[0][0] < current_timestamp:
             _, market_pair, order_id = self._shadow_gc_requests.popleft()
-            if (market_pair in self._shadow_tracked_maker_orders and
-                    order_id in self._shadow_tracked_maker_orders[market_pair]):
-                del self._shadow_tracked_maker_orders[market_pair][order_id]
-                if len(self._shadow_tracked_maker_orders[market_pair]) < 1:
-                    del self._shadow_tracked_maker_orders[market_pair]
+            if (market_pair in self._shadow_tracked_limit_orders and
+                    order_id in self._shadow_tracked_limit_orders[market_pair]):
+                del self._shadow_tracked_limit_orders[market_pair][order_id]
+                if len(self._shadow_tracked_limit_orders[market_pair]) < 1:
+                    del self._shadow_tracked_limit_orders[market_pair]
             if order_id in self._shadow_order_id_to_market_pair:
                 del self._shadow_order_id_to_market_pair[order_id]
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -306,10 +306,6 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         return self._hanging_order_ids
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        return self._sb_order_tracker.active_maker_orders
-
-    @property
     def market_info_to_active_orders(self) -> Dict[MarketTradingPairTuple, List[LimitOrder]]:
         return self._sb_order_tracker.market_pair_to_active_orders
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making_order_tracker.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_order_tracker.pyx
@@ -22,28 +22,28 @@ cdef class PureMarketMakingOrderTracker(OrderTracker):
         super().__init__()
 
     @property
-    def active_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        maker_orders = []
-        for market_pair, orders_map in self._tracked_maker_orders.items():
+    def active_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        limit_orders = []
+        for market_pair, orders_map in self._tracked_limit_orders.items():
             for limit_order in orders_map.values():
-                maker_orders.append((market_pair.market, limit_order))
-        return maker_orders
+                limit_orders.append((market_pair.market, limit_order))
+        return limit_orders
 
     @property
-    def shadow_maker_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
-        maker_orders = []
-        for market_pair, orders_map in self._shadow_tracked_maker_orders.items():
+    def shadow_limit_orders(self) -> List[Tuple[MarketBase, LimitOrder]]:
+        limit_orders = []
+        for market_pair, orders_map in self._shadow_tracked_limit_orders.items():
             for limit_order in orders_map.values():
-                maker_orders.append((market_pair.market, limit_order))
-        return maker_orders
+                limit_orders.append((market_pair.market, limit_order))
+        return limit_orders
 
     @property
     def market_pair_to_active_orders(self) -> Dict[MarketTradingPairTuple, List[LimitOrder]]:
         market_pair_to_orders = {}
-        market_pairs = self._tracked_maker_orders.keys()
+        market_pairs = self._tracked_limit_orders.keys()
         for market_pair in market_pairs:
             maker_orders = []
-            for limit_order in self._tracked_maker_orders[market_pair].values():
+            for limit_order in self._tracked_limit_orders[market_pair].values():
                 maker_orders.append(limit_order)
             market_pair_to_orders[market_pair] = maker_orders
         return market_pair_to_orders

--- a/test/test_arbitrage.py
+++ b/test/test_arbitrage.py
@@ -108,10 +108,10 @@ class ArbitrageUnitTest(unittest.TestCase):
         self.market_1.set_balance("COINALPHA", 5)
         self.market_2.set_balance("COINALPHA", 5)
         self.clock.backtest_til(self.start_timestamp + 1)
-        market_orders = self.strategy.tracked_taker_orders
-        market_1_market_order = [order for market, order in self.strategy.tracked_taker_orders
+        market_orders = self.strategy.tracked_market_orders
+        market_1_market_order = [order for market, order in self.strategy.tracked_market_orders
                                  if market == self.market_1][0]
-        market_2_market_order = [order for market, order in self.strategy.tracked_taker_orders
+        market_2_market_order = [order for market, order in self.strategy.tracked_market_orders
                                  if market == self.market_2][0]
 
         self.assertTrue(len(market_orders) == 2)
@@ -125,7 +125,7 @@ class ArbitrageUnitTest(unittest.TestCase):
             [OrderBookRow(1.05, 1.0, 2)],
             [], 2)
         self.clock.backtest_til(self.start_timestamp + 1)
-        market_orders = self.strategy.tracked_taker_orders
+        market_orders = self.strategy.tracked_market_orders
         self.assertTrue(len(market_orders) == 0)
 
     def test_find_best_profitable_amount(self):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1980 
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
- Update incorrect reference to limit orders as makers (simply keep them as limit) and market orders as takers (keep them as market)
- Refactor all strategies that use `order_tracker` as well.