### PR TITLE
docs / explain hanging orders with multiple order levels

### DIFF
--- a/documentation/docs/strategies/advanced-mm/hanging-orders.md
+++ b/documentation/docs/strategies/advanced-mm/hanging-orders.md
@@ -90,7 +90,7 @@ Buy order 1 gets filled.
 Maker BUY order 0.05000000 ETH @ 233.90000000 USDT is filled.  
 ```
 
-This leaves the 3 sell order hanging on top of the new orders on the next refresh.
+This leaves the 3 sell orders hanging on top of the new orders on the next refresh.
 
 ```
 Orders:                                                               

--- a/documentation/docs/strategies/advanced-mm/hanging-orders.md
+++ b/documentation/docs/strategies/advanced-mm/hanging-orders.md
@@ -62,6 +62,51 @@ The hanging order will stay outstanding and will be cancelled if its spread goes
 
 ![](/assets/img/hanging_order3.png)
 
+## Hanging Orders with Multiple Order Levels
+
+When an order is filled on one side either buy or sell, all active orders on the opposite side are left hanging.
+
+```json
+- hanging_orders_enabled: True
+- order_levels: 3
+```
+
+With the sample configuration above, the bot places 3 buy and 3 sell orders.
+
+```
+Orders:                                                                
+   Level  Type  Price Spread Amount (Orig)  Amount (Adj)       Age Hang
+       3  sell 239.75  2.49%          0.05          0.05  00:00:01   no
+       2  sell 237.41  1.49%          0.05          0.05  00:00:01   no
+       1  sell 235.07  0.49%          0.05          0.05  00:00:01   no
+       1   buy  233.9  0.01%          0.05          0.05  00:00:01   no
+       2   buy 231.56  1.01%          0.05          0.05  00:00:01   no
+       3   buy 229.22  2.01%          0.05          0.05  00:00:01   no
+```
+
+Buy order 1 gets filled.
+
+```
+Maker BUY order 0.05000000 ETH @ 233.90000000 USDT is filled.  
+```
+
+This leaves the 3 sell order hanging on top of the new orders on the next refresh.
+
+```
+Orders:                                                               
+  Level  Type  Price Spread Amount (Orig)  Amount (Adj)       Age Hang
+         sell 239.75  2.50%                        0.05  00:01:08  yes
+      3  sell 239.73  2.49%          0.05          0.05  00:00:01   no
+         sell 237.41  1.50%                        0.05  00:01:08  yes
+      2  sell 237.39  1.49%          0.05          0.05  00:00:01   no
+         sell 235.07  0.50%                        0.05  00:01:08  yes
+      1  sell 235.05  0.49%          0.05          0.05  00:00:01   no
+      1   buy 233.88  0.01%          0.05          0.05  00:00:01   no
+      2   buy 231.54  1.01%          0.05          0.05  00:00:01   no
+      3   buy  229.2  2.01%          0.05          0.05  00:00:01   no
+
+```
+
 
 ## Relevant Parameters
 

--- a/documentation/docs/strategies/advanced-mm/order-levels.md
+++ b/documentation/docs/strategies/advanced-mm/order-levels.md
@@ -32,8 +32,8 @@ Let us focus on one side of the order for now which is the "buy" side of the ord
 - ask_spread: 1
 - order_amount: 0.002
 - order_levels: 3
-- order_levels_amount: 0.002
-- order_levels_spread: 0.5
+- order_level_amount: 0.002
+- order_level_spread: 0.5
 ```
 
 Running a bot with the parameters above, the `status` command shows 3 levels of orders in the BTC-USDT trading pair: 
@@ -49,7 +49,7 @@ You might notice that the actual spread in our output is not exactly similar fro
 | Parameter | Prompt | Definition |
 |-----------|--------|------------|
 | **order_levels** | `How many orders do you want to place on both sides?` | The number of order levels to place for each side of the order book. |
-| **order_level_amount** | `How much do you want to increase or decrease the order size for each additional order?` | The size can either increase(if set to a value greater than zero) or decrease(if set to a value less than zero) for subsequent order levels after the first level. |
+| **order_level_amount** | `How much do you want to increase or decrease the order size for each additional order?` | The size can either increase (if set to a value greater than zero) or decrease (if set to a value less than zero) for subsequent order levels after the first level. |
 | **order_level_spread** | `Enter the price increments (as percentage) for subsequent orders?` | The incremental spread increases for subsequent order levels after the first level. |
 
 !!! warning "Low values for `order_level_spread`"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: https://github.com/CoinAlpha/hummingbot/issues/1900
- Related Clubhouse Story: https://app.clubhouse.io/coinalpha/story/9372/v0-29-0-bugs


**A description of the changes proposed in the pull request**:

Added explanation in docs how hanging order works when used when `order_levels` > 1.

<img width="960" alt="chrome_6Dcjp7bypX" src="https://user-images.githubusercontent.com/50150287/86588867-1c23fa00-bfbf-11ea-8f22-8d4884bd6c76.png">
