### PR TITLE
[v0.30] Fix / orders failed on insufficient balance

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -47,7 +47,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         int64_t _logging_options
     cdef object c_get_mid_price(self)
     cdef object c_create_base_proposal(self)
-    cdef tuple c_get_adjusted_available_balance(self, list orders)
+    cdef tuple c_get_adjusted_available_balance(self, bint exclude_hanging_orders)
+    cdef tuple c_get_adjusted_total_balance(self, bint exclude_hanging_orders)
     cdef c_apply_order_levels_modifiers(self, object proposal)
     cdef c_apply_price_band(self, object proposal)
     cdef c_apply_ping_pong(self, object proposal)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -592,9 +592,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         """
         cdef:
             MarketBase market = self._market_info.market
+        if self._market_info.market.name != "binance":
+            return market.c_get_balance(self.base_asset), market.c_get_balance(self.quote_asset)
+        cdef:
             object base_balance = market.c_get_available_balance(self.base_asset)
             object quote_balance = market.c_get_available_balance(self.quote_asset)
-
         for order in orders:
             if order.is_buy:
                 quote_balance += order.quantity * order.price


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #2012 
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
- Use total balance when allocate fund to orders (instead of available balance + outstanding orders) for exchanges other than Binance.