### PR TITLE
fix / Fix docker scripts

### DIFF
--- a/installation/docker-commands/create-web3.sh
+++ b/installation/docker-commands/create-web3.sh
@@ -44,8 +44,8 @@ echo
 echo "Your files will be saved to:"
 echo "=> instance folder:    $PWD/$FOLDER"
 echo "=> config files:       ├── $PWD/$FOLDER/hummingbot_conf"
-echo "=> log files:          └── $PWD/$FOLDER/hummingbot_logs"
-echo "=> data file:          └── $PWD/$FOLDER/hummingbot_data"
+echo "=> log files:          ├── $PWD/$FOLDER/hummingbot_logs"
+echo "=> data file:          ├── $PWD/$FOLDER/hummingbot_data"
 echo "=> scripts files:      └── $PWD/$FOLDER/hummingbot_scripts"
 echo
 pause Press [Enter] to continue

--- a/installation/docker-commands/create-web3.sh
+++ b/installation/docker-commands/create-web3.sh
@@ -57,7 +57,10 @@ pause Press [Enter] to continue
 # 1) Create folder for your new instance
 mkdir $FOLDER
 # 2) Create folders for log and config files
-mkdir $FOLDER/hummingbot_conf && mkdir $FOLDER/hummingbot_logs
+mkdir $FOLDER/hummingbot_conf
+mkdir $FOLDER/hummingbot_logs
+mkdir $FOLDER/hummingbot_data
+mkdir $FOLDER/hummingbot_scripts
 # 3) Launch a new instance of hummingbot
 docker run -it \
 --network host \

--- a/installation/docker-commands/create.sh
+++ b/installation/docker-commands/create.sh
@@ -45,7 +45,7 @@ echo "Your files will be saved to:"
 echo "=> instance folder:    $PWD/$FOLDER"
 echo "=> config files:       ├── $PWD/$FOLDER/hummingbot_conf"
 echo "=> log files:          ├── $PWD/$FOLDER/hummingbot_logs"
-echo "=> data file:          └── $PWD/$FOLDER/hummingbot_data"
+echo "=> data file:          ├── $PWD/$FOLDER/hummingbot_data"
 echo "=> scripts files:      └── $PWD/$FOLDER/hummingbot_scripts"
 echo
 pause Press [Enter] to continue

--- a/installation/docker-commands/create.sh
+++ b/installation/docker-commands/create.sh
@@ -60,6 +60,7 @@ mkdir $FOLDER
 mkdir $FOLDER/hummingbot_conf
 mkdir $FOLDER/hummingbot_logs
 mkdir $FOLDER/hummingbot_data
+mkdir $FOLDER/hummingbot_scripts
 # 3) Launch a new instance of hummingbot
 docker run -it --log-opt max-size=10m --log-opt max-file=5 \
 --name $INSTANCE_NAME \


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:

Fix addresses two missing mount source directories in docker create.sh scripts, hummingbot_data and hummingbot_scripts.