### PR TITLE
Feat / balance paper command

### DIFF
--- a/hummingbot/client/command/balance_command.py
+++ b/hummingbot/client/command/balance_command.py
@@ -7,35 +7,38 @@ from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.config.config_helpers import (
     save_to_yml
 )
+from hummingbot.client.config.config_validators import validate_decimal, validate_exchange
 from hummingbot.market.celo.celo_cli import CeloCLI
 import pandas as pd
 from decimal import Decimal
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, List, Any
 
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
 
 OPTIONS = [
     "limit",
+    "paper"
 ]
 
 OPTION_HELP = {
     "limit": "balance limit [exchange] [ASSET] [AMOUNT]",
+    "paper": "balance paper [ASSET] [AMOUNT]"
 }
 
 OPTION_DESCRIPTION = {
     "limit": "Configure the asset limits for specified exchange",
+    "paper": "Configure asset balances used in paper trading mode"
 }
 
 LIMIT_GLOBAL_CONFIG = "balance_asset_limit"
+PAPER_ACC_BALANCE_CONFIG = "paper_trade_account_balance"
 
 
 class BalanceCommand:
     def balance(self,
                 option: str = None,
-                exchange: str = None,
-                asset: str = None,
-                amount: str = None,
+                args: List[str] = None
                 ):
         self.app.clear_input()
         if option is None:
@@ -45,32 +48,42 @@ class BalanceCommand:
             config_map = global_config_map
             file_path = GLOBAL_CONFIG_PATH
             if option == "limit":
-
                 config_var = config_map[LIMIT_GLOBAL_CONFIG]
-                if exchange is None and asset is None and amount is None:
+                if args is None or len(args) == 0:
                     safe_ensure_future(self.show_asset_limits())
                     return
-
-                if asset is not None and amount is not None and exchange is not None:
-                    exchange_limit_conf = config_var.value[exchange]
-                    if exchange_limit_conf is None:
-                        config_var.value.update({exchange: {}})
-                    asset = asset.upper()
-                    self._notify(f"Limit for {asset} token, set to {amount}")
-                    config_var.value[exchange].update({asset: amount})
-                    save_to_yml(file_path, config_map)
-                else:
-                    self._notify("Error with command arguments. See command details below.")
-                    safe_ensure_future(self.list_options())
+                if len(args) != 3 or validate_exchange(args[0]) is not None or validate_decimal(args[2]) is not None:
+                    self._notify("Error: Invalid command arguments")
+                    self.notify_balance_limit_set()
                     return
+                exchange = args[0]
+                asset = args[1].upper()
+                amount = float(args[2])
+                exchange_limit_conf = config_var.value[exchange]
+                if exchange_limit_conf is None:
+                    config_var.value.update({asset: {}})
+                self._notify(f"Limit for {asset} on {exchange} exchange set to {amount}")
+                config_var.value[exchange].update({asset: amount})
+                save_to_yml(file_path, config_map)
 
-    async def list_options(self):
-        row = []
-        self._notify(f"List of Option(s) of Balance command\n")
-        for option in OPTIONS:
-            row.append(f"   - {option}: {OPTION_DESCRIPTION[option]}")
-            row.append(f"       e.g. {OPTION_HELP[option]}")
-        self._notify("\n".join(row))
+            elif option == "paper":
+                config_var = config_map[PAPER_ACC_BALANCE_CONFIG]
+                if args is None or len(args) == 0:
+                    safe_ensure_future(self.show_paper_account_balance())
+                    return
+                if len(args) != 2 or validate_decimal(args[1]) is not None:
+                    self._notify("Error: Invalid command arguments")
+                    self.notify_balance_paper_set()
+                    return
+                asset = args[0].upper()
+                amount = float(args[1])
+                asset_config = [c for c in config_var.value if c[0] == asset]
+                if asset_config:
+                    asset_config[0][1] = amount
+                else:
+                    config_var.value.append([asset, amount])
+                self._notify(f"Paper balance for {asset} token set to {amount}")
+                save_to_yml(file_path, config_map)
 
     async def show_balances(self):
         self._notify("Updating balances, please wait...")
@@ -158,8 +171,8 @@ class BalanceCommand:
         exchange_limit_conf: Dict[str, Dict[str, str]] = config_var.value
 
         if not any(list(exchange_limit_conf.values())):
-            self._notify("You have not set any limits. See command details below\n")
-            await self.list_options()
+            self._notify("You have not set any limits.")
+            self.notify_balance_limit_set()
             return
 
         self._notify(f"Balance Limits per exchange...")
@@ -175,5 +188,36 @@ class BalanceCommand:
             else:
                 lines = ["    " + line for line in df.to_string(index=False).split("\n")]
                 self._notify("\n".join(lines))
+        self._notify("\n")
+        return
+
+    async def paper_acccount_balance_df(self, paper_balances: List[List[Any]]):
+        rows = []
+        for balance in paper_balances:
+            rows.append({"Asset": balance[0], "Balance": round(Decimal(balance[1]), 4)})
+        df = pd.DataFrame(data=rows, columns=["Asset", "Balance"])
+        df.sort_values(by=["Asset"], inplace=True)
+        return df
+
+    def notify_balance_limit_set(self):
+        self._notify("To set a balance limit (how much the bot can use): \n"
+                     "    balance limit [EXCHANGE] [ASSET] [AMOUNT]\n"
+                     "e.g. balance limit binance BTC 0.1")
+
+    def notify_balance_paper_set(self):
+        self._notify("To set a paper account balance: \n"
+                     "    balance paper [ASSET] [AMOUNT]\n"
+                     "e.g. balance paper BTC 0.1")
+
+    async def show_paper_account_balance(self):
+        paper_balances = global_config_map[PAPER_ACC_BALANCE_CONFIG].value
+        if not paper_balances:
+            self._notify("You have not set any paper account balance.")
+            self.notify_balance_paper_set()
+            return
+        self._notify("Paper account balances:")
+        df = await self.paper_acccount_balance_df(paper_balances)
+        lines = ["    " + line for line in df.to_string(index=False).split("\n")]
+        self._notify("\n".join(lines))
         self._notify("\n")
         return

--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -33,6 +33,7 @@ class HummingbotCompleter(Completer):
         self._exchange_completer = WordCompleter(EXCHANGES, ignore_case=True)
         self._connect_exchange_completer = WordCompleter(CONNECT_EXCHANGES, ignore_case=True)
         self._export_completer = WordCompleter(["keys", "trades"], ignore_case=True)
+        self._balance_completer = WordCompleter(["limit", "paper"], ignore_case=True)
         self._strategy_completer = WordCompleter(STRATEGIES, ignore_case=True)
         self._py_file_completer = WordCompleter(file_name_list(SCRIPTS_PATH, "py"))
 
@@ -104,6 +105,10 @@ class HummingbotCompleter(Completer):
         text_before_cursor: str = document.text_before_cursor
         return "export" in text_before_cursor
 
+    def _complete_balance_options(self, document: Document) -> bool:
+        text_before_cursor: str = document.text_before_cursor
+        return text_before_cursor.startswith("balance ")
+
     def _complete_trading_pairs(self, document: Document) -> bool:
         return "trading pair" in self.prompt_text
 
@@ -157,6 +162,10 @@ class HummingbotCompleter(Completer):
 
         elif self._complete_export_options(document):
             for c in self._export_completer.get_completions(document, complete_event):
+                yield c
+
+        elif self._complete_balance_options(document):
+            for c in self._balance_completer.get_completions(document, complete_event):
                 yield c
 
         elif self._complete_exchanges(document):

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -2,8 +2,6 @@ import argparse
 from typing import (
     List,
 )
-
-from client.settings import EXCHANGES
 from hummingbot.client.errors import ArgumentParserError
 from hummingbot.client.command.connect_command import OPTIONS as CONNECT_OPTIONS
 
@@ -58,10 +56,9 @@ def load_parser(hummingbot) -> ThrowingArgumentParser:
     help_parser.set_defaults(func=hummingbot.help)
 
     balance_parser = subparsers.add_parser("balance", help=f"Display your asset balances across all connected exchanges")
-    balance_parser.add_argument("option", nargs="?", choices=["limit"], default=None, help="Option for balance configuration")
-    balance_parser.add_argument("exchange", nargs="?", choices=EXCHANGES, default=None, help="Name of Exchange")
-    balance_parser.add_argument("asset", nargs="?", default=None, help="Name of Asset Token")
-    balance_parser.add_argument("amount", nargs="?", default=None, help="Amount to limit")
+    balance_parser.add_argument("option", nargs="?", choices=["limit", "paper"], default=None,
+                                help="Option for balance configuration")
+    balance_parser.add_argument("args", nargs="*")
     balance_parser.set_defaults(func=hummingbot.balance)
 
     config_parser = subparsers.add_parser("config", help="Display the current bot's configuration")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story: 9365


**A description of the changes proposed in the pull request**:
- Add `paper` sub command to `balance`
- when `balance paper`, show existing paper account balance setting
- use `balance paper [ASSET] [BALANCE]` to update balance
