### PR TITLE
Fix / OrderBookTracker trade execution bug

### DIFF
--- a/hummingbot/core/data_type/order_book_tracker.py
+++ b/hummingbot/core/data_type/order_book_tracker.py
@@ -297,7 +297,7 @@ class OrderBookTracker(ABC):
                     price=float(trade_message.content["price"]),
                     amount=float(trade_message.content["amount"]),
                     type=TradeType.SELL if
-                    trade_message.content["trade_type"] == float(TradeType.SELL.value) else TradeType.SELL
+                    trade_message.content["trade_type"] == float(TradeType.SELL.value) else TradeType.BUY
                 ))
 
                 messages_accepted += 1


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue: #1330 
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
As discussed during client meeting, just modified code to evaluate to `TradeType.BUY` if condition doesn't evaluate to True.