### PR TITLE
Bug fix for `OrderBookAssetPriceDelegate.get_price_by_type`

### DIFF
--- a/hummingbot/strategy/pure_market_making/order_book_asset_price_delegate.pyx
+++ b/hummingbot/strategy/pure_market_making/order_book_asset_price_delegate.pyx
@@ -25,4 +25,4 @@ cdef class OrderBookAssetPriceDelegate(AssetPriceDelegate):
         elif price_type is PriceType.MidPrice:
             return self._market.get_mid_price(self._trading_pair)
         elif price_type is PriceType.LastTrade:
-            return self._market.get_order_book(self._trading_pair).last_trade_price
+            return Decimal(self._market.get_order_book(self._trading_pair).last_trade_price)

--- a/test/test_pmm.py
+++ b/test/test_pmm.py
@@ -700,6 +700,10 @@ class PMMUnitTest(unittest.TestCase):
 
         self.assertEqual((bid + ask) / 2, mid_price)
         self.assertEqual(last_trade, Decimal("123"))
+        assert isinstance(bid, Decimal)
+        assert isinstance(ask, Decimal)
+        assert isinstance(mid_price, Decimal)
+        assert isinstance(last_trade, Decimal)
 
     def test_external_exchange_price_source(self):
         strategy = self.one_level_strategy


### PR DESCRIPTION
Fixes a bug where `OrderBookAssetPriceDelegate.get_price_by_type` returns a float instead of a Decimal.

**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)


**Optional**:
- Related Github issue:
- Related Clubhouse Story:


**A description of the changes proposed in the pull request**:
