### PR TITLE
refactor / github actions ci: conda dependency caching + tests only for code changes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: README.md # placeholder file
-          key: ${{ runner.os }}-build-${{ env.CACHE_NUMBER }}-${{ hashFiles('hummingbot/*', 'build/*', '**/*.py', '**/*.py*', '**/*.pxd') }}
+          key: ${{ runner.os }}-build-${{ env.CACHE_NUMBER }}-${{ hashFiles('hummingbot/*', '**/*.py', '**/*.py*', '**/*.pxd') }}
       
       # Remove envs directory if exists to prevent bin/tar restore errors
       - name: Remove envs directory
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increase this value to manually reset cache if setup/environment-linux.yml has not changed
-          CONDA_CACHE_NUMBER: 2
+          CONDA_CACHE_NUMBER: 0
         with:
           path: |
             /home/runner/conda_pkgs_dir/

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -80,3 +80,17 @@ jobs:
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate hummingbot
           nosetests -d -v test/test*.py
+      
+      # Notify results to discord
+      - uses: actions/setup-ruby@v1
+      - name: Send Webhook Notification
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        run: |
+          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+        shell: bash

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: README.md # placeholder file
-          key: ${{ runner.os }}-build-${{ env.CACHE_NUMBER }}-${{ hashFiles('hummingbot/*', '**/*.py', '**/*.py*', '**/*.pxd') }}
+          key: ${{ runner.os }}-build-${{ env.CACHE_NUMBER }}-${{ hashFiles('hummingbot/*', '**/*.py', '**/*.py*', '**/*.pxd', 'test/*') }}
       
       # Remove envs directory if exists to prevent bin/tar restore errors
       - name: Remove envs directory

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,11 +11,42 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+    
+      # Use cache's hashFiles function to check for changes in core code
+      - name: Check for code changes
+        id: program-changes
+        uses: actions/cache@v2
+        env:
+          # Increase this value to manually reset cache if program files have not changed
+          CACHE_NUMBER: 0
+        with:
+          path: README.md # placeholder file
+          key: ${{ runner.os }}-build-${{ env.CACHE_NUMBER }}-${{ hashFiles('hummingbot/*', 'build/*', '**/*.py', '**/*.py*', '**/*.pxd') }}
+      
+      # Remove envs directory if exists to prevent bin/tar restore errors
+      - name: Remove envs directory
+        run: rm -Rf /usr/share/miniconda/envs
+
+      # Check for setup/environmnet-linux.yml changes
+      - name: Cache conda dependencies
+        id: conda-dependencies
+        uses: actions/cache@v2
+        env:
+          # Increase this value to manually reset cache if setup/environment-linux.yml has not changed
+          CONDA_CACHE_NUMBER: 2
+        with:
+          path: |
+            /home/runner/conda_pkgs_dir/
+            /usr/share/miniconda/envs
+          key: ${{ runner.os }}-conda-${{ env.CONDA_CACHE_NUMBER }}-${{ hashFiles('setup/environment-linux.yml') }}
+
+      # Install python/conda to check if core code has changed
       - uses: actions/setup-python@v2
+        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         with:
           python-version: 3.x
-
       - name: Install Miniconda and nose
+        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
           MINICONDA_FILENAME=Miniconda3-latest-Linux-x86_64.sh
@@ -23,19 +54,27 @@ jobs:
           bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda install -c anaconda nose
-
+        
+      # Install hummingbot env if environment-linux.yml has changed
       - name: Install Hummingbot
+        if: steps.conda-dependencies.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           ./install
+
+      # Compile and run tests if code has changed
       - name: Compile Hummingbot
         shell: bash
+        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda info --envs
           conda activate hummingbot
+          conda env export
           ./compile
       - name: Run stable tests
+        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/", etc)

**A description of the changes proposed in the pull request**:

- Refactored to optimize testing

**1) Only hummingbot code changes require compile + stable tests.**

Criteria for determining core code changes:
```
'hummingbot/*', 'bin/*', '**/*.py', '**/*.py*', '**/*.pxd'
```
_@Nullably @vic-en @sdgoh : please confirm that this covers what should trigger build + stable testing_


**2) Changes to `environment-linux.yml` trigger (1) re-install of conda dependencies, and (2) compile + stable tests**

If there are no changes, the `hummingbot` conda env is restored from cache.


**3) Other changes (e.g. docs) do not require any tests and pass immediately**
