### PR TITLE
feat / Bitstamp connector

### DIFF
--- a/conf/__init__.py
+++ b/conf/__init__.py
@@ -41,6 +41,11 @@ mock_api_enabled = os.getenv("MOCK_API_ENABLED")
 binance_api_key = os.getenv("BINANCE_API_KEY")
 binance_api_secret = os.getenv("BINANCE_API_SECRET")
 
+# Bitstamp Tests
+bitstamp_client_id = os.getenv("BITSTAMP_CLIENT_ID")
+bitstamp_api_key = os.getenv("BITSTAMP_API_KEY")
+bitstamp_api_secret = os.getenv("BITSTAMP_API_SECRET")
+
 # Coinbase Pro Tests
 coinbase_pro_api_key = os.getenv("COINBASE_PRO_API_KEY")
 coinbase_pro_secret_key = os.getenv("COINBASE_PRO_SECRET_KEY")

--- a/hummingbot/client/command/connect_command.py
+++ b/hummingbot/client/command/connect_command.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 OPTIONS = {
     "binance",
+    "bitstamp",
     "coinbase_pro",
     "huobi",
     "liquid",

--- a/hummingbot/client/config/fee_overrides_config_map.py
+++ b/hummingbot/client/config/fee_overrides_config_map.py
@@ -16,6 +16,8 @@ def new_fee_config_var(key):
 fee_overrides_config_map = {
     "binance_maker_fee": new_fee_config_var("binance_maker_fee"),
     "binance_taker_fee": new_fee_config_var("binance_taker_fee"),
+    "bitstamp_maker_fee": new_fee_config_var("bitstamp_maker_fee"),
+    "bitstamp_taker_fee": new_fee_config_var("bitstamp_taker_fee"),
     "coinbase_pro_maker_fee": new_fee_config_var("coinbase_pro_maker_fee"),
     "coinbase_pro_taker_fee": new_fee_config_var("coinbase_pro_taker_fee"),
     "huobi_maker_fee": new_fee_config_var("huobi_maker_fee"),

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -120,6 +120,24 @@ global_config_map = {
                   required_if=using_exchange("binance"),
                   is_secure=True,
                   is_connect_key=True),
+    "bitstamp_client_id":
+        ConfigVar(key="bitstamp_client_id",
+                  prompt="Enter your Bitstamp Client ID >>> ",
+                  required_if=using_exchange("bitstamp"),
+                  is_secure=True,
+                  is_connect_key=True),
+    "bitstamp_api_key":
+        ConfigVar(key="bitstamp_api_key",
+                  prompt="Enter your Bitstamp API key >>> ",
+                  required_if=using_exchange("bitstamp"),
+                  is_secure=True,
+                  is_connect_key=True),
+    "bitstamp_api_secret":
+        ConfigVar(key="bitstamp_api_secret",
+                  prompt="Enter your Bitstamp API secret >>> ",
+                  required_if=using_exchange("bitstamp"),
+                  is_secure=True,
+                  is_connect_key=True),
     "coinbase_pro_api_key":
         ConfigVar(key="coinbase_pro_api_key",
                   prompt="Enter your Coinbase API key >>> ",

--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -11,6 +11,7 @@ from hummingbot.core.clock import Clock
 from hummingbot.logger import HummingbotLogger
 from hummingbot.logger.application_warning import ApplicationWarning
 from hummingbot.connector.exchange.binance.binance_market import BinanceMarket
+from hummingbot.connector.exchange.bitstamp.bitstamp_market import BitstampMarket
 from hummingbot.connector.exchange.bittrex.bittrex_market import BittrexMarket
 from hummingbot.connector.exchange.kucoin.kucoin_market import KucoinMarket
 from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_market import CoinbaseProMarket
@@ -234,6 +235,18 @@ class HummingbotApplication(*commands):
                 market = BinanceMarket(
                     binance_api_key,
                     binance_api_secret,
+                    trading_pairs=trading_pairs,
+                    trading_required=self._trading_required
+                )
+
+            elif market_name == "bitstamp":
+                bitstamp_client_id = global_config_map.get("bitstamp_client_id").value
+                bitstamp_api_key = global_config_map.get("bitstamp_api_key").value
+                bitstamp_api_secret = global_config_map.get("bitstamp_api_secret").value
+                market = BitstampMarket(
+                    bitstamp_client_id,
+                    bitstamp_api_key,
+                    bitstamp_api_secret,
                     trading_pairs=trading_pairs,
                     trading_required=self._trading_required
                 )

--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -29,6 +29,7 @@ SCRIPTS_PATH = "scripts/"
 EXCHANGES = {
     "bamboo_relay",
     "binance",
+    "bitstamp",
     "coinbase_pro",
     "huobi",
     "liquid",
@@ -52,6 +53,7 @@ STRATEGIES: List[str] = get_strategy_list()
 EXAMPLE_PAIRS = {
     "bamboo_relay": "ZRX-WETH",
     "binance": "ZRX-ETH",
+    "bitstamp": "ETH-USD",
     "bittrex": "ZRX-ETH",
     "kucoin": "ETH-USDT",
     "coinbase_pro": "ETH-USDC",
@@ -67,6 +69,7 @@ EXAMPLE_PAIRS = {
 EXAMPLE_ASSETS = {
     "bamboo_relay": "ZRX",
     "binance": "ZRX",
+    "bitstamp": "eth",
     "bittrex": "ZRX",
     "kucoin": "ETH",
     "coinbase_pro": "ETH",

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_api_order_book_data_source.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+
+import asyncio
+import aiohttp
+import logging
+from typing import (
+    Any,
+    AsyncIterable,
+    Dict,
+    List,
+    Optional
+)
+import time
+import ujson
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from hummingbot.core.utils.async_utils import safe_gather
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.logger import HummingbotLogger
+from hummingbot.connector.exchange.bitstamp.bitstamp_order_book import BitstampOrderBook
+from hummingbot.connector.exchange.bitstamp.bitstamp_utils import (
+    convert_to_exchange_trading_pair,
+    convert_from_exchange_trading_pair
+)
+
+BITSTAMP_ROOT_URL = "https://www.bitstamp.net/api/v2/"
+ORDER_BOOK_SNAPSHOT_URL = "order_book/"
+TICKER_URL = "ticker/"
+TRADING_PAIRS_URL = "trading-pairs-info/"
+STREAM_URL = "wss://ws.bitstamp.net"
+MAX_RETRIES = 20
+NaN = float("nan")
+
+
+class BitstampAPIOrderBookDataSource(OrderBookTrackerDataSource):
+    MESSAGE_TIMEOUT = 30.0
+    PING_TIMEOUT = 10.0
+
+    _bstpobds_logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._bstpobds_logger is None:
+            cls._bstpobds_logger = logging.getLogger(__name__)
+        return cls._bstpobds_logger
+
+    def __init__(self, trading_pairs: Optional[List[str]] = None):
+        super().__init__(trading_pairs)
+
+    @classmethod
+    async def get_last_traded_prices(cls, trading_pairs: List[str]) -> Dict[str, float]:
+        tasks = [cls.get_last_traded_price(t_pair) for t_pair in trading_pairs]
+        results = await safe_gather(*tasks)
+        return {t_pair: result for t_pair, result in zip(trading_pairs, results)}
+
+    @classmethod
+    async def get_last_traded_price(cls, trading_pair: str) -> float:
+        async with aiohttp.ClientSession() as client:
+            resp = await client.get(
+                f"{BITSTAMP_ROOT_URL}{TICKER_URL}{convert_to_exchange_trading_pair(trading_pair)}/")
+            resp_json = await resp.json()
+            return float(resp_json["last"])
+
+    @staticmethod
+    async def get_snapshot(client: aiohttp.ClientSession, trading_pair: str) -> Dict[str, Any]:
+        order_book_url: str = f"{BITSTAMP_ROOT_URL}{ORDER_BOOK_SNAPSHOT_URL}" \
+                              f"{convert_to_exchange_trading_pair(trading_pair)}/"
+        print(order_book_url)
+        async with client.get(order_book_url) as response:
+            response: aiohttp.ClientResponse = response
+            if response.status != 200:
+                raise IOError(f"Error fetching Bitstamp market snapshot for {trading_pair}. "
+                              f"HTTP status is {response.status}.")
+            data: Dict[str, Any] = await response.json()
+            data = {"trading_pair": trading_pair, **data}
+
+            # Need to add the symbol into the snapshot message for the Kafka message queue.
+            # Because otherwise, there'd be no way for the receiver to know which market the
+            # snapshot belongs to.
+
+            return data
+
+    async def get_new_order_book(self, trading_pair: str) -> OrderBook:
+        async with aiohttp.ClientSession() as client:
+            snapshot: Dict[str, Any] = await self.get_snapshot(client, trading_pair)
+            snapshot_timestamp: float = time.time()
+            snapshot_msg: OrderBookMessage = BitstampOrderBook.snapshot_message_from_exchange(
+                snapshot,
+                snapshot_timestamp,
+                metadata={"trading_pair": trading_pair}
+            )
+            order_book = self.order_book_create_function()
+            order_book.apply_snapshot(snapshot_msg.bids, snapshot_msg.asks, snapshot_msg.update_id)
+            return order_book
+
+    async def _inner_messages(self,
+                              ws: websockets.WebSocketClientProtocol) -> AsyncIterable[str]:
+        # Terminate the recv() loop as soon as the next message timed out, so the outer loop can reconnect.
+        try:
+            while True:
+                try:
+                    msg: str = await asyncio.wait_for(ws.recv(), timeout=self.MESSAGE_TIMEOUT)
+                    yield msg
+                except asyncio.TimeoutError:
+                    try:
+                        pong_waiter = await ws.ping()
+                        await asyncio.wait_for(pong_waiter, timeout=self.PING_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        raise
+        except asyncio.TimeoutError:
+            self.logger().warning("WebSocket ping timed out. Going to reconnect...")
+            return
+        except ConnectionClosed:
+            return
+        finally:
+            await ws.close()
+
+    async def listen_for_trades(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                trading_pairs: List[str] = self._trading_pairs
+                async with websockets.connect(STREAM_URL) as ws:
+                    ws: websockets.WebSocketClientProtocol = ws
+                    for pair in trading_pairs:
+                        subscribe_msg: Dict[str, Any] = {
+                            "event": "bts:subscribe",
+                            "data": {"channel": f"live_trades_{convert_to_exchange_trading_pair(pair)}"}
+                        }
+                        await ws.send(ujson.dumps(subscribe_msg))
+                    async for raw_msg in self._inner_messages(ws):
+                        msg = ujson.loads(raw_msg)
+                        msg_type: str = msg.get("event", None)
+                        if msg_type is None:
+                            raise ValueError(f"Bitstamp Websocket message does not contain an event type - {msg}")
+                        elif msg_type == "bts:subscription_succeeded":
+                            pass
+                        elif msg_type == "trade":
+                            trade_msg: OrderBookMessage = BitstampOrderBook.trade_message_from_exchange(
+                                msg["data"],
+                                metadata={"trading_pair": convert_from_exchange_trading_pair(msg["channel"]
+                                                                                             .split("_")[2])}
+                            )
+                            output.put_nowait(trade_msg)
+                        else:
+                            raise ValueError(
+                                f"Bitstamp Websocket received event type other then trade in trade listener - {msg}")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error with WebSocket connection. Retrying after 30 seconds...",
+                                    exc_info=True)
+                await asyncio.sleep(30.0)
+
+    async def listen_for_order_book_diffs(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                trading_pairs: List[str] = self._trading_pairs
+                async with websockets.connect(STREAM_URL) as ws:
+                    ws: websockets.WebSocketClientProtocol = ws
+                    for pair in trading_pairs:
+                        subscribe_msg: Dict[str, Any] = {
+                            "event": "bts:subscribe",
+                            "data": {"channel": f"diff_order_book_{convert_to_exchange_trading_pair(pair)}"}
+                        }
+                        await ws.send(ujson.dumps(subscribe_msg))
+                    async for raw_msg in self._inner_messages(ws):
+                        msg = ujson.loads(raw_msg)
+                        msg_type: str = msg.get("event", None)
+                        if msg_type is None:
+                            raise ValueError(f"Bitstamp Websocket message does not contain an event type - {msg}")
+                        elif msg_type == "bts:subscription_succeeded":
+                            pass
+                        elif msg_type == "data":
+                            order_book_message: OrderBookMessage = BitstampOrderBook.diff_message_from_exchange(
+                                msg["data"],
+                                time.time(),
+                                metadata={"trading_pair": convert_from_exchange_trading_pair(msg["channel"]
+                                                                                             .split("_")[2])}
+                            )
+                            output.put_nowait(order_book_message)
+                        else:
+                            raise ValueError(
+                                f"Bitstamp Websocket received event type other then data in order book diff listener - "
+                                f"{msg}")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error with WebSocket connection. Retrying after 30 seconds...",
+                                    exc_info=True)
+                await asyncio.sleep(30.0)
+
+    async def listen_for_order_book_snapshots(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                trading_pairs: List[str] = self._trading_pairs
+                async with websockets.connect(STREAM_URL) as ws:
+                    ws: websockets.WebSocketClientProtocol = ws
+                    for pair in trading_pairs:
+                        subscribe_msg: Dict[str, Any] = {
+                            "event": "bts:subscribe",
+                            "data": {"channel": f"order_book_{convert_to_exchange_trading_pair(pair)}"}
+                        }
+                        await ws.send(ujson.dumps(subscribe_msg))
+                    async for raw_msg in self._inner_messages(ws):
+                        msg = ujson.loads(raw_msg)
+                        msg_type: str = msg.get("event", None)
+                        if msg_type is None:
+                            raise ValueError(f"Bitstamp Websocket message does not contain an event type - {msg}")
+                        elif msg_type == "bts:subscription_succeeded":
+                            pass
+                        elif msg_type == "data":
+                            order_book_message: OrderBookMessage = BitstampOrderBook.snapshot_message_from_exchange(
+                                msg["data"],
+                                time.time(),
+                                metadata={"trading_pair": convert_from_exchange_trading_pair(msg["channel"]
+                                                                                             .split("_")[2])}
+                            )
+                            output.put_nowait(order_book_message)
+                        else:
+                            raise ValueError(
+                                f"Bitstamp Websocket received event type other then trade in trade listener - {msg}")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error with WebSocket connection. Retrying after 30 seconds...",
+                                    exc_info=True)
+                await asyncio.sleep(30.0)

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_auth.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_auth.py
@@ -1,0 +1,33 @@
+import hashlib
+import hmac
+from hummingbot.connector.exchange.bitstamp.bitstamp_tracking_nonce import get_tracking_nonce
+from typing import Dict
+
+
+class BitstampAuth:
+    def __init__(self, client_id: str, api_key: str, secret_key: str):
+        self.client_id = client_id
+        self.api_key = api_key
+        self.secret_key = secret_key
+
+    def generate_auth_dict(self) -> Dict[str, str]:
+        """
+        Generates authentication signature and returns it in request parameters
+        :return: a string of request parameters including the signature
+        """
+
+        # Get next nonce
+        api_nonce: str = get_tracking_nonce()
+        # Compile message
+        message: str = api_nonce + self.client_id + self.api_key
+        # Calculate signature
+        api_signature: str = hmac.new(
+            self.secret_key.encode(),
+            message.encode(),
+            hashlib.sha256).hexdigest().upper()
+
+        return {
+            "key": self.api_key,
+            "signature": api_signature,
+            "nonce": api_nonce
+        }

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_in_flight_order.pxd
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_in_flight_order.pxd
@@ -1,0 +1,5 @@
+from hummingbot.connector.in_flight_order_base cimport InFlightOrderBase
+
+cdef class BitstampInFlightOrder(InFlightOrderBase):
+    cdef:
+        public int last_transaction_id

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_in_flight_order.pyx
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_in_flight_order.pyx
@@ -1,0 +1,88 @@
+from decimal import Decimal
+from typing import (
+    Any,
+    Dict
+)
+
+from hummingbot.core.event.events import (
+    OrderType,
+    TradeType
+)
+from hummingbot.connector.in_flight_order_base import InFlightOrderBase
+
+
+cdef class BitstampInFlightOrder(InFlightOrderBase):
+    def __init__(self,
+                 client_order_id: str,
+                 exchange_order_id: str,
+                 trading_pair: str,
+                 order_type: OrderType,
+                 trade_type: TradeType,
+                 price: Decimal,
+                 amount: Decimal,
+                 initial_state: str = "Open"):
+        super().__init__(
+            client_order_id,
+            exchange_order_id,
+            trading_pair,
+            order_type,
+            trade_type,
+            price,
+            amount,
+            initial_state  # Open, Finished, Cancelled
+        )
+        self.last_transaction_id = 0
+
+    @property
+    def is_done(self) -> bool:
+        return self.last_state in {"Finished", "Canceled"}
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.last_state in {"Canceled"}
+
+    @property
+    def is_failure(self) -> bool:
+        return self.last_state in {"Finished"}
+
+    @property
+    def is_open(self) -> bool:
+        return self.last_state in {"Open"}
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> InFlightOrderBase:
+        cdef:
+            BitstampInFlightOrder retval = BitstampInFlightOrder(
+                client_order_id=data["client_order_id"],
+                exchange_order_id=data["exchange_order_id"],
+                trading_pair=data["trading_pair"],
+                order_type=getattr(OrderType, data["order_type"]),
+                trade_type=getattr(TradeType, data["trade_type"]),
+                price=Decimal(data["price"]),
+                amount=Decimal(data["amount"]),
+                initial_state=data["last_state"]
+            )
+        retval.executed_amount_base = Decimal(data["executed_amount_base"])
+        retval.executed_amount_quote = Decimal(data["executed_amount_quote"])
+        retval.fee_asset = data["fee_asset"]
+        retval.fee_paid = Decimal(data["fee_paid"])
+        retval.last_state = data["last_state"]
+        retval.last_transaction_id = data["last_transaction_id"]
+        return retval
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "client_order_id": self.client_order_id,
+            "exchange_order_id": self.exchange_order_id,
+            "trading_pair": self.trading_pair,
+            "order_type": self.order_type.name,
+            "trade_type": self.trade_type.name,
+            "price": str(self.price),
+            "amount": str(self.amount),
+            "executed_amount_base": str(self.executed_amount_base),
+            "executed_amount_quote": str(self.executed_amount_quote),
+            "fee_asset": self.fee_asset,
+            "fee_paid": str(self.fee_paid),
+            "last_state": self.last_state,
+            "last_transaction_id": self.last_transaction_id,
+        }

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_market.pxd
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_market.pxd
@@ -1,0 +1,33 @@
+from libc.stdint cimport int64_t
+
+from hummingbot.connector.exchange_base cimport ExchangeBase
+from hummingbot.core.data_type.transaction_tracker cimport TransactionTracker
+
+
+cdef class BitstampMarket(ExchangeBase):
+    cdef:
+        object _async_scheduler
+        object _data_source_type
+        object _ev_loop
+        object _bitstamp_auth
+        dict _in_flight_orders
+        double _last_poll_timestamp
+        double _last_timestamp
+        object _poll_notifier
+        double _poll_interval
+        object _shared_client
+        public object _status_polling_task
+        dict _trading_rules
+        public object _trading_rules_polling_task
+        TransactionTracker _tx_tracker
+        object _nonce_lock
+
+    cdef c_did_timeout_tx(self, str tracking_id)
+    cdef c_start_tracking_order(self,
+                                str client_order_id,
+                                str exchange_order_id,
+                                str trading_pair,
+                                object order_type,
+                                object trade_type,
+                                object price,
+                                object amount)

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_market.pyx
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_market.pyx
@@ -1,0 +1,862 @@
+import aiohttp
+from aiohttp.test_utils import TestClient
+import asyncio
+import copy
+from decimal import Decimal
+from libc.stdint cimport int64_t
+import logging
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+from urllib.parse import urlencode
+
+from hummingbot.core.clock cimport Clock
+from hummingbot.core.data_type.cancellation_result import CancellationResult
+from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.core.data_type.transaction_tracker import TransactionTracker
+from hummingbot.core.event.events import (
+    MarketEvent,
+    BuyOrderCompletedEvent,
+    SellOrderCompletedEvent,
+    OrderFilledEvent,
+    OrderCancelledEvent,
+    BuyOrderCreatedEvent,
+    SellOrderCreatedEvent,
+    MarketTransactionFailureEvent,
+    MarketOrderFailureEvent,
+    OrderType,
+    TradeType,
+    TradeFee,
+)
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.utils.async_call_scheduler import AsyncCallScheduler
+from hummingbot.core.utils.async_utils import (
+    safe_ensure_future,
+)
+from hummingbot.logger import HummingbotLogger
+from hummingbot.connector.exchange.bitstamp.bitstamp_api_order_book_data_source import BitstampAPIOrderBookDataSource
+from hummingbot.connector.exchange.bitstamp.bitstamp_auth import BitstampAuth
+from hummingbot.connector.exchange.bitstamp.bitstamp_in_flight_order import BitstampInFlightOrder
+from hummingbot.connector.exchange.bitstamp.bitstamp_order_book_tracker import BitstampOrderBookTracker
+from hummingbot.connector.exchange.bitstamp.bitstamp_utils import (
+    convert_from_exchange_trading_pair,
+    convert_to_exchange_trading_pair)
+from hummingbot.connector.trading_rule cimport TradingRule
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
+from hummingbot.core.utils.estimate_fee import estimate_fee
+
+hm_logger = None
+s_decimal_0 = Decimal(0)
+s_decimal_NaN = Decimal("NaN")
+BITSTAMP_ROOT_URL = "https://www.bitstamp.net/api/"
+
+
+class BitstampAPIError(IOError):
+    def __init__(self, error_payload: Dict[str, Any]):
+        super().__init__(str(error_payload))
+        self.error_payload = error_payload
+
+
+cdef class BitstampMarketTransactionTracker(TransactionTracker):
+    cdef:
+        BitstampMarket _owner
+
+    def __init__(self, owner: BitstampMarket):
+        super().__init__()
+        self._owner = owner
+
+    cdef c_did_timeout_tx(self, str tx_id):
+        TransactionTracker.c_did_timeout_tx(self, tx_id)
+        self._owner.c_did_timeout_tx(tx_id)
+
+
+cdef class BitstampMarket(ExchangeBase):
+    MARKET_RECEIVED_ASSET_EVENT_TAG = MarketEvent.ReceivedAsset.value
+    MARKET_BUY_ORDER_COMPLETED_EVENT_TAG = MarketEvent.BuyOrderCompleted.value
+    MARKET_SELL_ORDER_COMPLETED_EVENT_TAG = MarketEvent.SellOrderCompleted.value
+    MARKET_WITHDRAW_ASSET_EVENT_TAG = MarketEvent.WithdrawAsset.value
+    MARKET_ORDER_CANCELLED_EVENT_TAG = MarketEvent.OrderCancelled.value
+    MARKET_TRANSACTION_FAILURE_EVENT_TAG = MarketEvent.TransactionFailure.value
+    MARKET_ORDER_FAILURE_EVENT_TAG = MarketEvent.OrderFailure.value
+    MARKET_ORDER_FILLED_EVENT_TAG = MarketEvent.OrderFilled.value
+    MARKET_BUY_ORDER_CREATED_EVENT_TAG = MarketEvent.BuyOrderCreated.value
+    MARKET_SELL_ORDER_CREATED_EVENT_TAG = MarketEvent.SellOrderCreated.value
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        global hm_logger
+        if hm_logger is None:
+            hm_logger = logging.getLogger(__name__)
+        return hm_logger
+
+    def __init__(self,
+                 bitstamp_client_id: str,
+                 bitstamp_api_key: str,
+                 bitstamp_secret_key: str,
+                 poll_interval: float = 1.0,
+                 trading_pairs: Optional[List[str]] = None,
+                 trading_required: bool = True):
+
+        super().__init__()
+        self._async_scheduler = AsyncCallScheduler(call_interval=0.5)
+        self._ev_loop = asyncio.get_event_loop()
+        self._bitstamp_auth = BitstampAuth(client_id=bitstamp_client_id, api_key=bitstamp_api_key, secret_key=bitstamp_secret_key)
+        self._in_flight_orders = {}
+        self._last_poll_timestamp = 0
+        self._last_timestamp = 0
+        self._order_book_tracker = BitstampOrderBookTracker(
+            trading_pairs=trading_pairs
+        )
+        self._poll_notifier = asyncio.Event()
+        self._poll_interval = poll_interval
+        self._shared_client = None
+        self._status_polling_task = None
+        self._trading_required = trading_required
+        self._trading_rules = {}
+        self._trading_rules_polling_task = None
+        self._tx_tracker = BitstampMarketTransactionTracker(self)
+        self._nonce_lock = asyncio.Lock()
+        self._real_time_balance_update = False
+
+    @property
+    def name(self) -> str:
+        return "bitstamp"
+
+    @property
+    def order_book_tracker(self) -> BitstampOrderBookTracker:
+        return self._order_book_tracker
+
+    @property
+    def order_books(self) -> Dict[str, OrderBook]:
+        return self._order_book_tracker.order_books
+
+    @property
+    def trading_rules(self) -> Dict[str, TradingRule]:
+        return self._trading_rules
+
+    @property
+    def in_flight_orders(self) -> Dict[str, BitstampInFlightOrder]:
+        return self._in_flight_orders
+
+    @property
+    def limit_orders(self) -> List[LimitOrder]:
+        return [
+            in_flight_order.to_limit_order()
+            for in_flight_order in self._in_flight_orders.values()
+        ]
+
+    @property
+    def tracking_states(self) -> Dict[str, Any]:
+        return {
+            key: value.to_json()
+            for key, value in self._in_flight_orders.items()
+        }
+
+    def restore_tracking_states(self, saved_states: Dict[str, Any]):
+        self._in_flight_orders.update({
+            key: BitstampInFlightOrder.from_json(value)
+            for key, value in saved_states.items()
+        })
+
+    @property
+    def shared_client(self) -> str:
+        return self._shared_client
+
+    @shared_client.setter
+    def shared_client(self, client: aiohttp.ClientSession):
+        self._shared_client = client
+
+    cdef c_start(self, Clock clock, double timestamp):
+        self._tx_tracker.c_start(clock, timestamp)
+        ExchangeBase.c_start(self, clock, timestamp)
+
+    cdef c_stop(self, Clock clock):
+        ExchangeBase.c_stop(self, clock)
+        self._async_scheduler.stop()
+
+    async def start_network(self):
+        self._stop_network()
+        self._order_book_tracker.start()
+        self._trading_rules_polling_task = safe_ensure_future(self._trading_rules_polling_loop())
+        if self._trading_required:
+            self._status_polling_task = safe_ensure_future(self._status_polling_loop())
+
+    def _stop_network(self):
+        self._order_book_tracker.stop()
+        if self._status_polling_task is not None:
+            self._status_polling_task.cancel()
+            self._status_polling_task = None
+        if self._trading_rules_polling_task is not None:
+            self._trading_rules_polling_task.cancel()
+            self._trading_rules_polling_task = None
+
+    async def stop_network(self):
+        self._stop_network()
+
+    async def check_network(self) -> NetworkStatus:
+        try:
+            await self._api_request(method="get", path_url="ticker/")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            return NetworkStatus.NOT_CONNECTED
+        return NetworkStatus.CONNECTED
+
+    cdef c_tick(self, double timestamp):
+        cdef:
+            int64_t last_tick = <int64_t>(self._last_timestamp / self._poll_interval)
+            int64_t current_tick = <int64_t>(timestamp / self._poll_interval)
+        ExchangeBase.c_tick(self, timestamp)
+        self._tx_tracker.c_tick(timestamp)
+        if current_tick > last_tick:
+            if not self._poll_notifier.is_set():
+                self._poll_notifier.set()
+        self._last_timestamp = timestamp
+
+    async def _http_client(self) -> aiohttp.ClientSession:
+        if self._shared_client is None:
+            self._shared_client = aiohttp.ClientSession()
+        return self._shared_client
+
+    async def _api_request(self,
+                           method,
+                           path_url,
+                           params: Optional[Dict[str, Any]] = None,
+                           data=None,
+                           is_auth_required: bool = False) -> Dict[str, Any]:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        url = BITSTAMP_ROOT_URL + path_url
+        client = await self._http_client()
+        if is_auth_required:
+            # wait to acquire nonce lock
+            await self._nonce_lock.acquire()
+            if data is None:
+                data = self._bitstamp_auth.generate_auth_dict()
+            else:
+                data.update(self._bitstamp_auth.generate_auth_dict())
+
+        # aiohttp TestClient requires path instead of url
+        if isinstance(client, TestClient):
+            response_coro = client.request(
+                method=method.upper(),
+                path=f"/{path_url}",
+                headers=headers,
+                params=params,
+                data=urlencode(data),
+                timeout=100
+            )
+        else:
+            response_coro = client.request(
+                method=method.upper(),
+                url=url,
+                headers=headers,
+                params=params,
+                data=urlencode(data) if data is not None else None,
+                timeout=100
+            )
+
+        async with response_coro as response:
+            if is_auth_required:
+                # release nonce lock
+                self._nonce_lock.release()
+            if response.status != 200:
+                # parsed_response = await response.json()
+                # if response.status == 403 and ("buy" in url or "sell" in url):
+                #     self.logger().info(f"{method} {url} {data} {parsed_response}")
+                raise IOError(f"Error fetching data from {url} with data {data}. HTTP status is {response.status}.")
+            try:
+                parsed_response = await response.json()
+                # self.logger().info(f"{method} {url} {data} {parsed_response}")
+                if type(parsed_response) is bool:
+                    parsed_response = {"status": parsed_response}
+            except Exception:
+                raise IOError(f"Error parsing data from {url}.")
+            if "error" in parsed_response:
+                if parsed_response["error"] == "Order not found":
+                    return {"id": data["id"]}
+                self.logger().error(f"Error received from {url}. Response is {parsed_response}.")
+                raise BitstampAPIError({"error": parsed_response["error"]})
+            return parsed_response
+
+    async def _update_balances(self):
+        cdef:
+            str path_url = "v2/balance/"
+            dict data
+            dict new_available_balances = {}
+            dict new_balances = {}
+            str asset_name
+            object balance
+
+        data = await self._api_request("post", path_url=path_url, is_auth_required=True)
+        if len(data) > 0:
+            for k in data:
+                asset_name = k.split("_")[0].upper()
+                balance = Decimal(data[k])
+                if balance == s_decimal_0:
+                    continue
+                if "balance" in k:
+                    new_balances[asset_name] = balance
+                if "available" in k:
+                    new_available_balances[asset_name] = balance
+
+            self._account_available_balances.clear()
+            self._account_available_balances = new_available_balances
+            self._account_balances.clear()
+            self._account_balances = new_balances
+
+            self._in_flight_orders_snapshot = {k: copy.copy(v) for k, v in self._in_flight_orders.items()}
+            self._in_flight_orders_snapshot_timestamp = self._current_timestamp
+
+    cdef object c_get_fee(self,
+                          str base_currency,
+                          str quote_currency,
+                          object order_type,
+                          object order_side,
+                          object amount,
+                          object price):
+        is_maker = order_type is OrderType.LIMIT
+        return estimate_fee("bitstamp", is_maker)
+
+    async def _update_trading_rules(self):
+        cdef:
+            # The poll interval for trade rules is 60 seconds.
+            int64_t last_tick = <int64_t>(self._last_timestamp / 60.0)
+            int64_t current_tick = <int64_t>(self._current_timestamp / 60.0)
+        if current_tick > last_tick or len(self._trading_rules) < 1:
+            exchange_info = await self._api_request("get", path_url="v2/trading-pairs-info/")
+            trading_rules_list = self._format_trading_rules(exchange_info)
+            self._trading_rules.clear()
+            for trading_rule in trading_rules_list:
+                self._trading_rules[trading_rule.trading_pair] = trading_rule
+
+    def _format_trading_rules(self, raw_trading_pair_info: List[Dict[str, Any]]) -> List[TradingRule]:
+        cdef:
+            list trading_rules = []
+
+        for info in raw_trading_pair_info:
+            try:
+                if info["trading"] is "Disabled":
+                    continue
+                trading_rules.append(
+                    TradingRule(trading_pair=convert_from_exchange_trading_pair(info["url_symbol"]),
+                                min_price_increment=Decimal(f"1e-{info['counter_decimals']}"),
+                                min_base_amount_increment=Decimal(f"1e-{info['base_decimals']}"),
+                                min_quote_amount_increment=Decimal(f"1e-{info['counter_decimals']}"),
+                                min_notional_size=Decimal(info["minimum_order"].split(" ")[0]))
+                )
+            except Exception:
+                self.logger().error(f"Error parsing the trading pair rule {info}. Skipping.", exc_info=True)
+        return trading_rules
+
+    async def get_order_status(self, exchange_order_id: str) -> Dict[str, Any]:
+        """
+        Example:
+        {
+            "status": "Open" or "Finished"
+            "transactions": [
+                {
+                    "tid": 12344,
+                    "usd": 10000.0,
+                    "price": 10000.0,
+                    "fee": 1.0,
+                    "btc": 1.0,
+                    "datetime": "2019-02-02 10:20:23.000000",
+                    "type": 2 0 - deposit; 1 - withdrawal; 2 - market trade
+                }
+            ]
+        }
+        """
+        path_url = "v2/order_status/"
+        return await self._api_request("post", path_url=path_url, data={"id": exchange_order_id}, is_auth_required=True)
+
+    async def _update_order_status(self):
+        if len(self._in_flight_orders) > 0:
+            tracked_orders = list(self._in_flight_orders.values())
+            for tracked_order in tracked_orders:
+                exchange_order_id = await tracked_order.get_exchange_order_id()
+                try:
+                    order_update = await self.get_order_status(exchange_order_id)
+                except BitstampAPIError as e:
+                    err_code = e.error_payload.get("error")
+                    self.logger().info(f"The order status request for {tracked_order.client_order_id} "
+                                       f"has failed according to order status API. - {err_code}")
+                    self.c_trigger_event(
+                        self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                        MarketOrderFailureEvent(
+                            self._current_timestamp,
+                            tracked_order.client_order_id,
+                            tracked_order.order_type
+                        )
+                    )
+                    continue
+
+                if order_update is None:
+                    self.logger().network(
+                        f"Error fetching status update for the order {tracked_order.client_order_id}: "
+                        f"{order_update}.",
+                        app_warning_msg=f"Could not fetch updates for the order {tracked_order.client_order_id}. "
+                                        f"The order has either been filled or canceled."
+                    )
+                    continue
+
+                order_state = order_update["status"]
+                # possible order states are "Open", "Finished", "Canceled"
+
+                if order_state not in ["Open", "Finished", "Canceled"]:
+                    self.logger().debug(f"Unrecognized order update response - {order_update}")
+
+                tracked_order.last_state = order_state
+
+                for transaction in order_update["transactions"]:
+                    # skip already processed transactions
+                    if transaction["tid"] <= tracked_order.last_transaction_id:
+                        continue
+                    execute_amount_base_diff = abs(Decimal(transaction[tracked_order.base_asset.lower()]))
+                    execute_amount_quote_diff = abs(Decimal(transaction[tracked_order.quote_asset.lower()]))
+
+                    tracked_order.executed_amount_base += execute_amount_base_diff
+                    tracked_order.executed_amount_quote += execute_amount_quote_diff
+                    tracked_order.fee_paid += Decimal(transaction["fee"])
+                    execute_price = Decimal(transaction["price"])
+                    self.logger().info(f"Filled {execute_amount_base_diff} out of {tracked_order.amount} of the "
+                                       f"order {tracked_order.client_order_id}.")
+                    self.c_trigger_event(self.MARKET_ORDER_FILLED_EVENT_TAG, OrderFilledEvent(
+                        self._current_timestamp,
+                        tracked_order.client_order_id,
+                        tracked_order.trading_pair,
+                        tracked_order.trade_type,
+                        tracked_order.order_type,
+                        execute_price,
+                        execute_amount_base_diff,
+                        self.c_get_fee(
+                            tracked_order.base_asset,
+                            tracked_order.quote_asset,
+                            tracked_order.order_type,
+                            tracked_order.trade_type,
+                            execute_price,
+                            execute_amount_base_diff,
+                        ),
+                        exchange_trade_id=transaction["tid"]
+                    ))
+                    tracked_order.last_transaction_id = transaction["tid"]
+
+                if tracked_order.is_open:
+                    continue
+
+                if tracked_order.is_done:
+                    if not tracked_order.is_cancelled:  # Handles "filled" order
+                        self.c_stop_tracking_order(tracked_order.client_order_id)
+                        if tracked_order.trade_type is TradeType.BUY:
+                            self.logger().info(f"The market buy order {tracked_order.client_order_id} has completed "
+                                               f"according to order status API.")
+                            self.c_trigger_event(self.MARKET_BUY_ORDER_COMPLETED_EVENT_TAG,
+                                                 BuyOrderCompletedEvent(self._current_timestamp,
+                                                                        tracked_order.client_order_id,
+                                                                        tracked_order.base_asset,
+                                                                        tracked_order.quote_asset,
+                                                                        tracked_order.fee_asset or tracked_order.base_asset,
+                                                                        tracked_order.executed_amount_base,
+                                                                        tracked_order.executed_amount_quote,
+                                                                        tracked_order.fee_paid,
+                                                                        tracked_order.order_type))
+                        else:
+                            self.logger().info(f"The market sell order {tracked_order.client_order_id} has completed "
+                                               f"according to order status API.")
+                            self.c_trigger_event(self.MARKET_SELL_ORDER_COMPLETED_EVENT_TAG,
+                                                 SellOrderCompletedEvent(self._current_timestamp,
+                                                                         tracked_order.client_order_id,
+                                                                         tracked_order.base_asset,
+                                                                         tracked_order.quote_asset,
+                                                                         tracked_order.fee_asset or tracked_order.quote_asset,
+                                                                         tracked_order.executed_amount_base,
+                                                                         tracked_order.executed_amount_quote,
+                                                                         tracked_order.fee_paid,
+                                                                         tracked_order.order_type))
+                    else:  # Handles "cancelled" or "partial-canceled" order
+                        self.c_stop_tracking_order(tracked_order.client_order_id)
+                        self.logger().info(f"The market order {tracked_order.client_order_id} "
+                                           f"has been cancelled according to order status API.")
+                        self.c_trigger_event(self.MARKET_ORDER_CANCELLED_EVENT_TAG,
+                                             OrderCancelledEvent(self._current_timestamp,
+                                                                 tracked_order.client_order_id))
+
+    async def _status_polling_loop(self):
+        while True:
+            try:
+                self._poll_notifier = asyncio.Event()
+                await self._poll_notifier.wait()
+
+                # Check orders and balances in sequence because of nonce race condition.
+                # Check order status first because this can trigger further hummingbot actions
+                # and is therefore more important then updating balances
+                await self._update_order_status()
+                await self._update_balances()
+
+                self._last_poll_timestamp = self._current_timestamp
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().network("Unexpected error while fetching account updates.",
+                                      exc_info=True,
+                                      app_warning_msg="Could not fetch account updates from Bitstamp. "
+                                                      f"Check API key and network connection. {e}")
+                await asyncio.sleep(0.5)
+
+    async def _trading_rules_polling_loop(self):
+        while True:
+            try:
+                await self._update_trading_rules()
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network("Unexpected error while fetching trading rules.",
+                                      exc_info=True,
+                                      app_warning_msg="Could not fetch new trading rules from Huobi. "
+                                                      "Check network connection.")
+                await asyncio.sleep(0.5)
+
+    @property
+    def status_dict(self) -> Dict[str, bool]:
+        return {
+            "order_books_initialized": self._order_book_tracker.ready,
+            "account_balance": len(self._account_balances) > 0 if self._trading_required else True,
+            "trading_rule_initialized": len(self._trading_rules) > 0
+        }
+
+    @property
+    def ready(self) -> bool:
+        return all(self.status_dict.values())
+
+    def supported_order_types(self):
+        return [OrderType.LIMIT, OrderType.MARKET]
+
+    async def place_order(self,
+                          order_id: str,
+                          trading_pair: str,
+                          amount: Decimal,
+                          is_buy: bool,
+                          order_type: OrderType,
+                          price: Decimal) -> str:
+        path_url = "v2/buy/" if is_buy else "v2/sell/"
+        path_url += f"market/{convert_to_exchange_trading_pair(trading_pair)}/"\
+            if order_type is OrderType.MARKET \
+            else f"/{convert_to_exchange_trading_pair(trading_pair)}/"
+        params = {
+            "amount": f"{amount:f}",
+        }
+        if order_type is OrderType.LIMIT or order_type is OrderType.LIMIT_MAKER:
+            params["price"] = f"{price:f}"
+        exchange_order = await self._api_request(
+            "post",
+            path_url=path_url,
+            data=params,
+            is_auth_required=True
+        )
+        if exchange_order.get("status") == "error":
+            raise BitstampAPIError(exchange_order)
+        return exchange_order["id"]
+
+    async def execute_buy(self,
+                          order_id: str,
+                          trading_pair: str,
+                          amount: Decimal,
+                          order_type: OrderType,
+                          price: Optional[Decimal] = s_decimal_0):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+            object quote_amount
+            object decimal_amount
+            object decimal_price
+            str exchange_order_id
+            object tracked_order
+
+        decimal_amount = self.c_quantize_order_amount(trading_pair, amount)
+        decimal_price = (s_decimal_0
+                         if order_type is OrderType.MARKET
+                         else self.c_quantize_order_price(trading_pair, price))
+        if decimal_amount < trading_rule.min_order_size:
+            raise ValueError(f"Buy order amount {decimal_amount} is lower than the minimum order size "
+                             f"{trading_rule.min_order_size}.")
+        try:
+            exchange_order_id = await self.place_order(order_id, trading_pair, decimal_amount, True, order_type, decimal_price)
+            self.c_start_tracking_order(
+                client_order_id=order_id,
+                exchange_order_id=exchange_order_id,
+                trading_pair=trading_pair,
+                order_type=order_type,
+                trade_type=TradeType.BUY,
+                price=decimal_price,
+                amount=decimal_amount
+            )
+            tracked_order = self._in_flight_orders.get(order_id)
+            if tracked_order is not None:
+                self.logger().info(f"Created {order_type} buy order {order_id} for {decimal_amount} {trading_pair} "
+                                   f"@ {decimal_price}.")
+            self.c_trigger_event(self.MARKET_BUY_ORDER_CREATED_EVENT_TAG,
+                                 BuyOrderCreatedEvent(
+                                     self._current_timestamp,
+                                     order_type,
+                                     trading_pair,
+                                     decimal_amount,
+                                     decimal_price,
+                                     order_id
+                                 ))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.c_stop_tracking_order(order_id)
+            order_type_str = "MARKET" if order_type == OrderType.MARKET else "LIMIT"
+            self.logger().network(
+                f"Error submitting buy {order_type_str} order to Bitstamp for "
+                f"{decimal_amount} {trading_pair} "
+                f"{decimal_price if order_type is OrderType.LIMIT else ''}.",
+                exc_info=True,
+                app_warning_msg=f"Failed to submit buy order to Bitstamp. Check API key and network connection. {e}"
+            )
+            self.c_trigger_event(self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                                 MarketOrderFailureEvent(self._current_timestamp, order_id, order_type))
+
+    cdef str c_buy(self,
+                   str trading_pair,
+                   object amount,
+                   object order_type=OrderType.MARKET,
+                   object price=s_decimal_0,
+                   dict kwargs={}):
+        cdef:
+            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
+            str order_id = f"buy-{trading_pair}-{tracking_nonce}"
+
+        safe_ensure_future(self.execute_buy(order_id, trading_pair, amount, order_type, price))
+        return order_id
+
+    async def execute_sell(self,
+                           order_id: str,
+                           trading_pair: str,
+                           amount: Decimal,
+                           order_type: OrderType,
+                           price: Optional[Decimal] = s_decimal_0):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+            object decimal_amount
+            object decimal_price
+            str exchange_order_id
+            object tracked_order
+
+        decimal_amount = self.quantize_order_amount(trading_pair, amount)
+        decimal_price = (s_decimal_0
+                         if order_type is OrderType.MARKET
+                         else self.c_quantize_order_price(trading_pair, price))
+        if decimal_amount < trading_rule.min_order_size:
+            raise ValueError(f"Sell order amount {decimal_amount} is lower than the minimum order size "
+                             f"{trading_rule.min_order_size}.")
+
+        try:
+            exchange_order_id = await self.place_order(order_id, trading_pair, decimal_amount, False, order_type, decimal_price)
+            self.c_start_tracking_order(
+                client_order_id=order_id,
+                exchange_order_id=exchange_order_id,
+                trading_pair=trading_pair,
+                order_type=order_type,
+                trade_type=TradeType.SELL,
+                price=decimal_price,
+                amount=decimal_amount
+            )
+            tracked_order = self._in_flight_orders.get(order_id)
+            if tracked_order is not None:
+                self.logger().info(f"Created {order_type} sell order {order_id} for {decimal_amount} {trading_pair} "
+                                   f"@ {decimal_price}.")
+            self.c_trigger_event(self.MARKET_SELL_ORDER_CREATED_EVENT_TAG,
+                                 SellOrderCreatedEvent(
+                                     self._current_timestamp,
+                                     order_type,
+                                     trading_pair,
+                                     decimal_amount,
+                                     decimal_price,
+                                     order_id
+                                 ))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.c_stop_tracking_order(order_id)
+            order_type_str = "MARKET" if order_type is OrderType.MARKET else "LIMIT"
+            self.logger().network(
+                f"Error submitting sell {order_type_str} order to Bitstamp for "
+                f"{decimal_amount} {trading_pair} "
+                f"{decimal_price if order_type is OrderType.LIMIT else ''}.",
+                exc_info=True,
+                app_warning_msg=f"Failed to submit sell order to Bitstamp. Check API key and network connection. {e}"
+            )
+            self.c_trigger_event(self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                                 MarketOrderFailureEvent(self._current_timestamp, order_id, order_type))
+
+    cdef str c_sell(self,
+                    str trading_pair,
+                    object amount,
+                    object order_type=OrderType.MARKET,
+                    object price=s_decimal_0,
+                    dict kwargs={}):
+        cdef:
+            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
+            str order_id = f"sell-{trading_pair}-{tracking_nonce}"
+        safe_ensure_future(self.execute_sell(order_id, trading_pair, amount, order_type, price))
+        return order_id
+
+    async def execute_cancel(self, trading_pair: str, order_id: str):
+        try:
+            tracked_order = self._in_flight_orders.get(order_id)
+            if tracked_order is None:
+                raise ValueError(f"Failed to cancel order - {order_id}. Order not found.")
+            path_url = f"v2/cancel_order/"
+            response = await self._api_request("post", path_url=path_url, data={"id": tracked_order.exchange_order_id}, is_auth_required=True)
+
+            if str(response["id"]) == tracked_order.exchange_order_id:
+                self.c_stop_tracking_order(tracked_order.client_order_id)
+                self.logger().info(f"The order {tracked_order.client_order_id} has been cancelled according"
+                                   f" to order status API.")
+                self.c_trigger_event(self.MARKET_ORDER_CANCELLED_EVENT_TAG,
+                                     OrderCancelledEvent(self._current_timestamp,
+                                                         tracked_order.client_order_id))
+        except BitstampAPIError as e:
+            self.logger().network(
+                f"Failed to cancel order {order_id}: {str(e)}",
+                exc_info=True,
+                app_warning_msg=f"Failed to cancel the order {order_id} on Bitstamp. "
+                                f"Check API key and network connection."
+            )
+
+        except Exception as e:
+            self.logger().network(
+                f"Failed to cancel order {order_id}: {str(e)}",
+                exc_info=True,
+                app_warning_msg=f"Failed to cancel the order {order_id} on Bitstamp. "
+                                f"Check API key and network connection."
+            )
+
+    cdef c_cancel(self, str trading_pair, str order_id):
+        safe_ensure_future(self.execute_cancel(trading_pair, order_id))
+        return order_id
+
+    async def cancel_all(self, timeout_seconds: float) -> List[CancellationResult]:
+        open_orders = [o for o in self._in_flight_orders.values() if o.is_open]
+        if len(open_orders) == 0:
+            return []
+        cancel_order_ids = [o.exchange_order_id for o in open_orders]
+        self.logger().debug(f"cancel_order_ids {cancel_order_ids} {open_orders}")
+        path_url = "cancel_all_orders/"
+        cancellation_results = []
+        try:
+            cancel_all_results = await self._api_request(
+                "post",
+                path_url=path_url,
+                is_auth_required=True
+            )
+            for order in open_orders:
+                cancellation_results.append(CancellationResult(order.exchange_order_id, cancel_all_results["status"]))
+        except Exception as e:
+            self.logger().network(
+                f"Failed to cancel all orders: {cancel_order_ids}",
+                exc_info=True,
+                app_warning_msg=f"Failed to cancel all orders on Bitstamp. Check API key and network connection."
+            )
+        return cancellation_results
+
+    cdef OrderBook c_get_order_book(self, str trading_pair):
+        cdef:
+            dict order_books = self._order_book_tracker.order_books
+
+        if trading_pair not in order_books:
+            raise ValueError(f"No order book exists for '{trading_pair}'.")
+        return order_books.get(trading_pair)
+
+    cdef c_did_timeout_tx(self, str tracking_id):
+        self.c_trigger_event(self.MARKET_TRANSACTION_FAILURE_EVENT_TAG,
+                             MarketTransactionFailureEvent(self._current_timestamp, tracking_id))
+
+    cdef c_start_tracking_order(self,
+                                str client_order_id,
+                                str exchange_order_id,
+                                str trading_pair,
+                                object order_type,
+                                object trade_type,
+                                object price,
+                                object amount):
+        self._in_flight_orders[client_order_id] = BitstampInFlightOrder(
+            client_order_id=client_order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=trading_pair,
+            order_type=order_type,
+            trade_type=trade_type,
+            price=price,
+            amount=amount
+        )
+
+    cdef c_stop_tracking_order(self, str order_id):
+        if order_id in self._in_flight_orders:
+            del self._in_flight_orders[order_id]
+
+    cdef object c_get_order_price_quantum(self, str trading_pair, object price):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+        return trading_rule.min_price_increment
+
+    cdef object c_get_order_size_quantum(self, str trading_pair, object order_size):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+        return Decimal(trading_rule.min_base_amount_increment)
+
+    cdef object c_quantize_order_amount(self, str trading_pair, object amount, object price=s_decimal_0):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+            object quantized_amount = ExchangeBase.c_quantize_order_amount(self, trading_pair, amount)
+            object current_price = self.c_get_price(trading_pair, False)
+            object notional_size
+
+        # Check against min_order_size. If not passing check, return 0.
+        if quantized_amount < trading_rule.min_order_size:
+            return s_decimal_0
+
+        # Check against max_order_size. If not passing check, return maximum.
+        if quantized_amount > trading_rule.max_order_size:
+            return trading_rule.max_order_size
+
+        if price == s_decimal_0:
+            notional_size = current_price * quantized_amount
+        else:
+            notional_size = price * quantized_amount
+        # Add 1% as a safety factor in case the prices changed while making the order.
+        if notional_size < trading_rule.min_notional_size * Decimal("1.01"):
+            return s_decimal_0
+
+        return quantized_amount
+
+    def get_price(self, trading_pair: str, is_buy: bool) -> Decimal:
+        return self.c_get_price(trading_pair, is_buy)
+
+    def buy(self, trading_pair: str, amount: Decimal, order_type=OrderType.MARKET,
+            price: Decimal = s_decimal_NaN, **kwargs) -> str:
+        return self.c_buy(trading_pair, amount, order_type, price, kwargs)
+
+    def sell(self, trading_pair: str, amount: Decimal, order_type=OrderType.MARKET,
+             price: Decimal = s_decimal_NaN, **kwargs) -> str:
+        return self.c_sell(trading_pair, amount, order_type, price, kwargs)
+
+    def cancel(self, trading_pair: str, client_order_id: str):
+        return self.c_cancel(trading_pair, client_order_id)
+
+    def get_fee(self,
+                base_currency: str,
+                quote_currency: str,
+                order_type: OrderType,
+                order_side: TradeType,
+                amount: Decimal,
+                price: Decimal = s_decimal_NaN) -> TradeFee:
+        return self.c_get_fee(base_currency, quote_currency, order_type, order_side, amount, price)
+
+    def get_order_book(self, trading_pair: str) -> OrderBook:
+        return self.c_get_order_book(trading_pair)

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_order_book.pxd
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_order_book.pxd
@@ -1,0 +1,4 @@
+from hummingbot.core.data_type.order_book cimport OrderBook
+
+cdef class BitstampOrderBook(OrderBook):
+    pass

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_order_book.pyx
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_order_book.pyx
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+import logging
+from typing import (
+    Dict,
+    Optional
+)
+import ujson
+
+from aiokafka import ConsumerRecord
+from sqlalchemy.engine import RowProxy
+
+from hummingbot.logger import HummingbotLogger
+from hummingbot.core.event.events import TradeType
+from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.core.data_type.order_book_message import (
+    OrderBookMessage,
+    OrderBookMessageType
+)
+
+_bob_logger = None
+
+
+cdef class BitstampOrderBook(OrderBook):
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        global _bob_logger
+        if _bob_logger is None:
+            _bob_logger = logging.getLogger(__name__)
+        return _bob_logger
+
+    @classmethod
+    def snapshot_message_from_exchange(cls,
+                                       msg: Dict[str, any],
+                                       timestamp: float,
+                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": msg["trading_pair"],
+            "update_id": int(msg["timestamp"]),
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=timestamp)
+
+    @classmethod
+    def diff_message_from_exchange(cls,
+                                   msg: Dict[str, any],
+                                   timestamp: Optional[float] = None,
+                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        ts = int(msg["timestamp"])
+        return OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": msg["trading_pair"],
+            "update_id": ts,
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=timestamp)
+
+    @classmethod
+    def snapshot_message_from_db(cls, record: RowProxy, metadata: Optional[Dict] = None) -> OrderBookMessage:
+        msg = record["json"] if type(record["json"])==dict else ujson.loads(record["json"])
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": msg["trading_pair"],
+            "update_id": msg["lastUpdateId"],
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=record["timestamp"] * 1e-3)
+
+    @classmethod
+    def diff_message_from_db(cls, record: RowProxy, metadata: Optional[Dict] = None) -> OrderBookMessage:
+        msg = ujson.loads(record["json"])  # Binance json in DB is TEXT
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": msg["s"],
+            "update_id": msg["u"],
+            "bids": msg["b"],
+            "asks": msg["a"]
+        }, timestamp=record["timestamp"] * 1e-3)
+
+    @classmethod
+    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+        msg = ujson.loads(record.value.decode("utf-8"))
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": msg["trading_pair"],
+            "update_id": msg["lastUpdateId"],
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=record.timestamp * 1e-3)
+
+    @classmethod
+    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+        msg = ujson.loads(record.value.decode("utf-8"))
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": msg["s"],
+            "update_id": msg["u"],
+            "bids": msg["b"],
+            "asks": msg["a"],
+
+        }, timestamp=record.timestamp * 1e-3)
+
+    @classmethod
+    def trade_message_from_db(cls, record: RowProxy, metadata: Optional[Dict] = None):
+        msg = record["json"]
+        if metadata:
+            msg.update(metadata)
+        ts = record.timestamp
+        return OrderBookMessage(OrderBookMessageType.TRADE, {
+            "trading_pair": msg["s"],
+            "trade_type": float(TradeType.SELL.value) if msg["m"] else float(TradeType.BUY.value),
+            "trade_id": msg["t"],
+            "update_id": ts,
+            "price": msg["p"],
+            "amount": msg["q"]
+        }, timestamp=ts * 1e-3)
+
+    @classmethod
+    def trade_message_from_exchange(cls, msg: Dict[str, any], metadata: Optional[Dict] = None):
+        if metadata:
+            msg.update(metadata)
+        ts = float(msg["timestamp"])
+        return OrderBookMessage(OrderBookMessageType.TRADE, {
+            "trading_pair": msg["trading_pair"],
+            "trade_type": float(TradeType.SELL.value) if msg["type"] == 1 else float(TradeType.BUY.value),
+            "trade_id": msg["id"],
+            "update_id": ts,
+            "price": msg["price"],
+            "amount": msg["amount"]
+        }, timestamp=ts)
+
+    @classmethod
+    def from_snapshot(cls, msg: OrderBookMessage) -> "OrderBook":
+        retval = BitstampOrderBook()
+        retval.apply_snapshot(msg.bids, msg.asks, msg.update_id)
+        return retval

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_order_book_tracker.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_order_book_tracker.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+import asyncio
+from collections import deque, defaultdict
+import logging
+import time
+from typing import (
+    Deque,
+    Dict,
+    List,
+    Optional
+)
+
+from hummingbot.logger import HummingbotLogger
+from hummingbot.core.data_type.order_book_tracker import OrderBookTracker
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.connector.exchange.bitstamp.bitstamp_api_order_book_data_source import BitstampAPIOrderBookDataSource
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+
+
+class BitstampOrderBookTracker(OrderBookTracker):
+    _bstobt_logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._bstobt_logger is None:
+            cls._bstobt_logger = logging.getLogger(__name__)
+        return cls._bstobt_logger
+
+    def __init__(self,
+                 trading_pairs: Optional[List[str]] = None):
+        super().__init__(
+            data_source=BitstampAPIOrderBookDataSource(trading_pairs),
+            trading_pairs=trading_pairs
+        )
+        self._order_book_diff_stream: asyncio.Queue = asyncio.Queue()
+        self._order_book_snapshot_stream: asyncio.Queue = asyncio.Queue()
+        self._ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        self._saved_message_queues: Dict[str, Deque[OrderBookMessage]] = defaultdict(lambda: deque(maxlen=1000))
+
+    @property
+    def exchange_name(self) -> str:
+        return "bitstamp"
+
+    @property
+    def data_source(self) -> OrderBookTrackerDataSource:
+        if not self._data_source:
+            self._data_source = BitstampAPIOrderBookDataSource(trading_pairs=self._trading_pairs)
+        return self._data_source
+
+    @data_source.setter
+    def data_source(self, data_source):
+        self._data_source = data_source
+
+    async def _order_book_diff_router(self):
+        """
+        Route the real-time order book diff messages to the correct order book.
+        """
+        last_message_timestamp: float = time.time()
+        messages_queued: int = 0
+        messages_accepted: int = 0
+        messages_rejected: int = 0
+
+        while True:
+            try:
+                ob_message: OrderBookMessage = await self._order_book_diff_stream.get()
+                trading_pair: str = ob_message.trading_pair
+
+                if trading_pair not in self._tracking_message_queues:
+                    messages_queued += 1
+                    # Save diff messages received before snapshots are ready
+                    self._saved_message_queues[trading_pair].append(ob_message)
+                    continue
+                message_queue: asyncio.Queue = self._tracking_message_queues[trading_pair]
+                # Check the order book's initial update ID. If it's larger, don't bother.
+                order_book: OrderBook = self._order_books[trading_pair]
+
+                if order_book.snapshot_uid > ob_message.update_id:
+                    messages_rejected += 1
+                    continue
+                await message_queue.put(ob_message)
+                messages_accepted += 1
+
+                # Log some statistics.
+                now: float = time.time()
+                if int(now / 60.0) > int(last_message_timestamp / 60.0):
+                    self.logger().debug("Diff messages processed: %d, rejected: %d, queued: %d",
+                                        messages_accepted,
+                                        messages_rejected,
+                                        messages_queued)
+                    messages_accepted = 0
+                    messages_rejected = 0
+                    messages_queued = 0
+
+                last_message_timestamp = now
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network(
+                    "Unexpected error routing order book messages.",
+                    exc_info=True,
+                    app_warning_msg="Unexpected error routing order book messages. Retrying after 5 seconds."
+                )
+                await asyncio.sleep(5.0)
+
+    async def _track_single_book(self, trading_pair: str):
+        past_diffs_window: Deque[OrderBookMessage] = deque()
+        self._past_diffs_windows[trading_pair] = past_diffs_window
+
+        message_queue: asyncio.Queue = self._tracking_message_queues[trading_pair]
+        order_book: OrderBook = self._order_books[trading_pair]
+        last_message_timestamp: float = time.time()
+        diff_messages_accepted: int = 0
+
+        while True:
+            try:
+                message: OrderBookMessage = None
+                saved_messages: Deque[OrderBookMessage] = self._saved_message_queues[trading_pair]
+
+                # Process saved messages first if there are any
+                if len(saved_messages) > 0:
+                    message = saved_messages.popleft()
+                else:
+                    message = await message_queue.get()
+
+                if message.type is OrderBookMessageType.DIFF:
+                    order_book.apply_diffs(message.bids, message.asks, message.update_id)
+                    past_diffs_window.append(message)
+                    while len(past_diffs_window) > self.PAST_DIFF_WINDOW_SIZE:
+                        past_diffs_window.popleft()
+                    diff_messages_accepted += 1
+
+                    # Output some statistics periodically.
+                    now: float = time.time()
+                    if int(now / 60.0) > int(last_message_timestamp / 60.0):
+                        self.logger().debug("Processed %d order book diffs for %s.",
+                                            diff_messages_accepted, trading_pair)
+                        diff_messages_accepted = 0
+                    last_message_timestamp = now
+                elif message.type is OrderBookMessageType.SNAPSHOT:
+                    past_diffs: List[OrderBookMessage] = list(past_diffs_window)
+                    order_book.restore_from_snapshot_and_diffs(message, past_diffs)
+                    self.logger().debug("Processed order book snapshot for %s.", trading_pair)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network(
+                    f"Unexpected error tracking order book for {trading_pair}.",
+                    exc_info=True,
+                    app_warning_msg="Unexpected error tracking order book. Retrying after 5 seconds."
+                )
+                await asyncio.sleep(5.0)

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_tracking_nonce.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_tracking_nonce.py
@@ -1,0 +1,9 @@
+import time
+
+_last_tracking_nonce: int = int(time.time() * 1e6)
+
+
+def get_tracking_nonce() -> str:
+    global _last_tracking_nonce
+    _last_tracking_nonce += 1
+    return str(_last_tracking_nonce)

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_utils.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_utils.py
@@ -1,0 +1,28 @@
+import re
+from typing import (
+    Optional,
+    Tuple)
+
+TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(usd|eur|btc|gbp|pax)$")
+
+
+def split_trading_pair(trading_pair: str) -> Optional[Tuple[str, str]]:
+    try:
+        m = TRADING_PAIR_SPLITTER.match(trading_pair)
+        return m.group(1), m.group(2)
+    # Exceptions are now logged as warnings in trading pair fetcher
+    except Exception:
+        return None
+
+
+def convert_from_exchange_trading_pair(exchange_trading_pair: str) -> Optional[str]:
+    if split_trading_pair(exchange_trading_pair) is None:
+        return None
+    # Bitstamp uses lowercase (btcusd)
+    base_asset, quote_asset = split_trading_pair(exchange_trading_pair)
+    return f"{base_asset.upper()}-{quote_asset.upper()}"
+
+
+def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
+    # Bitstamp uses lowercase (btcusd)
+    return hb_trading_pair.replace("-", "").lower()

--- a/hummingbot/core/utils/estimate_fee.py
+++ b/hummingbot/core/utils/estimate_fee.py
@@ -5,6 +5,7 @@ from hummingbot.client.config.fee_overrides_config_map import fee_overrides_conf
 default_cex_estimate = {
     # exchange: [maker_fee, taker_fee]
     "binance": [0.1, 0.1],
+    "bitstamp": [0.5, 0.5],
     "bittrex": [0.25, 0.25],
     "coinbase_pro": [0.5, 0.5],
     "huobi": [0.2, 0.2],

--- a/hummingbot/core/utils/market_mid_price.py
+++ b/hummingbot/core/utils/market_mid_price.py
@@ -5,6 +5,7 @@ import cachetools.func
 
 
 BINANCE_PRICE_URL = "https://api.binance.com/api/v3/ticker/bookTicker"
+BITSTAMP_PRICE_URL = "https://www.bitstamp.net/api/v2/ticker/"
 KUCOIN_PRICE_URL = "https://api.kucoin.com/api/v1/market/allTickers"
 LIQUID_PRICE_URL = "https://api.liquid.com/products"
 BITTREX_PRICE_URL = "https://api.bittrex.com/api/v1.1/public/getmarketsummaries"
@@ -41,6 +42,16 @@ def binance_mid_price(trading_pair: str) -> Optional[Decimal]:
         if trading_pair == pair and record["bidPrice"] is not None and record["askPrice"] is not None:
             result = (Decimal(record["bidPrice"]) + Decimal(record["askPrice"])) / Decimal("2")
             break
+    return result
+
+
+@cachetools.func.ttl_cache(ttl=10)
+def bitstamp_mid_price(trading_pair: str) -> Optional[Decimal]:
+    from hummingbot.connector.exchange.bitstamp.bitstamp_utils import convert_to_exchange_trading_pair
+    pair = convert_to_exchange_trading_pair(trading_pair)
+    resp = requests.get(url=f"{BITSTAMP_PRICE_URL}{pair}/")
+    record = resp.json()
+    result = (Decimal(record["bid"]) + Decimal(record["ask"])) / Decimal("2")
     return result
 
 

--- a/hummingbot/core/utils/trading_pair_fetcher.py
+++ b/hummingbot/core/utils/trading_pair_fetcher.py
@@ -14,6 +14,7 @@ from .async_utils import safe_ensure_future
 from .ssl_client_request import SSLClientRequest
 
 BINANCE_ENDPOINT = "https://api.binance.com/api/v1/exchangeInfo"
+BITSTAMP_ENDPOINT = "https://www.bitstamp.net/api/v2/trading-pairs-info/"
 RADAR_RELAY_ENDPOINT = "https://api.radarrelay.com/v3/markets"
 BAMBOO_RELAY_ENDPOINT = "https://rest.bamboorelay.com/main/0x/markets"
 COINBASE_PRO_ENDPOINT = "https://api.pro.coinbase.com/products/"
@@ -79,6 +80,31 @@ class TradingPairFetcher:
 
         except Exception:
             # Do nothing if the request fails -- there will be no autocomplete for binance trading pairs
+            pass
+
+        return []
+
+    async def fetch_bitstamp_trading_pairs(self) -> List[str]:
+        try:
+            from hummingbot.connector.exchange.bitstamp.bitstamp_utils import convert_from_exchange_trading_pair
+
+            client: aiohttp.ClientSession = self.http_client()
+            async with client.get(BITSTAMP_ENDPOINT, timeout=API_CALL_TIMEOUT) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    raw_trading_pairs = [d["url_symbol"] for d in data if d["trading"] == "Enabled"]
+                    trading_pair_list: List[str] = []
+                    for raw_trading_pair in raw_trading_pairs:
+                        converted_trading_pair: Optional[str] = \
+                            convert_from_exchange_trading_pair(raw_trading_pair)
+                        if converted_trading_pair is not None:
+                            trading_pair_list.append(converted_trading_pair)
+                        else:
+                            self.logger().debug(f"Could not parse the trading pair {raw_trading_pair}, skipping it...")
+                    return trading_pair_list
+
+        except Exception:
+            # Do nothing if the request fails -- there will be no autocomplete for bitstamo trading pairs
             pass
 
         return []
@@ -335,7 +361,8 @@ class TradingPairFetcher:
                  self.fetch_kraken_trading_pairs(),
                  self.fetch_radar_relay_trading_pairs(),
                  self.fetch_eterbase_trading_pairs(),
-                 self.fetch_crypto_com_trading_pairs()]
+                 self.fetch_crypto_com_trading_pairs(),
+                 self.fetch_bitstamp_trading_pairs()]
 
         # Radar Relay has not yet been migrated to a new version
         # Endpoint needs to be updated after migration
@@ -354,6 +381,7 @@ class TradingPairFetcher:
             "kraken": results[8],
             "radar_relay": results[9],
             "eterbase": results[10],
-            "crypto_com": results[11]
+            "crypto_com": results[11],
+            "bitstamo": results[12],
         }
         self.ready = True

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -12,6 +12,10 @@ bamboo_relay_pre_emptive_soft_cancels: false
 binance_api_key: null
 binance_api_secret: null
 
+bitstamp_client_id: null
+bitstamp_api_key: null
+bitstamp_api_secret: null
+
 bittrex_api_key: null
 bittrex_secret_key: null
 

--- a/hummingbot/user/user_balances.py
+++ b/hummingbot/user/user_balances.py
@@ -1,4 +1,5 @@
 from hummingbot.connector.exchange.binance.binance_market import BinanceMarket
+from hummingbot.connector.exchange.bitstamp.bitstamp_market import BitstampMarket
 from hummingbot.connector.exchange.bittrex.bittrex_market import BittrexMarket
 from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_market import CoinbaseProMarket
 from hummingbot.connector.exchange.huobi.huobi_market import HuobiMarket
@@ -26,6 +27,8 @@ class UserBalances:
         market = None
         if exchange == "binance":
             market = BinanceMarket(*api_details)
+        elif exchange == "bitstamp":
+            market = BitstampMarket(*api_details)
         elif exchange == "bittrex":
             market = BittrexMarket(api_details[0], api_details[1])
         elif exchange == "coinbase_pro":

--- a/test/integration/test_bitstamp_api_order_book_data_source.py
+++ b/test/integration/test_bitstamp_api_order_book_data_source.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+from hummingbot.connector.exchange.bitstamp.bitstamp_api_order_book_data_source import BitstampAPIOrderBookDataSource
+from hummingbot.core.data_type.order_book_tracker_entry import OrderBookTrackerEntry
+import asyncio
+import aiohttp
+import logging
+from typing import (
+    Dict,
+    Optional,
+    Any,
+)
+import unittest
+
+
+class BitstampAPIOrderBookDataSourceUnitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.order_book_data_source: BitstampAPIOrderBookDataSource = BitstampAPIOrderBookDataSource()
+
+    def run_async(self, task):
+        return self.ev_loop.run_until_complete(task)
+
+    async def get_snapshot(self, trading_pair):
+        async with aiohttp.ClientSession() as client:
+            try:
+                snapshot: Dict[str, Any] = await self.order_book_data_source.get_snapshot(client, trading_pair)
+                return snapshot
+            except Exception:
+                return None
+
+    def test_get_snapshot(self):
+        snapshot: Optional[Dict[str, Any]] = self.run_async(self.get_snapshot("ETH-USD"))
+        self.assertIsNotNone(snapshot)
+        self.assertIn(snapshot["trading_pair"], ["ETH-USD"])
+
+    def test_get_last_traded_prices(self):
+        last_traded_prices: Dict[str, float] = self.run_async(
+            self.order_book_data_source.get_last_traded_prices(["ETH-USD", "BTC-USD"])
+        )
+        self.assertIn("ETH-USD", last_traded_prices)
+        self.assertIn("BTC-USD", last_traded_prices)
+
+    def test_get_tracking_pairs(self):
+        tracking_pairs: Dict[str, OrderBookTrackerEntry] = self.run_async(
+            self.order_book_data_source.get_last_traded_prices(["ETH-USD", "BTC-USD"])
+        )
+        self.assertIsInstance(tracking_pairs["ethusd"], OrderBookTrackerEntry)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_bitstamp_market.py
+++ b/test/integration/test_bitstamp_market.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python
+import logging
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+from hummingbot.logger.struct_logger import METRICS_LOG_LEVEL
+
+import asyncio
+import contextlib
+from decimal import Decimal
+import os
+import time
+from typing import (
+    List,
+    Optional
+)
+import unittest
+
+import conf
+from hummingbot.core.clock import (
+    Clock,
+    ClockMode
+)
+from hummingbot.core.event.event_logger import EventLogger
+from hummingbot.core.event.events import (
+    MarketEvent,
+    BuyOrderCompletedEvent,
+    SellOrderCompletedEvent,
+    OrderFilledEvent,
+    OrderCancelledEvent,
+    BuyOrderCreatedEvent,
+    SellOrderCreatedEvent,
+    TradeFee,
+    TradeType,
+)
+from hummingbot.core.utils.async_utils import (
+    safe_ensure_future,
+    safe_gather,
+)
+from hummingbot.connector.exchange.bitstamp.bitstamp_market import BitstampMarket
+from hummingbot.core.event.events import OrderType
+from hummingbot.connector.markets_recorder import MarketsRecorder
+from hummingbot.model.market_state import MarketState
+from hummingbot.model.order import Order
+from hummingbot.model.sql_connection_manager import (
+    SQLConnectionManager,
+    SQLConnectionType
+)
+from hummingbot.model.trade_fill import TradeFill
+from hummingbot.client.config.fee_overrides_config_map import fee_overrides_config_map
+
+CLIENT_ID = conf.bitstamp_client_id
+API_KEY = conf.bitstamp_api_key
+API_SECRET = conf.bitstamp_api_secret
+logging.basicConfig(level=METRICS_LOG_LEVEL)
+
+
+class BitstampMarketUnitTest(unittest.TestCase):
+    events: List[MarketEvent] = [
+        MarketEvent.ReceivedAsset,
+        MarketEvent.BuyOrderCompleted,
+        MarketEvent.SellOrderCompleted,
+        MarketEvent.WithdrawAsset,
+        MarketEvent.OrderFilled,
+        MarketEvent.OrderCancelled,
+        MarketEvent.TransactionFailure,
+        MarketEvent.BuyOrderCreated,
+        MarketEvent.SellOrderCreated,
+        MarketEvent.OrderCancelled
+    ]
+
+    market: BitstampMarket
+    market_logger: EventLogger
+    stack: contextlib.ExitStack
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.clock: Clock = Clock(ClockMode.REALTIME)
+        cls.market: BitstampMarket = BitstampMarket(
+            CLIENT_ID,
+            API_KEY,
+            API_SECRET,
+            trading_pairs=["ETH-BTC"],
+        )
+        cls.clock.add_iterator(cls.market)
+        cls.stack = contextlib.ExitStack()
+        cls._clock = cls.stack.enter_context(cls.clock)
+        cls.ev_loop.run_until_complete(cls.wait_til_ready())
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.stack.close()
+
+    @classmethod
+    async def wait_til_ready(cls):
+        while True:
+            now = time.time()
+            next_iteration = now // 1.0 + 1
+            if cls.market.ready:
+                break
+            else:
+                await cls._clock.run_til(next_iteration)
+            await asyncio.sleep(1.0)
+
+    def setUp(self):
+        self.db_path: str = realpath(join(__file__, "../bitstamp_test.sqlite"))
+        try:
+            os.unlink(self.db_path)
+        except FileNotFoundError:
+            pass
+
+        self.market_logger = EventLogger()
+        for event_tag in self.events:
+            self.market.add_listener(event_tag, self.market_logger)
+
+    def tearDown(self):
+        for event_tag in self.events:
+            self.market.remove_listener(event_tag, self.market_logger)
+        self.market_logger = None
+
+    async def run_parallel_async(self, *tasks):
+        future: asyncio.Future = safe_ensure_future(safe_gather(*tasks))
+        while not future.done():
+            now = time.time()
+            next_iteration = now // 1.0 + 1
+            await self._clock.run_til(next_iteration)
+            await asyncio.sleep(0.5)
+        return future.result()
+
+    def run_parallel(self, *tasks):
+        return self.ev_loop.run_until_complete(self.run_parallel_async(*tasks))
+
+    def test_get_fee(self):
+        limit_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.LIMIT, TradeType.BUY, 1, 10)
+        self.assertGreater(limit_fee.percent, 0)
+        self.assertEqual(len(limit_fee.flat_fees), 0)
+        market_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.MARKET, TradeType.BUY, 1)
+        self.assertGreater(market_fee.percent, 0)
+        self.assertEqual(len(market_fee.flat_fees), 0)
+        sell_trade_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.LIMIT, TradeType.SELL, 1, 10)
+        self.assertGreater(sell_trade_fee.percent, 0)
+        self.assertEqual(len(sell_trade_fee.flat_fees), 0)
+
+    def test_fee_overrides_config(self):
+        fee_overrides_config_map["bitstamp_taker_fee"].value = None
+        taker_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.MARKET, TradeType.BUY, Decimal(1),
+                                                  Decimal('0.1'))
+        self.assertAlmostEqual(Decimal("0.005"), taker_fee.percent)
+        fee_overrides_config_map["bitstamp_taker_fee"].value = Decimal('0.1')
+        taker_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.MARKET, TradeType.BUY, Decimal(1),
+                                                  Decimal('0.1'))
+        self.assertAlmostEqual(Decimal("0.001"), taker_fee.percent)
+        fee_overrides_config_map["bitstamp_maker_fee"].value = None
+        maker_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.LIMIT, TradeType.BUY, Decimal(1),
+                                                  Decimal('0.1'))
+        self.assertAlmostEqual(Decimal("0.005"), maker_fee.percent)
+        fee_overrides_config_map["bitstamp_maker_fee"].value = Decimal('0.5')
+        maker_fee: TradeFee = self.market.get_fee("ETH", "USD", OrderType.LIMIT, TradeType.BUY, Decimal(1),
+                                                  Decimal('0.1'))
+        self.assertAlmostEqual(Decimal("0.005"), maker_fee.percent)
+
+    def place_order(self, is_buy, trading_pair, amount, order_type, price):
+        if is_buy:
+            order_id = self.market.buy(trading_pair, amount, order_type, price)
+        else:
+            order_id = self.market.sell(trading_pair, amount, order_type, price)
+        return order_id
+
+    def cancel_order(self, trading_pair, order_id):
+        self.market.cancel(trading_pair, order_id)
+
+    def test_limit_buy(self):
+        trading_pair = "ETH-BTC"
+
+        amount: Decimal = Decimal("0.05")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        current_bid_price: Decimal = self.market.get_price(trading_pair, True)
+        bid_price: Decimal = current_bid_price + Decimal("0.05") * current_bid_price
+        quantize_bid_price: Decimal = self.market.quantize_order_price(trading_pair, bid_price)
+
+        order_id = self.place_order(True, trading_pair, quantized_amount, OrderType.LIMIT, quantize_bid_price)
+        [order_completed_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCompletedEvent))
+        order_completed_event: BuyOrderCompletedEvent = order_completed_event
+        trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
+                                                if isinstance(t, OrderFilledEvent)]
+        base_amount_traded: Decimal = sum(t.amount for t in trade_events)
+        quote_amount_traded: Decimal = sum(t.amount * t.price for t in trade_events)
+
+        self.assertTrue([evt.order_type == OrderType.LIMIT for evt in trade_events])
+        self.assertEqual(order_id, order_completed_event.order_id)
+        self.assertAlmostEqual(quantized_amount, order_completed_event.base_asset_amount)
+        self.assertEqual("ETH", order_completed_event.base_asset)
+        self.assertEqual("BTC", order_completed_event.quote_asset)
+        self.assertAlmostEqual(base_amount_traded, order_completed_event.base_asset_amount)
+        self.assertAlmostEqual(quote_amount_traded, order_completed_event.quote_asset_amount)
+        self.assertGreater(order_completed_event.fee_amount, Decimal(0))
+        self.assertTrue(any([isinstance(event, BuyOrderCreatedEvent) and event.order_id == order_id
+                             for event in self.market_logger.event_log]))
+        # Reset the logs
+        self.market_logger.clear()
+
+    def test_limit_sell(self):
+        trading_pair = "ethusd"
+        amount: Decimal = Decimal("0.6")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        current_ask_price: Decimal = self.market.get_price(trading_pair, False)
+        ask_price: Decimal = current_ask_price - Decimal("0.05") * current_ask_price
+        quantize_ask_price: Decimal = self.market.quantize_order_price(trading_pair, ask_price)
+
+        order_id = self.place_order(False, trading_pair, amount, OrderType.LIMIT, quantize_ask_price)
+        [order_completed_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCompletedEvent))
+        order_completed_event: SellOrderCompletedEvent = order_completed_event
+        trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
+                                                if isinstance(t, OrderFilledEvent)]
+        base_amount_traded = sum(t.amount for t in trade_events)
+        quote_amount_traded = sum(t.amount * t.price for t in trade_events)
+
+        self.assertTrue([evt.order_type == OrderType.LIMIT for evt in trade_events])
+        self.assertEqual(order_id, order_completed_event.order_id)
+        self.assertAlmostEqual(quantized_amount, order_completed_event.base_asset_amount)
+        self.assertEqual("eth", order_completed_event.base_asset)
+        self.assertEqual("usd", order_completed_event.quote_asset)
+        self.assertAlmostEqual(base_amount_traded, order_completed_event.base_asset_amount)
+        self.assertAlmostEqual(quote_amount_traded, order_completed_event.quote_asset_amount)
+        self.assertGreater(order_completed_event.fee_amount, Decimal(0))
+        self.assertTrue(any([isinstance(event, SellOrderCreatedEvent) and event.order_id == order_id
+                             for event in self.market_logger.event_log]))
+        # Reset the logs
+        self.market_logger.clear()
+
+    def test_market_buy(self):
+        trading_pair = "ETH-USD"
+        amount: Decimal = Decimal("0.6")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        order_id = self.place_order(True, trading_pair, quantized_amount, OrderType.MARKET, 0)
+        [buy_order_completed_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCompletedEvent))
+        buy_order_completed_event: BuyOrderCompletedEvent = buy_order_completed_event
+        trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
+                                                if isinstance(t, OrderFilledEvent)]
+        base_amount_traded: Decimal = sum(t.amount for t in trade_events)
+        quote_amount_traded: Decimal = sum(t.amount * t.price for t in trade_events)
+
+        self.assertTrue([evt.order_type == OrderType.MARKET for evt in trade_events])
+        self.assertEqual(order_id, buy_order_completed_event.order_id)
+        self.assertAlmostEqual(quantized_amount, buy_order_completed_event.base_asset_amount, places=4)
+        self.assertEqual("eth", buy_order_completed_event.base_asset)
+        self.assertEqual("usd", buy_order_completed_event.quote_asset)
+        self.assertAlmostEqual(base_amount_traded, buy_order_completed_event.base_asset_amount, places=4)
+        self.assertAlmostEqual(quote_amount_traded, buy_order_completed_event.quote_asset_amount, places=4)
+        self.assertGreater(buy_order_completed_event.fee_amount, Decimal(0))
+        self.assertTrue(any([isinstance(event, BuyOrderCreatedEvent) and event.order_id == order_id
+                             for event in self.market_logger.event_log]))
+        # Reset the logs
+        self.market_logger.clear()
+
+    def test_market_sell(self):
+        trading_pair = "ETH-USD"
+        amount: Decimal = Decimal("0.6")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        order_id = self.place_order(False, trading_pair, amount, OrderType.MARKET, 0)
+        [sell_order_completed_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCompletedEvent))
+        sell_order_completed_event: SellOrderCompletedEvent = sell_order_completed_event
+        trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
+                                                if isinstance(t, OrderFilledEvent)]
+        base_amount_traded = sum(t.amount for t in trade_events)
+        quote_amount_traded = sum(t.amount * t.price for t in trade_events)
+
+        self.assertTrue([evt.order_type == OrderType.MARKET for evt in trade_events])
+        self.assertEqual(order_id, sell_order_completed_event.order_id)
+        self.assertAlmostEqual(quantized_amount, sell_order_completed_event.base_asset_amount)
+        self.assertEqual("eth", sell_order_completed_event.base_asset)
+        self.assertEqual("usd", sell_order_completed_event.quote_asset)
+        self.assertAlmostEqual(base_amount_traded, sell_order_completed_event.base_asset_amount)
+        self.assertAlmostEqual(quote_amount_traded, sell_order_completed_event.quote_asset_amount)
+        self.assertGreater(sell_order_completed_event.fee_amount, Decimal(0))
+        self.assertTrue(any([isinstance(event, SellOrderCreatedEvent) and event.order_id == order_id
+                             for event in self.market_logger.event_log]))
+        # Reset the logs
+        self.market_logger.clear()
+
+    def test_cancel_order(self):
+        trading_pair = "ethusd"
+
+        current_bid_price: Decimal = self.market.get_price(trading_pair, True)
+        amount: Decimal = Decimal("0.5")
+
+        bid_price: Decimal = current_bid_price - Decimal("0.1") * current_bid_price
+        quantize_bid_price: Decimal = self.market.quantize_order_price(trading_pair, bid_price)
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        order_id = self.place_order(True, trading_pair, quantized_amount, OrderType.LIMIT, quantize_bid_price)
+        [order_created_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
+
+        self.cancel_order(trading_pair, order_id)
+        [order_cancelled_event] = self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+        order_cancelled_event: OrderCancelledEvent = order_cancelled_event
+        self.assertEqual(order_cancelled_event.order_id, order_id)
+
+    def test_cancel_all(self):
+        trading_pair = "ethusd"
+
+        current_bid_price: Decimal = self.market.get_price(trading_pair, True)
+        current_ask_price: Decimal = self.market.get_price(trading_pair, False)
+
+        bid_price: Decimal = current_bid_price - Decimal("0.1") * current_bid_price
+        ask_price: Decimal = current_ask_price + Decimal("0.1") * current_ask_price
+        amount: Decimal = Decimal("0.6")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        quantize_bid_price: Decimal = self.market.quantize_order_price(trading_pair, bid_price)
+        quantize_ask_price: Decimal = self.market.quantize_order_price(trading_pair, ask_price)
+
+        self.place_order(True, trading_pair, quantized_amount, OrderType.LIMIT, quantize_bid_price)
+        self.place_order(False, trading_pair, quantized_amount, OrderType.LIMIT, quantize_ask_price)
+        self.run_parallel(asyncio.sleep(1))
+        [cancellation_results] = self.run_parallel(self.market.cancel_all(5))
+        for cr in cancellation_results:
+            # can't test order_id because place_order returns
+            # internal order id, but CancellationResult holds
+            # exchange order id
+            # self.assertIn(cr.order_id, [order_id1, order_id2])
+            self.assertEqual(cr.success, True)
+
+    def test_orders_saving_and_restoration(self):
+        config_path: str = "test_config"
+        strategy_name: str = "test_strategy"
+        trading_pair: str = "ethusd"
+        sql: SQLConnectionManager = SQLConnectionManager(SQLConnectionType.TRADE_FILLS, db_path=self.db_path)
+        order_id: Optional[str] = None
+        recorder: MarketsRecorder = MarketsRecorder(sql, [self.market], config_path, strategy_name)
+        recorder.start()
+
+        try:
+            self.assertEqual(0, len(self.market.tracking_states))
+
+            # Try to put limit buy order for 0.5 ETH, and watch for order creation event.
+            current_bid_price: Decimal = self.market.get_price(trading_pair, True)
+            bid_price: Decimal = current_bid_price * Decimal("0.8")
+            quantize_bid_price: Decimal = self.market.quantize_order_price(trading_pair, bid_price)
+
+            amount: Decimal = Decimal("0.5")
+            quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+            order_id = self.place_order(True, trading_pair, quantized_amount, OrderType.LIMIT, quantize_bid_price)
+            [order_created_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
+            order_created_event: BuyOrderCreatedEvent = order_created_event
+            self.assertEqual(order_id, order_created_event.order_id)
+
+            # Verify tracking states
+            self.assertEqual(1, len(self.market.tracking_states))
+            self.assertEqual(order_id, list(self.market.tracking_states.keys())[0])
+
+            # Verify orders from recorder
+            recorded_orders: List[Order] = recorder.get_orders_for_config_and_market(config_path, self.market)
+            self.assertEqual(1, len(recorded_orders))
+            self.assertEqual(order_id, recorded_orders[0].id)
+
+            # Verify saved market states
+            saved_market_states: MarketState = recorder.get_market_states(config_path, self.market)
+            self.assertIsNotNone(saved_market_states)
+            self.assertIsInstance(saved_market_states.saved_state, dict)
+            self.assertGreater(len(saved_market_states.saved_state), 0)
+
+            # Close out the current market and start another market.
+            self.clock.remove_iterator(self.market)
+            for event_tag in self.events:
+                self.market.remove_listener(event_tag, self.market_logger)
+            self.market: BitstampMarket = BitstampMarket(
+                bitstamp_client_id=CLIENT_ID,
+                bitstamp_api_key=API_KEY,
+                bitstamp_secret_key=API_SECRET,
+                trading_pairs=["ethusd", "btcusd"]
+            )
+            for event_tag in self.events:
+                self.market.add_listener(event_tag, self.market_logger)
+            recorder.stop()
+            recorder = MarketsRecorder(sql, [self.market], config_path, strategy_name)
+            recorder.start()
+            saved_market_states = recorder.get_market_states(config_path, self.market)
+            self.clock.add_iterator(self.market)
+            self.assertEqual(0, len(self.market.limit_orders))
+            self.assertEqual(0, len(self.market.tracking_states))
+            self.market.restore_tracking_states(saved_market_states.saved_state)
+            self.assertEqual(1, len(self.market.limit_orders))
+            self.assertEqual(1, len(self.market.tracking_states))
+
+            # Cancel the order and verify that the change is saved.
+            self.cancel_order(trading_pair, order_id)
+            self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+            order_id = None
+            self.assertEqual(0, len(self.market.limit_orders))
+            self.assertEqual(0, len(self.market.tracking_states))
+            saved_market_states = recorder.get_market_states(config_path, self.market)
+            self.assertEqual(0, len(saved_market_states.saved_state))
+        finally:
+            if order_id is not None:
+                self.market.cancel(trading_pair, order_id)
+                self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+
+            recorder.stop()
+            os.unlink(self.db_path)
+
+    def test_order_fill_record(self):
+        config_path: str = "test_config"
+        strategy_name: str = "test_strategy"
+        trading_pair: str = "ethusd"
+        sql: SQLConnectionManager = SQLConnectionManager(SQLConnectionType.TRADE_FILLS, db_path=self.db_path)
+        order_id: Optional[str] = None
+        recorder: MarketsRecorder = MarketsRecorder(sql, [self.market], config_path, strategy_name)
+        recorder.start()
+
+        try:
+            # Try to buy 0.6 ETH from the exchange, and watch for completion event.
+            amount: Decimal = Decimal("0.6")
+            order_id = self.place_order(True, trading_pair, amount, OrderType.MARKET, 0)
+            [buy_order_completed_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCompletedEvent))
+
+            # Reset the logs
+            self.market_logger.clear()
+
+            # Try to sell back the same amount of ETH to the exchange, and watch for completion event.
+            amount = buy_order_completed_event.base_asset_amount
+            order_id = self.place_order(False, trading_pair, amount, OrderType.MARKET, 0)
+            [sell_order_completed_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCompletedEvent))
+
+            # Query the persisted trade logs
+            trade_fills: List[TradeFill] = recorder.get_trades_for_config(config_path)
+            self.assertEqual(2, len(trade_fills))
+            buy_fills: List[TradeFill] = [t for t in trade_fills if t.trade_type == "BUY"]
+            sell_fills: List[TradeFill] = [t for t in trade_fills if t.trade_type == "SELL"]
+            self.assertEqual(1, len(buy_fills))
+            self.assertEqual(1, len(sell_fills))
+
+            order_id = None
+
+        finally:
+            if order_id is not None:
+                self.market.cancel(trading_pair, order_id)
+                self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+
+            recorder.stop()
+            os.unlink(self.db_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/integration/test_bitstamp_order_book_tracker.py
+++ b/test/integration/test_bitstamp_order_book_tracker.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+import math
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+from hummingbot.core.event.event_logger import EventLogger
+from hummingbot.core.event.events import OrderBookEvent, OrderBookTradeEvent, TradeType
+
+from hummingbot.connector.exchange.bitstamp.bitstamp_order_book_tracker import BitstampOrderBookTracker
+import asyncio
+import logging
+from typing import (
+    Dict,
+    Optional,
+    List,
+)
+import unittest
+
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.utils.async_utils import (
+    safe_ensure_future,
+    safe_gather,
+)
+
+
+class BitstampOrderBookTrackerUnitTest(unittest.TestCase):
+    order_book_tracker: Optional[BitstampOrderBookTracker] = None
+    events: List[OrderBookEvent] = [
+        OrderBookEvent.TradeEvent
+    ]
+    trading_pairs: List[str] = [
+        "BTC-USD",
+        "ETH-BTC"
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.order_book_tracker: BitstampOrderBookTracker = BitstampOrderBookTracker(
+            trading_pairs=cls.trading_pairs)
+        cls.order_book_tracker_task: asyncio.Task = safe_ensure_future(cls.order_book_tracker.start())
+        cls.ev_loop.run_until_complete(cls.wait_til_tracker_ready())
+
+    @classmethod
+    async def wait_til_tracker_ready(cls):
+        while True:
+            if len(cls.order_book_tracker.order_books) > 0:
+                print("Initialized real-time order books.")
+                return
+            await asyncio.sleep(1)
+
+    async def run_parallel_async(self, *tasks):
+        future: asyncio.Future = safe_ensure_future(safe_gather(*tasks))
+        while not future.done():
+            await asyncio.sleep(1.0)
+        return future.result()
+
+    def run_parallel(self, *tasks):
+        return self.ev_loop.run_until_complete(self.run_parallel_async(*tasks))
+
+    def setUp(self):
+        self.event_logger = EventLogger()
+        for event_tag in self.events:
+            for trading_pair, order_book in self.order_book_tracker.order_books.items():
+                order_book.add_listener(event_tag, self.event_logger)
+
+    def test_order_book_trade_event_emission(self):
+        """
+        Test if order book tracker is able to retrieve order book trade message from exchange and
+        emit order book trade events after correctly parsing the trade messages
+        """
+        self.run_parallel(self.event_logger.wait_for(OrderBookTradeEvent))
+        for ob_trade_event in self.event_logger.event_log:
+            self.assertTrue(type(ob_trade_event) == OrderBookTradeEvent)
+            self.assertTrue(ob_trade_event.trading_pair in self.trading_pairs)
+            self.assertTrue(type(ob_trade_event.timestamp) == float)
+            self.assertTrue(type(ob_trade_event.amount) == float)
+            self.assertTrue(type(ob_trade_event.price) == float)
+            self.assertTrue(type(ob_trade_event.type) == TradeType)
+            self.assertTrue(math.ceil(math.log10(ob_trade_event.timestamp)) == 10)
+            self.assertTrue(ob_trade_event.amount > 0)
+            self.assertTrue(ob_trade_event.price > 0)
+
+    def test_tracker_integrity(self):
+        # Wait 5 seconds to process some diffs.
+        self.ev_loop.run_until_complete(asyncio.sleep(10.0))
+        order_books: Dict[str, OrderBook] = self.order_book_tracker.order_books
+        btcusd_book: OrderBook = order_books["BTC-USD"]
+        ethbtc_book: OrderBook = order_books["ETH-BTC"]
+        self.assertGreaterEqual(btcusd_book.get_price_for_volume(True, 10).result_price,
+                                btcusd_book.get_price(True))
+        self.assertLessEqual(btcusd_book.get_price_for_volume(False, 10).result_price,
+                             btcusd_book.get_price(False))
+        self.assertGreaterEqual(ethbtc_book.get_price_for_volume(True, 100).result_price,
+                                ethbtc_book.get_price(True))
+        self.assertLessEqual(ethbtc_book.get_price_for_volume(False, 100).result_price,
+                             ethbtc_book.get_price(False))
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implemented market connector for Bitstamp exchange. The old Market base implemented first, then refactored to the new exchange base, so methods are implemented in cython. Integration tests are implemented and are passing if run one by one. I did not bother with using 2 markets in integration tests. Mock tests are not implemented yet so testing in production is required.
