### PR TITLE
Revert "docs / update fee override"

### DIFF
--- a/documentation/docs/advanced/fee-overrides.md
+++ b/documentation/docs/advanced/fee-overrides.md
@@ -36,28 +36,16 @@ bittrex_taker_fee:
 
 kucoin_maker_fee:
 kucoin_taker_fee:
-
-crypto_com_maker_fee:
-crypto_com_taker_fee:
-
-bitfinex_maker_fee:
-bitfinex_taker_fee:
-
 kraken_maker_fee:
 kraken_taker_fee:
-
 eterbase_maker_fee:
 eterbase_taker_fee:
-
 dolomite_maker_fee_amount:
 dolomite_taker_fee_amount:
-
 bamboo_relay_maker_fee_amount:
 bamboo_relay_taker_fee_amount:
-
 radar_relay_maker_fee_amount:
 radar_relay_taker_fee_amount:
-
 ```
 
 !!! note

--- a/documentation/docs/connectors/loopring.md
+++ b/documentation/docs/connectors/loopring.md
@@ -54,3 +54,4 @@ By default, trading fees are 0% for market makers and 0.20% for takers on Loopri
 
 - [Fee Schedule](https://loopring.io/document/fees)
 
+For users who are on discounted fees (VIP level 1 and above) can override the default fees used in the Hummingbot client by following our guide for [Fee Overrides](/advanced/fee-overrides/).

--- a/hummingbot/templates/conf_fee_overrides_TEMPLATE.yml
+++ b/hummingbot/templates/conf_fee_overrides_TEMPLATE.yml
@@ -31,18 +31,3 @@ crypto_com_taker_fee:
 
 bitfinex_maker_fee:
 bitfinex_taker_fee:
-
-kraken_maker_fee:
-kraken_taker_fee:
-
-eterbase_maker_fee:
-eterbase_taker_fee:
-
-dolomite_maker_fee_amount:
-dolomite_taker_fee_amount:
-
-bamboo_relay_maker_fee_amount:
-bamboo_relay_taker_fee_amount:
-
-radar_relay_maker_fee_amount:
-radar_relay_taker_fee_amount:


### PR DESCRIPTION
Reverts CoinAlpha/hummingbot#2438 that caused errors in `development` branch.