### PR TITLE
Fix / remote logger initialization

### DIFF
--- a/hummingbot/logger/log_server_client.py
+++ b/hummingbot/logger/log_server_client.py
@@ -24,8 +24,6 @@ class LogServerClient(NetworkBase):
     def get_instance(cls, log_server_url: str = "https://api.coinalpha.com/reporting-proxy/") -> "LogServerClient":
         if cls._lsc_shared_instance is None:
             cls._lsc_shared_instance = LogServerClient(log_server_url=log_server_url)
-        if not cls._lsc_shared_instance.started:
-            cls._lsc_shared_instance.start()
         return cls._lsc_shared_instance
 
     @classmethod


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**After creating this PR, please make sure:**

- [ ] You link the related GitHub issue or ticket

**A description of the changes proposed in the pull request**:
Calling network start in the property field raised a `RuntimeWarning: coroutine 'NetworkBase._check_network_loop' was never awaited`, the start function should only be called once in log server client when remote log request starts coming in.
