### PR TITLE
[v0.33] Fix / paper trade check on balancer and binance perpetual

### DIFF
--- a/hummingbot/client/command/status_command.py
+++ b/hummingbot/client/command/status_command.py
@@ -216,6 +216,19 @@ class StatusCommand:
             for offline_market in offline_markets:
                 self._notify(f"  - Connector check: {offline_market} is currently offline.")
             return False
+
+        # Paper trade mode is currently not available for connectors other than exchanges.
+        # Todo: This check is hard coded at the moment, when we get a clearer direction on how we should handle this,
+        # this section will need updating.
+        if global_config_map.get("paper_trade_enabled").value:
+            if "balancer" in required_exchanges and \
+                    str(global_config_map.get("ethereum_chain_name").value).lower() != "kovan":
+                self._notify("Error: Paper trade mode is not available on balancer at the moment.")
+                return False
+            if "binance_perpetual" in required_exchanges:
+                self._notify("Error: Paper trade mode is not available on binance_perpetual at the moment.")
+                return False
+
         self.application_warning()
         self._notify("  - All checks: Confirmed.")
         return True

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -166,7 +166,7 @@ def get_eth_wallet_private_key() -> Optional[str]:
 def get_erc20_token_addresses(tokens: List[str]) -> Dict[str, str]:
     chain = global_config_map.get("ethereum_chain_name").value
     address_file_path = TOKEN_ADDRESSES_FILE_PATH
-    if chain is not None and chain != "MAIN_NET":
+    if chain is not None and chain.lower() == "kovan":
         address_file_path = TOKEN_ADDRESSES_FILE_PATH.replace(".json", f"_{chain.lower()}.json")
     with open(address_file_path) as f:
         try:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ def main():
             "wallet/ethereum/zero_ex/*.json",
             "wallet/ethereum/token_abi/*.json",
             "wallet/ethereum/erc20_tokens.json",
+            "wallet/ethereum/erc20_tokens_kovan.json",
             "VERSION",
             "templates/*TEMPLATE.yml"
         ],


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**After creating this PR, please make sure:**

- [ ] You link the related GitHub issue or ticket

**A description of the changes proposed in the pull request**:
- Since we don't have paper trade connector for connectors other than exchanges, let's stop the user from starting the strategy when balancer and binance perpetual are set up (doesn't apply to kovan and testnet).
- Also fix ethereum_chain_name check, this should fix the #2562
