### PR TITLE
(fix) Correct docker container port mapping for node

### DIFF
--- a/installation/docker-commands/create-gateway.sh
+++ b/installation/docker-commands/create-gateway.sh
@@ -153,7 +153,7 @@ create_instance () {
  # Launch a new instance of hummingbot
  docker run -d \
  --name $GATEWAY_INSTANCE_NAME \
- -p 127.0.0.1:$PORT:5000 \
+ -p 127.0.0.1:$PORT:$PORT \
  --env-file $ENV_FILE \
  -e CERT_PASSPHRASE="$PASSWORD" \
  --mount "type=bind,source=$FOLDER,destination=/usr/src/app/certs/" \

--- a/installation/docker-commands/create.sh
+++ b/installation/docker-commands/create.sh
@@ -42,7 +42,7 @@ printf "%30s %5s\n" "Main folder path:" "$PWD/$FOLDER"
 printf "%30s %5s\n" "Config files:" "├── $FOLDER/hummingbot_conf"
 printf "%30s %5s\n" "Log files:" "├── $FOLDER/hummingbot_logs"
 printf "%30s %5s\n" "Trade and data files:" "├── $FOLDER/hummingbot_data"
-printf "%30s %5s\n" "Scripts files:" "└── $FOLDER/hummingbot_scripts"
+printf "%30s %5s\n" "Scripts files:" "├── $FOLDER/hummingbot_scripts"
 printf "%30s %5s\n" "Cert files:" "└── $FOLDER/hummingbot_certs"
 echo
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

- Bug: #2568 

Fix Gateway API server port mapping other than 5000. The script fix will pass correct port number instead of 5000 for the docker container's node server running port.
