### PR TITLE
[v0.33] Fix / incorrect sslcert path for win mac binary

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -21,8 +21,8 @@ ENV WALLET=${WALLET}
 ENV CONFIG_PASSWORD=${CONFIG_PASSWORD}
 
 # Create mount points
-RUN mkdir /conf /logs /data /scripts
-VOLUME /conf /logs /data /scripts
+RUN mkdir /conf /logs /data /scripts /certs
+VOLUME /conf /logs /data /scripts /certs
 
 # Copy files
 COPY bin/ bin/

--- a/hummingbot/client/command/generate_certs_command.py
+++ b/hummingbot/client/command/generate_certs_command.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 from hummingbot.core.utils.async_utils import safe_ensure_future
-from hummingbot.core.utils.ssl_cert import certs_files_exist, create_self_sign_certs, cert_path
+from hummingbot.core.utils.ssl_cert import certs_files_exist, create_self_sign_certs
+from hummingbot import cert_path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/hummingbot/core/utils/ssl_cert.py
+++ b/hummingbot/core/utils/ssl_cert.py
@@ -9,7 +9,6 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from hummingbot import cert_path
 
-CERT_FILE_PATH = cert_path()
 CERT_SUBJECT = [
     x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'localhost'),
     x509.NameAttribute(NameOID.COMMON_NAME, 'localhost'),
@@ -19,7 +18,7 @@ SAN_DNS = [x509.DNSName('localhost')]
 VALIDITY_DURATION = 365
 
 
-def generate_private_key(filename, password):
+def generate_private_key(password, filepath):
     """
     Generate Private Key
     """
@@ -35,7 +34,7 @@ def generate_private_key(filename, password):
         algorithm = serialization.BestAvailableEncryption(password.encode("utf-8"))
 
     # Write key to cert
-    filepath = join(CERT_FILE_PATH, filename)
+    # filepath = join(CERT_FILE_PATH, filename)
     with open(filepath, "wb") as key_file:
         key_file.write(
             private_key.private_bytes(
@@ -48,7 +47,7 @@ def generate_private_key(filename, password):
     return private_key
 
 
-def generate_public_key(private_key, filename):
+def generate_public_key(private_key, filepath):
     """
     Generate Public Key
     """
@@ -83,14 +82,14 @@ def generate_public_key(private_key, filename):
     )
 
     # Write key to cert
-    filepath = join(CERT_FILE_PATH, filename)
+    # filepath = join(CERT_FILE_PATH, filename)
     with open(filepath, "wb") as cert_file:
         cert_file.write(public_key.public_bytes(serialization.Encoding.PEM))
 
     return public_key
 
 
-def generate_csr(private_key, filename):
+def generate_csr(private_key, filepath):
     """
     Generate CSR (Certificate Signing Request)
     """
@@ -108,14 +107,14 @@ def generate_csr(private_key, filename):
 
     csr = builder.sign(private_key, hashes.SHA256(), default_backend())
 
-    filepath = join(CERT_FILE_PATH, filename)
+    # filepath = join(CERT_FILE_PATH, filename)
     with open(filepath, "wb") as csr_file:
         csr_file.write(csr.public_bytes(serialization.Encoding.PEM))
 
     return csr
 
 
-def sign_csr(csr, ca_public_key, ca_private_key, filename):
+def sign_csr(csr, ca_public_key, ca_private_key, filepath):
     """
     Sign CSR with CA public & private keys & generate a verified public key
     """
@@ -144,7 +143,7 @@ def sign_csr(csr, ca_public_key, ca_private_key, filename):
             backend=default_backend(),
         )
 
-        filepath = join(CERT_FILE_PATH, filename)
+        # filepath = join(CERT_FILE_PATH, filename)
         with open(filepath, "wb") as key_file:
             key_file.write(public_key.public_bytes(serialization.Encoding.PEM))
 
@@ -168,7 +167,7 @@ def certs_files_exist() -> bool:
                       server_key_filename, server_cert_filename,
                       client_key_filename, client_cert_filename]
 
-    file_list = listdir(CERT_FILE_PATH)
+    file_list = listdir(cert_path())
     return all(elem in file_list for elem in required_certs)
 
 
@@ -176,33 +175,45 @@ def create_self_sign_certs(pass_phase: str):
     """
     Create self-sign CA Cert
     """
+    CERT_FILE_PATH = cert_path()
+
+    filepath_list = {
+        'ca_key': join(CERT_FILE_PATH, ca_key_filename),
+        'ca_cert': join(CERT_FILE_PATH, ca_cert_filename),
+        'server_key': join(CERT_FILE_PATH, server_key_filename),
+        'server_cert': join(CERT_FILE_PATH, server_cert_filename),
+        'server_csr': join(CERT_FILE_PATH, server_csr_filename),
+        'client_key': join(CERT_FILE_PATH, client_key_filename),
+        'client_cert': join(CERT_FILE_PATH, client_cert_filename),
+        'client_csr': join(CERT_FILE_PATH, client_csr_filename)
+    }
 
     # Create CA Private & Public Keys for signing
-    ca_private_key = generate_private_key(ca_key_filename, pass_phase)
-    generate_public_key(ca_private_key, ca_cert_filename)
+    ca_private_key = generate_private_key(pass_phase, filepath_list['ca_key'])
+    generate_public_key(ca_private_key, filepath_list['ca_cert'])
 
     # Create Server Private & Public Keys for signing
-    server_private_key = generate_private_key(server_key_filename, pass_phase)
+    server_private_key = generate_private_key(pass_phase, filepath_list['server_key'])
     # Create CSR
-    generate_csr(server_private_key, server_csr_filename)
+    generate_csr(server_private_key, filepath_list['server_csr'])
     # Load CSR
-    server_csr_file = open(join(CERT_FILE_PATH, server_csr_filename), 'rb')
+    server_csr_file = open(filepath_list['server_csr'], 'rb')
     server_csr = x509.load_pem_x509_csr(server_csr_file.read(), default_backend())
 
     # Create Client CSR
     # local certificate must be unencrypted. Currently, Requests does not support using encrypted keys.
-    client_private_key = generate_private_key(client_key_filename, None)
+    client_private_key = generate_private_key(None, filepath_list['client_key'])
     # Create CSR
-    generate_csr(client_private_key, client_csr_filename)
+    generate_csr(client_private_key, filepath_list['client_csr'])
     # Load CSR
-    client_csr_file = open(join(CERT_FILE_PATH, client_csr_filename), 'rb')
+    client_csr_file = open(filepath_list['client_csr'], 'rb')
     client_csr = x509.load_pem_x509_csr(client_csr_file.read(), default_backend())
 
     # Load CA public key
-    ca_cert_file = open(join(CERT_FILE_PATH, ca_cert_filename), 'rb')
+    ca_cert_file = open(filepath_list['ca_cert'], 'rb')
     ca_cert = x509.load_pem_x509_certificate(ca_cert_file.read(), default_backend())
     # Load CA private key
-    ca_key_file = open(join(CERT_FILE_PATH, ca_key_filename), 'rb')
+    ca_key_file = open(filepath_list['ca_key'], 'rb')
     ca_key = serialization.load_pem_private_key(
         ca_key_file.read(),
         pass_phase.encode('utf-8'),
@@ -210,6 +221,6 @@ def create_self_sign_certs(pass_phase: str):
     )
 
     # Sign Server Cert with CSR
-    sign_csr(server_csr, ca_cert, ca_key, server_cert_filename)
+    sign_csr(server_csr, ca_cert, ca_key, filepath_list['server_cert'])
     # Sign Client Cert with CSR
-    sign_csr(client_csr, ca_cert, ca_key, client_cert_filename)
+    sign_csr(client_csr, ca_cert, ca_key, filepath_list['client_cert'])


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

Issue: #2592

The SSL cert path function was triggered in generate ssl command which result in an incorrect ssl cert path for HB binary in MacOS and Windows. Windows binary's failure to launch was likely due to this inaccessible path. 

Moved the cert_path function into the ssl generation function. 
