### PR TITLE
Fix / script error not handled

### DIFF
--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -8,7 +8,7 @@ from typing import (
     Optional,
     Callable,
 )
-from os.path import dirname
+from os.path import dirname, join
 from hummingbot.core.clock import (
     Clock,
     ClockMode
@@ -125,7 +125,7 @@ class StartCommand:
                 script_file = global_config_map["script_file_path"].value
                 folder = dirname(script_file)
                 if folder == "":
-                    script_file = SCRIPTS_PATH + script_file
+                    script_file = join(SCRIPTS_PATH, script_file)
                 if self.strategy_name != "pure_market_making":
                     self._notify("Error: script feature is only available for pure_market_making strategy (for now).")
                 else:

--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -32,7 +32,6 @@ TEMPLATE_PATH = realpath(join(__file__, "../../templates/"))
 CONF_FILE_PATH = "conf/"
 CONF_PREFIX = "conf_"
 CONF_POSTFIX = "_strategy"
-# SCRIPTS_PATH = "scripts/"
 SCRIPTS_PATH = realpath(join(__file__, "../../../scripts/"))
 CERTS_PATH = "certs/"
 

--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -32,7 +32,8 @@ TEMPLATE_PATH = realpath(join(__file__, "../../templates/"))
 CONF_FILE_PATH = "conf/"
 CONF_PREFIX = "conf_"
 CONF_POSTFIX = "_strategy"
-SCRIPTS_PATH = "scripts/"
+# SCRIPTS_PATH = "scripts/"
+SCRIPTS_PATH = realpath(join(__file__, "../../../scripts/"))
 CERTS_PATH = "certs/"
 
 GATEAWAY_CA_CERT_PATH = realpath(join(__file__, join(f"../../../{CERTS_PATH}/ca_cert.pem")))

--- a/hummingbot/script/script_base.py
+++ b/hummingbot/script/script_base.py
@@ -1,10 +1,11 @@
 import asyncio
+import traceback
 from multiprocessing import Queue
 from typing import List, Optional, Dict, Any, Callable
 from decimal import Decimal
 from statistics import mean, median
 from operator import itemgetter
-from .script_interface import OnTick, OnStatus, PMMParameters, CallNotify, CallLog, PmmMarketInfo
+from .script_interface import OnTick, OnStatus, PMMParameters, CallNotify, CallLog, PmmMarketInfo, ScriptError
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
     SellOrderCompletedEvent
@@ -46,30 +47,38 @@ class ScriptBase:
 
     async def listen_to_parent(self):
         while True:
-            if self._parent_queue.empty():
-                await asyncio.sleep(self._queue_check_interval)
-                continue
-            item = self._parent_queue.get()
-            # print(f"child gets {str(item)}")
-            if item is None:
-                # print("child exiting..")
-                asyncio.get_event_loop().stop()
-                break
-            if isinstance(item, OnTick):
-                self.mid_prices.append(item.mid_price)
-                self.pmm_parameters = item.pmm_parameters
-                self.all_total_balances = item.all_total_balances
-                self.all_available_balances = item.all_available_balances
-                self.on_tick()
-            elif isinstance(item, BuyOrderCompletedEvent):
-                self.on_buy_order_completed(item)
-            elif isinstance(item, SellOrderCompletedEvent):
-                self.on_sell_order_completed(item)
-            elif isinstance(item, OnStatus):
-                status_msg = self.on_status()
-                self.notify(f"Script status: {status_msg}")
-            elif isinstance(item, PmmMarketInfo):
-                self.pmm_market_info = item
+            try:
+                if self._parent_queue.empty():
+                    await asyncio.sleep(self._queue_check_interval)
+                    continue
+                item = self._parent_queue.get()
+                # print(f"child gets {str(item)}")
+                if item is None:
+                    # print("child exiting..")
+                    asyncio.get_event_loop().stop()
+                    break
+                if isinstance(item, OnTick):
+                    self.mid_prices.append(item.mid_price)
+                    self.pmm_parameters = item.pmm_parameters
+                    self.all_total_balances = item.all_total_balances
+                    self.all_available_balances = item.all_available_balances
+                    self.on_tick()
+                elif isinstance(item, BuyOrderCompletedEvent):
+                    self.on_buy_order_completed(item)
+                elif isinstance(item, SellOrderCompletedEvent):
+                    self.on_sell_order_completed(item)
+                elif isinstance(item, OnStatus):
+                    status_msg = self.on_status()
+                    self.notify(f"Script status: {status_msg}")
+                elif isinstance(item, PmmMarketInfo):
+                    self.pmm_market_info = item
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # Capturing traceback here and put it as part of ScriptError, which can then be reported in the parent
+                # process.
+                tb = "".join(traceback.TracebackException.from_exception(e).format())
+                self._child_queue.put(ScriptError(e, tb))
 
     def notify(self, msg: str):
         """

--- a/hummingbot/script/script_interface.py
+++ b/hummingbot/script/script_interface.py
@@ -145,3 +145,12 @@ class CallLog:
 
     def __repr__(self):
         return f"{self.__class__.__name__} {str(self.__dict__)}"
+
+
+class ScriptError:
+    def __init__(self, error: Exception, traceback: str):
+        self.error = error
+        self.traceback = traceback
+
+    def __repr__(self):
+        return f"{self.__class__.__name__} {str(self.error)} \nTrace back: {self.traceback}"

--- a/hummingbot/script/script_process.py
+++ b/hummingbot/script/script_process.py
@@ -2,12 +2,17 @@ import asyncio
 import importlib
 import inspect
 import os
+import sys
+
 from multiprocessing import Queue
 from hummingbot.script.script_base import ScriptBase
 from hummingbot.script.script_interface import set_child_queue
 
 
 def run_script(script_file_name: str, parent_queue: Queue, child_queue: Queue, queue_check_interval: float):
+    sys.stdin.close()
+    sys.stdout.close()
+    sys.stderr.close()
     script_class = import_script_sub_class(script_file_name)
     script = script_class()
     script.assign_init(parent_queue, child_queue, queue_check_interval)

--- a/scripts/hello_world_script.py
+++ b/scripts/hello_world_script.py
@@ -3,9 +3,13 @@ from hummingbot.script.script_base import ScriptBase
 
 class HelloWorldScript(ScriptBase):
     """
-    Demonstrates how to send messages using notify and log functions.
+    Demonstrates how to send messages using notify and log functions. It also shows how errors handled.
     """
 
     def on_tick(self):
-        self.notify("Hello Hummingbots World!")
-        self.log("Hello world logged.")
+        if len(self.mid_prices) < 3:
+            self.notify("Hello Hummingbots World!")
+            self.log("Hello world logged.")
+        elif 3 <= len(self.mid_prices) < 5:
+            # This below statement will cause ZeroDivisionError, Hummingbot will later report this on the log screen.
+            _ = 1 / 0


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**After creating this PR, please make sure:**

- [ ] You link the related GitHub issue or ticket

**A description of the changes proposed in the pull request**:
- Create a new interface ScriptError class
- Add error handling into both parent and child queue listen loops
- Errors are now reported on HB log section and will not cause script to stop functioning
- Run `hello_world_script` example to see how this works

This should fix #2123 
For some reason, i can't link this bug to the PR.