### PR TITLE
fix / parsing error on specific BUSD pairs

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_utils.py
+++ b/hummingbot/connector/exchange/binance/binance_utils.py
@@ -11,7 +11,8 @@ CENTRALIZED = True
 EXAMPLE_PAIR = "ZRX-ETH"
 DEFAULT_FEES = [0.1, 0.1]
 
-TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(BTC|ETH|BNB|DAI|XRP|USDT|USDC|USDS|TUSD|PAX|TRX|BUSD|NGN|RUB|TRY|EUR|IDRT|ZAR|UAH|GBP|BKRW|BIDR|USD)$")
+TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(BNB|BTC|ETH|TRX|XRP|USDT|BKRW|BUSD|EUR|TUSD|USDC|TRY|PAX|AUD|BIDR|BRL|DAI|"
+                                   r"GBP|IDRT|NGN|RUB|ZAR|UAH)$")
 
 
 def split_trading_pair(trading_pair: str) -> Optional[Tuple[str, str]]:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**After creating this PR, please make sure:**

- [x] You link the related GitHub issue or ticket

**A description of the changes proposed in the pull request**:

Removed USD from `TRADING_PAIR_SPLITTER` since Binance doesn't have that pair anyway which causes issues like `STRAXB-USD` showing instead of `STRAX-BUSD` (see linked issue). Also added `BRL` trading pair.

![image](https://user-images.githubusercontent.com/50150287/99865219-2ef04180-2be3-11eb-883b-29d353817076.png)
