### PR TITLE
Fix / regular expression split errors

### DIFF
--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_utils.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_utils.py
@@ -14,13 +14,16 @@ EXAMPLE_PAIR = "BTC-USDT"
 DEFAULT_FEES = [0.02, 0.04]
 
 
-TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(BTC|ETH|BNB|XRP|USDT|USDC|USDS|TUSD|PAX|TRX|BUSD|NGN|RUB|TRY|EUR|IDRT|ZAR|UAH|GBP|BKRW|BIDR)$")
+RE_4_LETTERS_QUOTE = re.compile(r"^(\w+)(USDT|USDC|USDS|TUSD|BUSD|IDRT|BKRW|BIDR)$")
+RE_3_LETTERS_QUOTE = re.compile(r"^(\w+)(BTC|ETH|BNB|DAI|XRP|PAX|TRX|NGN|RUB|TRY|EUR|ZAR|UAH|GBP|USD|BRL)$")
 
 
 # Helper Functions ---
 def split_trading_pair(trading_pair: str) -> Optional[Tuple[str, str]]:
     try:
-        m = TRADING_PAIR_SPLITTER.match(trading_pair)
+        m = RE_4_LETTERS_QUOTE.match(trading_pair)
+        if m is None:
+            m = RE_3_LETTERS_QUOTE.match(trading_pair)
         return m.group(1), m.group(2)
     except Exception as e:
         raise e

--- a/hummingbot/connector/exchange/binance/binance_utils.py
+++ b/hummingbot/connector/exchange/binance/binance_utils.py
@@ -11,12 +11,15 @@ CENTRALIZED = True
 EXAMPLE_PAIR = "ZRX-ETH"
 DEFAULT_FEES = [0.1, 0.1]
 
-TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(BTC|ETH|BNB|DAI|XRP|USDT|USDC|USDS|TUSD|PAX|TRX|BUSD|NGN|RUB|TRY|EUR|IDRT|ZAR|UAH|GBP|BKRW|BIDR)$")
+RE_4_LETTERS_QUOTE = re.compile(r"^(\w+)(USDT|USDC|USDS|TUSD|BUSD|IDRT|BKRW|BIDR)$")
+RE_3_LETTERS_QUOTE = re.compile(r"^(\w+)(BTC|ETH|BNB|DAI|XRP|PAX|TRX|NGN|RUB|TRY|EUR|ZAR|UAH|GBP|USD|BRL)$")
 
 
 def split_trading_pair(trading_pair: str) -> Optional[Tuple[str, str]]:
     try:
-        m = TRADING_PAIR_SPLITTER.match(trading_pair)
+        m = RE_4_LETTERS_QUOTE.match(trading_pair)
+        if m is None:
+            m = RE_3_LETTERS_QUOTE.match(trading_pair)
         return m.group(1), m.group(2)
     # Exceptions are now logged as warnings in trading pair fetcher
     except Exception:

--- a/hummingbot/connector/exchange/huobi/huobi_utils.py
+++ b/hummingbot/connector/exchange/huobi/huobi_utils.py
@@ -6,7 +6,9 @@ from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
 
 
-TRADING_PAIR_SPLITTER = re.compile(r"^(\w+)(usdt|husd|btc|eth|ht|trx)$")
+RE_4_LETTERS_QUOTE = re.compile(r"^(\w+)(usdt|husd)$")
+RE_3_LETTERS_QUOTE = re.compile(r"^(\w+)(btc|eth|trx)$")
+RE_2_LETTERS_QUOTE = re.compile(r"^(\w+)(ht)$")
 
 CENTRALIZED = True
 
@@ -17,7 +19,11 @@ DEFAULT_FEES = [0.2, 0.2]
 
 def split_trading_pair(trading_pair: str) -> Optional[Tuple[str, str]]:
     try:
-        m = TRADING_PAIR_SPLITTER.match(trading_pair)
+        m = RE_4_LETTERS_QUOTE.match(trading_pair)
+        if m is None:
+            m = RE_3_LETTERS_QUOTE.match(trading_pair)
+            if m is None:
+                m = RE_2_LETTERS_QUOTE.match(trading_pair)
         return m.group(1), m.group(2)
     # Exceptions are now logged as warnings in trading pair fetcher
     except Exception:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**After creating this PR, please make sure:**

- [ ] You link the related GitHub issue or ticket

**A description of the changes proposed in the pull request**:
- A fix to development, create groups depending on the length of of key words, match the longer ones first.
- When there are multiple searches with same ending key word, shorter one always returned first, e.g. TUSD or BUSD will not be returned (as USD is returned instead)

