### PR TITLE
feat/ add BUSD to global template

### DIFF
--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -119,6 +119,7 @@ min_quote_order_amount:
   BNB: 0.5
   USDT: 11
   USDC: 11
+  BUSD: 11
 
 
 # Advanced database options, currently supports SQLAlchemy's included dialects


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**After creating this PR, please make sure:**

- [ ] You link the related GitHub issue or ticket

**A description of the changes proposed in the pull request**:

Add BUSD to `min_quote_order_amount` under conf_global template to show suggested order_amount when using markets with BUSD quote .

Current suggested order_amount:
![BUSD sample](https://user-images.githubusercontent.com/57189990/100287800-50b94200-2fb0-11eb-9c76-f00f0b2a8b1c.PNG)

After adding BUSD:
![ENJ sample](https://user-images.githubusercontent.com/57189990/100287810-5747b980-2fb0-11eb-95c9-29c289b16f64.PNG)
![STRAX sample](https://user-images.githubusercontent.com/57189990/100287816-5a42aa00-2fb0-11eb-8b99-22216e6aef62.PNG)
