### PR TITLE
Refactor / Fix spacing on max order age prompt

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -153,7 +153,7 @@ pure_market_making_config_map = {
     "max_order_age":
         ConfigVar(key="max_order_age",
                   prompt="How long do you want to cancel and replace bids and asks "
-                         " with thesame price(in seconds)? >>> ",
+                         "with the same price (in seconds)? >>> ",
                   required_if=lambda: not (using_exchange("radar_relay")() or
                                            (using_exchange("bamboo_relay")() and not using_bamboo_coordinator_mode())),
                   type_str="float",


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Fix spacing on max order age prompt.

![unknown](https://user-images.githubusercontent.com/64377055/102445208-ebfc7f00-4065-11eb-8805-5cfeda49fc89.png)
 
<img width="694" alt="Screen Shot 2020-12-17 at 12 39 44 PM" src="https://user-images.githubusercontent.com/64377055/102445149-c0799480-4065-11eb-9536-679ad648b96e.png">

