### PR TITLE
cleanup / deprecate get_active_exchange_markets

### DIFF
--- a/hummingbot/connector/exchange/bamboo_relay/bamboo_relay_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bamboo_relay/bamboo_relay_api_order_book_data_source.py
@@ -144,9 +144,6 @@ class BambooRelayAPIOrderBookDataSource(OrderBookTrackerDataSource):
                               f"HTTP status is {response.status}.")
             return await response.json()
 
-    async def get_trading_pairs(self) -> List[str]:
-        return await self.fetch_trading_pairs()
-
     async def get_new_order_book(self, trading_pair: str) -> BambooRelayOrderBook:
         async with aiohttp.ClientSession() as client:
             snapshot: Dict[str, any] = await self.get_snapshot(client, trading_pair, self._api_endpoint,

--- a/hummingbot/connector/exchange/bamboo_relay/bamboo_relay_exchange.pyx
+++ b/hummingbot/connector/exchange/bamboo_relay/bamboo_relay_exchange.pyx
@@ -355,9 +355,6 @@ cdef class BambooRelayExchange(ExchangeBase):
         except Exception:
             self.logger().error(f"Error restoring tracking states.", exc_info=True)
 
-    async def get_active_exchange_markets(self):
-        return await BambooRelayAPIOrderBookDataSource.get_active_exchange_markets(self._api_endpoint, self._api_prefix)
-
     async def _status_polling_loop(self):
         while True:
             try:

--- a/hummingbot/connector/exchange/binance/binance_exchange.pyx
+++ b/hummingbot/connector/exchange/binance/binance_exchange.pyx
@@ -203,9 +203,6 @@ cdef class BinanceExchange(ExchangeBase):
             for key, value in saved_states.items()
         })
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await BinanceAPIOrderBookDataSource.get_active_exchange_markets()
-
     def monkey_patch_binance_time(self):
         if binance_client_module.time != BinanceTime.get_instance():
             binance_client_module.time = BinanceTime.get_instance()

--- a/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
+++ b/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
@@ -1144,14 +1144,6 @@ cdef class BitfinexExchange(ExchangeBase):
             )
             return list(map(lambda client_order_id: CancellationResult(client_order_id, False), order_ids))
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        """
-        *required
-        Used by the discovery strategy to read order books of all actively trading markets,
-        and find opportunities to profit
-        """
-        return await BitfinexAPIOrderBookDataSource.get_active_exchange_markets()
-
     @property
     def limit_orders(self) -> List[LimitOrder]:
         """

--- a/hummingbot/connector/exchange/bittrex/bittrex_exchange.pyx
+++ b/hummingbot/connector/exchange/bittrex/bittrex_exchange.pyx
@@ -154,9 +154,6 @@ cdef class BittrexExchange(ExchangeBase):
             for key, value in saved_states.items()
         })
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await BittrexAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         self._tx_tracker.c_start(clock, timestamp)
         ExchangeBase.c_start(self, clock, timestamp)

--- a/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
+++ b/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
@@ -208,14 +208,6 @@ cdef class CoinbaseProExchange(ExchangeBase):
             for key, value in saved_states.items()
         })
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        """
-        *required
-        Used by the discovery strategy to read order books of all actively trading markets,
-        and find opportunities to profit
-        """
-        return await CoinbaseProAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         """
         *required

--- a/hummingbot/connector/exchange/dolomite/dolomite_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/dolomite/dolomite_api_order_book_data_source.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 
 import asyncio
-from decimal import Decimal
 
 import aiohttp
 import logging
-import pandas as pd
-import math
 
 from typing import AsyncIterable, Dict, List, Optional, Any
 
@@ -15,7 +12,6 @@ import ujson
 import websockets
 from websockets.exceptions import ConnectionClosed
 
-from hummingbot.core.utils import async_ttl_cache
 from hummingbot.connector.exchange.dolomite.dolomite_active_order_tracker import DolomiteActiveOrderTracker
 from hummingbot.connector.exchange.dolomite.dolomite_order_book import DolomiteOrderBook
 from hummingbot.connector.exchange.dolomite.dolomite_order_book_tracker_entry import DolomiteOrderBookTrackerEntry
@@ -53,47 +49,6 @@ class DolomiteAPIOrderBookDataSource(OrderBookTrackerDataSource):
         self._get_tracking_pair_done_event: asyncio.Event = asyncio.Event()
         self.order_book_create_function = lambda: DolomiteOrderBook()
 
-    @classmethod
-    @async_ttl_cache(ttl=60 * 30, maxsize=1)
-    async def get_active_exchange_markets(cls) -> pd.DataFrame:
-        """
-        Returned data frame should have trading pair as index and include usd volume, baseAsset and quoteAsset
-        """
-        async with aiohttp.ClientSession() as client:
-            # Hard coded to use the live exchange api for auto completing markets (opposed to using testnet)
-            markets_response: aiohttp.ClientResponse = await client.get(
-                f"https://exchange-api.dolomite.io{MARKETS_URL}"
-            )
-
-            if markets_response.status != 200:
-                raise IOError(f"Error fetching active Dolomite markets. HTTP status is {markets_response.status}.")
-
-            markets_data = await markets_response.json()
-            markets_data = markets_data["data"]
-
-            field_mapping = {
-                "market": "market",
-                "primary_token": "baseAsset",
-                "primary_ticker_decimal_places": "int",
-                "secondary_token": "quoteAsset",
-                "secondary_ticker_price_decimal_places": "int",
-                "period_volume": "volume",
-                "period_volume_usd": "USDVolume",
-            }
-
-            all_markets: pd.DataFrame = pd.DataFrame.from_records(
-                data=markets_data, index="market", columns=list(field_mapping.keys())
-            )
-
-            def obj_to_decimal(c):
-                return Decimal(c["amount"]) / Decimal(math.pow(10, c["currency"]["precision"]))
-
-            all_markets.rename(field_mapping, axis="columns", inplace=True)
-            all_markets["USDVolume"] = all_markets["USDVolume"].map(obj_to_decimal)
-            all_markets["volume"] = all_markets["volume"].map(obj_to_decimal)
-
-            return all_markets.sort_values("USDVolume", ascending=False)
-
     @property
     def order_book_class(self) -> DolomiteOrderBook:
         return DolomiteOrderBook
@@ -124,9 +79,7 @@ class DolomiteAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def get_trading_pairs(self) -> List[str]:
         if self._trading_pairs is None:
-            active_markets: pd.DataFrame = await self.get_active_exchange_markets()
-            trading_pairs: List[str] = active_markets.index.tolist()
-            self._trading_pairs = trading_pairs
+            self._trading_pairs = await self.fetch_trading_pairs()
         else:
             trading_pairs: List[str] = self._trading_pairs
         return trading_pairs

--- a/hummingbot/connector/exchange/dolomite/dolomite_exchange.pyx
+++ b/hummingbot/connector/exchange/dolomite/dolomite_exchange.pyx
@@ -212,9 +212,6 @@ cdef class DolomiteExchange(ExchangeBase):
     def in_flight_orders(self) -> Dict[str, DolomiteInFlightOrder]:
         return self._in_flight_orders
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await DolomiteAPIOrderBookDataSource.get_active_exchange_markets()
-
     # ----------------------------------------
     # Account Balances
 

--- a/hummingbot/connector/exchange/dydx/dydx_exchange.pyx
+++ b/hummingbot/connector/exchange/dydx/dydx_exchange.pyx
@@ -237,9 +237,6 @@ cdef class DydxExchange(ExchangeBase):
                 retval.append(dydx_flight_order.to_limit_order())
         return retval
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await DydxAPIOrderBookDataSource.get_active_exchange_markets()
-
     # ----------------------------------------
     # Account Balances
 

--- a/hummingbot/connector/exchange/eterbase/eterbase_exchange.pyx
+++ b/hummingbot/connector/exchange/eterbase/eterbase_exchange.pyx
@@ -217,14 +217,6 @@ cdef class EterbaseExchange(ExchangeBase):
             for key, value in saved_states.items()
         })
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        """
-        *required
-        Used by the discovery strategy to read order books of all actively trading markets,
-        and find opportunities to profit
-        """
-        return await EterbaseAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         """
         *required

--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -181,9 +181,6 @@ cdef class HuobiExchange(ExchangeBase):
     def shared_client(self, client: aiohttp.ClientSession):
         self._shared_client = client
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await HuobiAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         self._tx_tracker.c_start(clock, timestamp)
         ExchangeBase.c_start(self, clock, timestamp)

--- a/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
@@ -251,7 +251,6 @@ class KrakenAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 await asyncio.sleep(5.0)
 
     async def get_ws_subscription_message(self, subscription_type: str):
-        # all_markets: pd.DataFrame = await self.get_active_exchange_markets()
         trading_pairs: List[str] = []
         for tp in self._trading_pairs:
             base, quote = self.split_to_base_quote(convert_to_exchange_trading_pair(tp))

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.pyx
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.pyx
@@ -191,9 +191,6 @@ cdef class KrakenExchange(ExchangeBase):
             self._asset_pairs = {pair: details for pair, details in asset_pairs.items() if "." not in pair}
         return self._asset_pairs
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await KrakenAPIOrderBookDataSource.get_active_exchange_markets()
-
     async def _update_balances(self):
         cdef:
             dict open_orders

--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.pyx
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.pyx
@@ -191,9 +191,6 @@ cdef class KucoinExchange(ExchangeBase):
     def user_stream_tracker(self) -> KucoinUserStreamTracker:
         return self._user_stream_tracker
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await KucoinAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         self._tx_tracker.c_start(clock, timestamp)
         ExchangeBase.c_start(self, clock, timestamp)

--- a/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
+++ b/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
@@ -203,14 +203,6 @@ cdef class LiquidExchange(ExchangeBase):
             for key, value in saved_states.items()
         })
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        """
-        *required
-        Used by the discovery strategy to read order books of all actively trading markets,
-        and find opportunities to profit
-        """
-        return await LiquidAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         """
         *required

--- a/hummingbot/connector/exchange/loopring/loopring_exchange.pyx
+++ b/hummingbot/connector/exchange/loopring/loopring_exchange.pyx
@@ -241,9 +241,6 @@ cdef class LoopringExchange(ExchangeBase):
                 retval.append(loopring_flight_order.to_limit_order())
         return retval
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await LoopringAPIOrderBookDataSource.get_active_exchange_markets()
-
     # ----------------------------------------
     # Account Balances
 

--- a/hummingbot/connector/exchange/okex/okex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/okex/okex_api_order_book_data_source.py
@@ -23,7 +23,6 @@ from websockets.exceptions import ConnectionClosed
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
-from hummingbot.core.utils import async_ttl_cache
 from hummingbot.logger import HummingbotLogger
 from hummingbot.connector.exchange.okex.okex_order_book import OkexOrderBook
 from hummingbot.connector.exchange.okex.constants import (
@@ -54,34 +53,6 @@ class OkexAPIOrderBookDataSource(OrderBookTrackerDataSource):
     def __init__(self, trading_pairs: List[str]):
         super().__init__(trading_pairs)
         self._trading_pairs: List[str] = trading_pairs
-
-    @classmethod
-    @async_ttl_cache(ttl=60 * 30, maxsize=1)
-    async def get_active_exchange_markets(cls) -> pd.DataFrame:
-        """
-        Performs the necessary API request(s) to get all currently active trading pairs on the
-        exchange and returns a pandas.DataFrame with each row representing one active trading pair.
-
-        Also the the base and quote currency should be represented under the baseAsset and quoteAsset
-        columns respectively in the DataFrame.
-
-        Refer to Calling a Class method for an example on how to test this particular function.
-        Returned data frame should have trading pair as index and include usd volume, baseAsset and quoteAsset
-        """
-        async with aiohttp.ClientSession() as client:
-            async with client.get(OKEX_SYMBOLS_URL) as products_response:
-
-                products_response: aiohttp.ClientResponse = products_response
-                if products_response.status != 200:
-                    raise IOError(f"Error fetching active OKEx markets. HTTP status is {products_response.status}.")
-
-                data = await products_response.json()
-                all_markets: pd.DataFrame = pd.DataFrame.from_records(data=data)
-
-                all_markets.rename({"quote_volume_24h": "volume", "last": "price"},
-                                   axis="columns", inplace=True)
-
-                return all_markets
 
     @staticmethod
     @cachetools.func.ttl_cache(ttl=10)
@@ -147,8 +118,7 @@ class OkexAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def get_trading_pairs(self) -> List[str]:
         if not self._trading_pairs:
             try:
-                active_markets: pd.DataFrame = await self.get_active_exchange_markets()
-                self._trading_pairs = active_markets['product_id'].tolist()
+                self._trading_pairs = await self.fetch_trading_pairs()
             except Exception:
                 self._trading_pairs = []
                 self.logger().network(

--- a/hummingbot/connector/exchange/okex/okex_exchange.pyx
+++ b/hummingbot/connector/exchange/okex/okex_exchange.pyx
@@ -197,9 +197,6 @@ cdef class OkexExchange(ExchangeBase):
     def shared_client(self, client: aiohttp.ClientSession):
         self._shared_client = client
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await OkexAPIOrderBookDataSource.get_active_exchange_markets()
-
     cdef c_start(self, Clock clock, double timestamp):
         self._tx_tracker.c_start(clock, timestamp)
         ExchangeBase.c_start(self, clock, timestamp)

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -818,9 +818,6 @@ cdef class PaperTradeExchange(ExchangeBase):
     cdef object c_get_available_balance(self, str currency):
         return self.available_balances.get(currency.upper(), s_decimal_0)
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        return await self._order_book_tracker.data_source.get_active_exchange_markets()
-
     async def cancel_all(self, timeout_seconds: float) -> List[CancellationResult]:
         cdef:
             LimitOrders *limit_orders_map_ptr

--- a/hummingbot/connector/exchange/radar_relay/radar_relay_exchange.pyx
+++ b/hummingbot/connector/exchange/radar_relay/radar_relay_exchange.pyx
@@ -223,9 +223,6 @@ cdef class RadarRelayExchange(ExchangeBase):
             for key, value in saved_states["limit_orders"].items()
         })
 
-    async def get_active_exchange_markets(self):
-        return await RadarRelayAPIOrderBookDataSource.get_active_exchange_markets()
-
     async def _status_polling_loop(self):
         while True:
             try:

--- a/hummingbot/connector/exchange_base.pyx
+++ b/hummingbot/connector/exchange_base.pyx
@@ -59,13 +59,6 @@ cdef class ExchangeBase(ConnectorBase):
     def get_mid_price(self, trading_pair: str) -> Decimal:
         return (self.get_price(trading_pair, True) + self.get_price(trading_pair, False)) / Decimal("2")
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        """
-        :return: data frame with trading_pair as index, and at least the following columns --
-                 ["baseAsset", "quoteAsset", "volume", "USDVolume"]
-        """
-        raise NotImplementedError
-
     cdef str c_buy(self, str trading_pair, object amount, object order_type=OrderType.MARKET,
                    object price=s_decimal_NaN, dict kwargs={}):
         return self.buy(trading_pair, amount, order_type, price, **kwargs)

--- a/hummingbot/connector/mock_api_order_book_data_source.py
+++ b/hummingbot/connector/mock_api_order_book_data_source.py
@@ -44,15 +44,14 @@ class MockAPIOrderBookDataSource(OrderBookTrackerDataSource):
         self._diff_messages: asyncio.Queue = asyncio.Queue()
         self._snapshot_messages: asyncio.Queue = asyncio.Queue()
 
-    @classmethod
-    async def get_active_exchange_markets(cls) -> pd.DataFrame:
+    @staticmethod
+    async def fetch_trading_pairs() -> List[str]:
         raise NotImplementedError("Trading Pairs are required for mock data source")
 
     async def get_trading_pairs(self) -> List[str]:
         if not self._trading_pairs:
             try:
-                active_markets: pd.DataFrame = await self.get_active_exchange_markets()
-                self._trading_pairs = active_markets.index.tolist()
+                self._trading_pairs = await self.fetch_trading_pairs()
             except Exception:
                 self._trading_pairs = []
                 self.logger().network(

--- a/hummingbot/market/market_base.pyx
+++ b/hummingbot/market/market_base.pyx
@@ -189,13 +189,6 @@ cdef class MarketBase(NetworkIterator):
         exchange_limits = all_ex_limit.get(market, {})
         return exchange_limits if exchange_limits is not None else {}
 
-    async def get_active_exchange_markets(self) -> pd.DataFrame:
-        """
-        :return: data frame with trading_pair as index, and at least the following columns --
-                 ["baseAsset", "quoteAsset", "volume", "USDVolume"]
-        """
-        raise NotImplementedError
-
     async def get_deposit_info(self, asset: str) -> DepositInfo:
         raise NotImplementedError
 

--- a/test/integration/test_bitfinex_order_book_tracker.py
+++ b/test/integration/test_bitfinex_order_book_tracker.py
@@ -152,14 +152,6 @@ class BitfinexOrderBookTrackerUnitTest(unittest.TestCase):
                 break
         self.assertLessEqual(total_volume, 10 * self.daily_volume)
 
-    def test_get_active_exchange_markets(self):
-        [data] = self.run_parallel(self.order_book_tracker.data_source.get_active_exchange_markets())
-
-        self.assertGreater(data.size, 0)
-        self.assertTrue("baseAsset" in data)
-        self.assertTrue("quoteAsset" in data)
-        self.assertTrue("USDVolume" in data)
-
 
 def main():
     logging.basicConfig(level=logging.INFO)

--- a/test/integration/test_kraken_api_order_book_data_source.py
+++ b/test/integration/test_kraken_api_order_book_data_source.py
@@ -13,7 +13,6 @@ from typing import (
     Any,
     List,
 )
-import pandas as pd
 import unittest
 
 
@@ -25,10 +24,6 @@ class KrakenAPIOrderBookDataSourceUnitTest(unittest.TestCase):
 
     def run_async(self, task):
         return self.ev_loop.run_until_complete(task)
-
-    def test_get_active_exchange_markets(self):
-        market_data: pd.DataFrame = self.run_async(self.order_book_data_source.get_active_exchange_markets())
-        self.assertIn("ETHDAI", market_data.index)
 
     def test_get_trading_pairs(self):
         trading_pairs: List[str] = self.run_async(self.order_book_data_source.get_trading_pairs())

--- a/test/integration/test_okex_api_order_book_data_source.py
+++ b/test/integration/test_okex_api_order_book_data_source.py
@@ -64,11 +64,6 @@ class TestOkexAPIOrderBookDataSource(unittest.TestCase):
         self.mocked_trading_pairs = ["BTC-USDT", "ETH-USDT"]
         self.order_book_data_source = OkexAPIOrderBookDataSource(self.mocked_trading_pairs)
 
-    def test_example_market(self):
-        ev_loop = asyncio.get_event_loop()
-        # TODO this is currently executing the call, how to mock this?
-        ev_loop.run_until_complete(OkexAPIOrderBookDataSource.get_active_exchange_markets())
-
     def test_get_snapshot(self):
         ev_loop = asyncio.get_event_loop()
         # TODO this is currently executing the call, how to mock this?


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This task is to deprecate the `get_active_exchange_markets` function in the main connector file.