### PR TITLE
feat/Add relative-to-start profitability and equity

### DIFF
--- a/hummingbot/client/command/config_command.py
+++ b/hummingbot/client/command/config_command.py
@@ -52,7 +52,8 @@ global_configs_to_display = ["0x_active_cancels",
                              "gateway_cert_passphrase",
                              "gateway_api_host",
                              "gateway_api_port",
-                             "balancer_max_swaps"]
+                             "balancer_max_swaps",
+                             "advanced_stats"]
 
 
 class ConfigCommand:

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -164,8 +164,7 @@ class HistoryCommand:
         perf_data = [
             ["Hold portfolio value    ", f"{smart_round(perf.hold_value, precision)} {quote}"],
             ["Current portfolio value ", f"{smart_round(perf.cur_value, precision)} {quote}"],
-            ["Trade P&L               ", f"{smart_round(perf.trade_pnl, precision)} {quote}"],
-            
+            ["Trade P&L               ", f"{smart_round(perf.trade_pnl, precision)} {quote}"]
         ]
         if global_config_map.get("advanced_stats").value:
             perf_data.extend(

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -169,8 +169,8 @@ class HistoryCommand:
         ]
         if global_config_map.get("advanced_stats").value:
             perf_data.extend(
-                ["*Start portfolio value  ", f"{smart_round(perf.start_value, precision)} {quote}"],
-                ["*Relative to start value", f"{smart_round(perf.rel_value, precision)} {quote}"],
+                [["*Start portfolio value  ", f"{smart_round(perf.start_value, precision)} {quote}"],
+                ["*Relative to start value", f"{smart_round(perf.rel_value, precision)} {quote}"]]
             )
         perf_data.extend(
             ["Fees paid               ", f"{smart_round(fee_amount, precision)} {fee_token}"]

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -150,9 +150,9 @@ class HistoryCommand:
              smart_round(perf.cur_quote_bal, precision),
              smart_round(perf.tot_vol_quote, precision)],
             [f"{trading_pair + ' price':<17}",
-             smart_round(perf.start_price),
-             smart_round(perf.cur_price),
-             smart_round(perf.cur_price - perf.start_price)],
+             smart_round(perf.start_price, precision),
+             smart_round(perf.cur_price, precision),
+             smart_round(perf.cur_price - perf.start_price, precision)],
             [f"{'Base asset %':<17}",
              f"{perf.start_base_ratio_pct:.2%}",
              f"{perf.cur_base_ratio_pct:.2%}",
@@ -164,7 +164,9 @@ class HistoryCommand:
         perf_data = [
             ["Hold portfolio value    ", f"{smart_round(perf.hold_value, precision)} {quote}"],
             ["Current portfolio value ", f"{smart_round(perf.cur_value, precision)} {quote}"],
-            ["Trade P&L               ", f"{smart_round(perf.trade_pnl, precision)} {quote}"]
+            ["Trade P&L               ", f"{smart_round(perf.trade_pnl, precision)} {quote}"],
+            ["Start portfolio value   ", f"{smart_round(perf.start_value, precision)} {quote}"],
+            ["Relative portfolio value", f"{smart_round(perf.rel_value, precision)} {quote}"],
         ]
         perf_data.extend(
             ["Fees paid               ", f"{smart_round(fee_amount, precision)} {fee_token}"]

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -165,9 +165,13 @@ class HistoryCommand:
             ["Hold portfolio value    ", f"{smart_round(perf.hold_value, precision)} {quote}"],
             ["Current portfolio value ", f"{smart_round(perf.cur_value, precision)} {quote}"],
             ["Trade P&L               ", f"{smart_round(perf.trade_pnl, precision)} {quote}"],
-            ["Start portfolio value   ", f"{smart_round(perf.start_value, precision)} {quote}"],
-            ["Relative portfolio value", f"{smart_round(perf.rel_value, precision)} {quote}"],
+            
         ]
+        if global_config_map.get("advanced_stats").value:
+            perf_data.extend(
+                ["*Start portfolio value  ", f"{smart_round(perf.start_value, precision)} {quote}"],
+                ["*Relative to start value", f"{smart_round(perf.rel_value, precision)} {quote}"],
+            )
         perf_data.extend(
             ["Fees paid               ", f"{smart_round(fee_amount, precision)} {fee_token}"]
             for fee_token, fee_amount in perf.fees.items()

--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -169,7 +169,7 @@ class HistoryCommand:
         if global_config_map.get("advanced_stats").value:
             perf_data.extend(
                 [["*Start portfolio value  ", f"{smart_round(perf.start_value, precision)} {quote}"],
-                ["*Relative to start value", f"{smart_round(perf.rel_value, precision)} {quote}"]]
+                 ["*Relative to start value", f"{smart_round(perf.rel_value, precision)} {quote}"]]
             )
         perf_data.extend(
             ["Fees paid               ", f"{smart_round(fee_amount, precision)} {fee_token}"]

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -109,6 +109,13 @@ main_config_map = {
                   required_if=lambda: False,
                   type_str="json",
                   ),
+    "advanced_stats":
+        ConfigVar(key="advanced_stats",
+                  prompt="Would you like to enable advanced stats? (Yes/No) >>> ",
+                  required_if=lambda: True,
+                  type_str="bool",
+                  default=False,
+                  validator=validate_bool),
     "celo_address":
         ConfigVar(key="celo_address",
                   prompt="Enter your Celo account address >>> ",

--- a/hummingbot/client/performance.py
+++ b/hummingbot/client/performance.py
@@ -43,6 +43,8 @@ class PerformanceMetrics:
     hold_value: Decimal = s_decimal_0
     cur_value: Decimal = s_decimal_0
     trade_pnl: Decimal = s_decimal_0
+    start_value: Decimal = s_decimal_0
+    rel_value: Decimal = s_decimal_0
 
     fee_in_quote: Decimal = s_decimal_0
     total_pnl: Decimal = s_decimal_0
@@ -113,6 +115,8 @@ async def calculate_performance_metrics(exchange: str,
     perf.hold_value = (perf.start_base_bal * perf.cur_price) + perf.start_quote_bal
     perf.cur_value = (perf.cur_base_bal * perf.cur_price) + perf.cur_quote_bal
     perf.trade_pnl = perf.cur_value - perf.hold_value
+    perf.start_value = (perf.start_base_bal * perf.start_price) + perf.start_quote_bal
+    perf.rel_value = (perf.cur_base_bal * perf.start_price) + perf.cur_quote_bal
 
     for trade in trades:
         if type(trade) is TradeFill:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -549,10 +549,10 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         base_value = base_balance * float(price)
         total_in_quote = base_value + quote_balance
 
-        quote_unclosed_value = Decimal(0)
-        equity_value = Decimal(0)
-        unclosed_value_quote = Decimal(0)
-        unclosed_value_base = Decimal(0)
+        quote_unclosed_value = 0
+        equity_value = 0
+        unclosed_value_quote = 0
+        unclosed_value_base = 0
 
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
@@ -560,11 +560,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                 fee = market.get_fee(self.base_asset, self.quote_asset,
                                      self._limit_order_type, TradeType.BUY, order.quantity, order.price)
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
-                unclosed_value_base += float(order.quantity) * (1 - fee.percent)
+                unclosed_value_base += float(order.quantity) * (1 - float(fee.percent))
             else:
                 fee = market.get_fee(self.base_asset, self.quote_asset,
                                      self._limit_order_type, TradeType.SELL, order.quantity, order.price)
-                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (1 - fee.percent)
+                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (1 - float(fee.percent))
                 unclosed_value_base -= float(order.quantity)
 
         quote_unclosed_value = float(unclosed_value_quote) + (float(unclosed_value_base) * float(price))

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -542,8 +542,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         price = self.get_price()
         active_orders = self.active_orders
         active_orders.sort(key=lambda x: x.price, reverse=True)
-        unclosed_value = 0
+        quote_unclosed_value = 0
         equity_value = 0
+        unclosed_value_quote = 0
+        unclosed_value_base = 0
+        fee = 0.001
 
         market, trading_pair, base_asset, quote_asset = self._market_info
         base_balance = float(market.get_balance(base_asset))
@@ -556,9 +559,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             order = active_orders[idx]
             if order.is_buy:
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
-                unclosed_value_base += float(order.quantity)
+                unclosed_value_base += float(order.quantity) * (1 - fee)
             else:
-                unclosed_value_quote += (float(order.quantity) * float(order.price))
+                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (1 - fee)
                 unclosed_value_base -= float(order.quantity)
 
         quote_unclosed_value = float(unclosed_value_quote) + (float(unclosed_value_base) * float(price))

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -541,10 +541,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
     def equity_orders_df(self) -> pd.DataFrame:
         price = self.get_price()
         active_orders = self.active_orders
-        no_sells = len([o for o in active_orders if not o.is_buy and o.client_order_id not in self._hanging_order_ids])
         active_orders.sort(key=lambda x: x.price, reverse=True)
-        unclosed_value = None
-        equity_value = None
+        unclosed_value = 0
+        equity_value = 0
 
         market, trading_pair, base_asset, quote_asset = self._market_info
         base_balance = float(market.get_balance(base_asset))
@@ -569,7 +568,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             ["delta", round(unclosed_value, 4)]
         ]
 
-        return pd.DataFrame(data=data, columns=columns)
+        return pd.DataFrame(data=data)
 
     def market_status_data_frame(self, market_trading_pair_tuples: List[MarketTradingPairTuple]) -> pd.DataFrame:
         markets_data = []

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,14 +555,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                fee = market.get_fee(self.base_asset, self.quote_asset,
-                        self._limit_order_type, TradeType.BUY, order.quantity, order.price)
+                float fee = 0.001
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
-                unclosed_value_base += float(order.quantity) * (Decimal(1) - fee.percent)
+                unclosed_value_base += float(order.quantity) * (Decimal(1) - fee)
             else:
-                fee = market.get_fee(self.base_asset, self.quote_asset,
-                        self._limit_order_type, TradeType.SELL, order.quantity, order.price)
-                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee.percent)
+                float fee = 0.001
+                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee)
                 unclosed_value_base -= float(order.quantity)
 
         quote_unclosed_value = float(unclosed_value_quote) + (float(unclosed_value_base) * float(price))

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -557,13 +557,13 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                fee = self.market.get_fee(self.base_asset, self.quote_asset,
-                                          self._limit_order_type, TradeType.BUY, order.quantity, order.price)
+                fee = market.get_fee(self.base_asset, self.quote_asset,
+                                     self._limit_order_type, TradeType.BUY, order.quantity, order.price)
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
                 unclosed_value_base += float(order.quantity) * (1 - fee.percent)
             else:
-                fee = self.market.get_fee(self.base_asset, self.quote_asset,
-                                          self._limit_order_type, TradeType.SELL, order.quantity, order.price)
+                fee = market.get_fee(self.base_asset, self.quote_asset,
+                                     self._limit_order_type, TradeType.SELL, order.quantity, order.price)
                 unclosed_value_quote += (float(order.quantity) * float(order.price)) * (1 - fee.percent)
                 unclosed_value_base -= float(order.quantity)
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,20 +555,20 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                unclosed_value[quote_asset] -= (float(order.quantity) * float(order.price))
-                unclosed_value[base_asset] += float(order.quantity) * (Decimal(1) - fee.percent)
+                unclosed_value_quote -= (float(order.quantity) * float(order.price))
+                unclosed_value_base += float(order.quantity) * (Decimal(1) - fee.percent)
             else:
-                unclosed_value[quote_asset] += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee.percent)
-                unclosed_value[base_asset] -= float(order.quantity)
+                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee.percent)
+                unclosed_value_base -= float(order.quantity)
 
-        quote_unclosed_value = unclosed_value[quote_asset] + (unclosed_value[base_asset] * float(price))
+        quote_unclosed_value = float(unclosed_value_quote) + (float(unclosed_value_base) * float(price))
         equity_value = float(quote_unclosed_value) + float(total_in_quote)
 
         data=[
             ["", base_asset, quote_asset, f"Total in ({quote_asset})"],
             ["Current Value", round(base_balance, 6), round(quote_balance, 6), round(total_in_quote, 6)],
-            ["Equity", round(base_balance + unclosed_value[base_asset], 6), round(quote_balance + unclosed_value[quote_asset], 6), round(equity_value, 6)],
-            ["delta", round(unclosed_value[base_asset], 6), round(unclosed_value[quote_asset], 6), round(quote_unclosed_value, 6)]
+            ["Equity", round(base_balance + unclosed_value_base, 6), round(quote_balance + unclosed_value_quote, 6), round(equity_value, 6)],
+            ["delta", round(unclosed_value_base, 6), round(unclosed_value_quote, 6), round(quote_unclosed_value, 6)]
         ]
 
         return pd.DataFrame(data=data)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -622,7 +622,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         # See if there're any open orders.
         if len(self.active_orders) > 0:
             df = self.active_orders_df()
-            equity_df= self.equity_orders_df()
+            equity_df= self.equity_orders_df([self._market_info])
             lines.extend(["", "  Orders:"] + ["    " + line for line in df.to_string(index=False).split("\n")])
             lines.extend(["", "  Equity:"] + ["    " + line for line in equity_df.to_string(index=False).split("\n")])
         else:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -563,9 +563,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
         data=[
             ["", quote_asset],
-            ["Current Value", round(total_in_quote, 4)],
-            ["Equity", round(equity_value, 4)],
-            ["delta", round(unclosed_value, 4)]
+            ["Current Value", round(total_in_quote, 6)],
+            ["Equity", round(equity_value, 6)],
+            ["delta", round(unclosed_value, 6)]
         ]
 
         return pd.DataFrame(data=data)
@@ -621,9 +621,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         # See if there're any open orders.
         if len(self.active_orders) > 0:
             df = self.active_orders_df()
-            equity_df = self.equity_orders_df()
             lines.extend(["", "  Orders:"] + ["    " + line for line in df.to_string(index=False).split("\n")])
-            lines.extend(["", "  Equity:"] + ["    " + line for line in equity_df.to_string(index=False).split("\n")])
+            
+            if global_config_map.get("advanced_stats").value:
+                equity_df = self.equity_orders_df()
+                lines.extend(["", "  Equity:"] + ["    " + line for line in equity_df.to_string(index=False, header=False).split("\n")])
         else:
             lines.extend(["", "  No active maker orders."])
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -601,7 +601,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         cdef:
             list lines = []
             list warning_lines = []
-        warning_lines.extend(self._ping_pong_warning_lines)
+        warning_lines.extend(self._peing_pong_warning_lines)
         warning_lines.extend(self.network_warning([self._market_info]))
 
         markets_df = self.market_status_data_frame([self._market_info])
@@ -621,7 +621,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         # See if there're any open orders.
         if len(self.active_orders) > 0:
             df = self.active_orders_df()
-            equity_df= self.equity_orders_df([self._market_info])
+            equity_df = self.equity_orders_df()
             lines.extend(["", "  Orders:"] + ["    " + line for line in df.to_string(index=False).split("\n")])
             lines.extend(["", "  Equity:"] + ["    " + line for line in equity_df.to_string(index=False).split("\n")])
         else:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,9 +555,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                unclosed_value -= (float(order.price) * float(order.quantity)) * float(price)
+                unclosed_value -= (float(order.quantity) * float(order.price))
             else:
-                unclosed_value += (float(order.price) * float(order.quantity)) * float(price)
+                unclosed_value += (float(order.quantity) * float(order.price))
 
         equity_value = float(unclosed_value) + float(total_in_quote)
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,12 +555,10 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                float fee = 0.001
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
-                unclosed_value_base += float(order.quantity) * (Decimal(1) - fee)
+                unclosed_value_base += float(order.quantity)
             else:
-                float fee = 0.001
-                unclosed_value_quote += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee)
+                unclosed_value_quote += (float(order.quantity) * float(order.price))
                 unclosed_value_base -= float(order.quantity)
 
         quote_unclosed_value = float(unclosed_value_quote) + (float(unclosed_value_base) * float(price))

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,9 +555,13 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
+                fee = market.c_get_fee(self.base_asset, self.quote_asset,
+                        self._limit_order_type, TradeType.BUY, order.quantity, order.price)
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
                 unclosed_value_base += float(order.quantity) * (Decimal(1) - fee.percent)
             else:
+                fee = market.c_get_fee(self.base_asset, self.quote_asset,
+                        self._limit_order_type, TradeType.SELL, order.quantity, order.price)
                 unclosed_value_quote += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee.percent)
                 unclosed_value_base -= float(order.quantity)
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -631,7 +631,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         if len(self.active_orders) > 0:
             df = self.active_orders_df()
             lines.extend(["", "  Orders:"] + ["    " + line for line in df.to_string(index=False).split("\n")])
-            
+
             if global_config_map.get("advanced_stats").value:
                 equity_df = self.equity_orders_df()
                 lines.extend(["", "  Equity:"] + ["    " + line for line in equity_df.to_string(index=False, header=False).split("\n")])

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -558,12 +558,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             order = active_orders[idx]
             if order.is_buy:
                 fee = self.market.get_fee(self.base_asset, self.quote_asset,
-                                          self._limit_order_type, TradeType.BUY, order_quantity, order.price)
+                                          self._limit_order_type, TradeType.BUY, order.quantity, order.price)
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
                 unclosed_value_base += float(order.quantity) * (1 - fee.percent)
             else:
                 fee = self.market.get_fee(self.base_asset, self.quote_asset,
-                                          self._limit_order_type, TradeType.SELL, order_quantity, order.price)
+                                          self._limit_order_type, TradeType.SELL, order.quantity, order.price)
                 unclosed_value_quote += (float(order.quantity) * float(order.price)) * (1 - fee.percent)
                 unclosed_value_base -= float(order.quantity)
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,12 +555,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                fee = market.c_get_fee(self.base_asset, self.quote_asset,
+                fee = market.get_fee(self.base_asset, self.quote_asset,
                         self._limit_order_type, TradeType.BUY, order.quantity, order.price)
                 unclosed_value_quote -= (float(order.quantity) * float(order.price))
                 unclosed_value_base += float(order.quantity) * (Decimal(1) - fee.percent)
             else:
-                fee = market.c_get_fee(self.base_asset, self.quote_asset,
+                fee = market.get_fee(self.base_asset, self.quote_asset,
                         self._limit_order_type, TradeType.SELL, order.quantity, order.price)
                 unclosed_value_quote += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee.percent)
                 unclosed_value_base -= float(order.quantity)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -555,17 +555,20 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
             if order.is_buy:
-                unclosed_value -= (float(order.quantity) * float(order.price))
+                unclosed_value[quote_asset] -= (float(order.quantity) * float(order.price))
+                unclosed_value[base_asset] += float(order.quantity) * (Decimal(1) - fee.percent)
             else:
-                unclosed_value += (float(order.quantity) * float(order.price))
+                unclosed_value[quote_asset] += (float(order.quantity) * float(order.price)) * (Decimal(1) - fee.percent)
+                unclosed_value[base_asset] -= float(order.quantity)
 
-        equity_value = float(unclosed_value) + float(total_in_quote)
+        quote_unclosed_value = unclosed_value[quote_asset] + (unclosed_value[base_asset] * float(price))
+        equity_value = float(quote_unclosed_value) + float(total_in_quote)
 
         data=[
-            ["", quote_asset],
-            ["Current Value", round(total_in_quote, 6)],
-            ["Equity", round(equity_value, 6)],
-            ["delta", round(unclosed_value, 6)]
+            ["", base_asset, quote_asset, f"Total in ({quote_asset})"],
+            ["Current Value", round(base_balance, 6), round(quote_balance, 6), round(total_in_quote, 6)],
+            ["Equity", round(base_balance + unclosed_value[base_asset], 6), round(quote_balance + unclosed_value[quote_asset], 6), round(equity_value, 6)],
+            ["delta", round(unclosed_value[base_asset], 6), round(unclosed_value[quote_asset], 6), round(quote_unclosed_value, 6)]
         ]
 
         return pd.DataFrame(data=data)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -601,7 +601,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         cdef:
             list lines = []
             list warning_lines = []
-        warning_lines.extend(self._peing_pong_warning_lines)
+        warning_lines.extend(self._ping_pong_warning_lines)
         warning_lines.extend(self.network_warning([self._market_info]))
 
         markets_df = self.market_status_data_frame([self._market_info])

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -83,6 +83,9 @@ kill_switch_enabled: null
 # The rate of performance at which you would want the bot to stop trading (-20 = 20%)
 kill_switch_rate: null
 
+# Advanced stats (wequity, relative-to-start profitability)
+advanced_stats: false
+
 # DEX active order cancellation
 0x_active_cancels: false
 


### PR DESCRIPTION
In an effort to better asses the market-making profitability of my pmm bot I added relative-to-start profitability (as in the hummingbot blog: [here](https://hummingbot.io/blog/2019-07-measure-performance-crypto-trading/), the fixed method) and equity (to status screen).

Equity represents the value that would be returned to a company's shareholders if all of the assets were liquidated and all of the company's debts were paid off. We can also think of equity as a degree of residual ownership in a firm or asset after subtracting all debts associated with that asset. (Wikipedia)

Basically equity is the balance you would have if all the orders were instantly closed, this solves the hanging orders dragging down your profitability, when they could close soon/or never (so take some precaution).

In global config I added a variable `advanced_stats`, which enables the display of the mentioned statistics.

_Minor issues that I didn't know how to solve but don't affect the functionality of the bot:_

> There is only one problem I didn't know how to tackle. The advanced_stats variable isn't persistant. Every time I restart the hummingbot it has empty value and you have to set it again.
> 
> Also: I also found increased RAM usage in my docker image, but haven't found the reason why or if it even is a problem.

The build passes on docker hub and I am sucessfully running it.

![image](https://user-images.githubusercontent.com/24854006/105644936-c6e70180-5e98-11eb-97d2-06cb9f158a09.png)
![image](https://user-images.githubusercontent.com/24854006/105644960-f138bf00-5e98-11eb-8898-dbd34a6041f3.png)
