### PR TITLE
Feat/add stop_loss to perpetual mm strategy

### DIFF
--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
@@ -21,6 +21,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         object _stop_loss_spread
         object _close_position_order_type
         object _close_order_type
+        double _market_position_close_timestamp
         int _order_levels
         int _buy_levels
         int _sell_levels
@@ -52,7 +53,6 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         int _filled_buys_balance
         int _filled_sells_balance
         list _hanging_order_ids
-        list _exit_order_ids
         double _last_timestamp
         double _status_report_interval
         int64_t _logging_options

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
@@ -20,6 +20,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         object _ts_callback_rate
         object _stop_loss_spread
         object _close_position_order_type
+        object _close_order_type
         int _order_levels
         int _buy_levels
         int _sell_levels
@@ -62,6 +63,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
     cdef c_manage_positions(self, list session_positions)
     cdef c_profit_taking_feature(self, object mode, list active_positions)
     cdef c_trailing_stop_feature(self, object mode, list active_positions)
+    cdef c_stop_loss_feature(self, object mode, list active_positions)
     cdef c_apply_initial_settings(self, str trading_pair, object position, int64_t leverage)
     cdef object c_get_mid_price(self)
     cdef object c_create_base_proposal(self)

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
@@ -58,7 +58,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         object _last_own_trade_price
         object _ts_peak_bid_price
         object _ts_peak_ask_price
-        list _ts_exit_orders
+        list _exit_orders
     cdef c_manage_positions(self, list session_positions)
     cdef c_profit_taking_feature(self, object mode, list active_positions)
     cdef c_trailing_stop_feature(self, object mode, list active_positions)

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
@@ -18,6 +18,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         object _short_profit_taking_spread
         object _ts_activation_spread
         object _ts_callback_rate
+        object _stop_loss_spread
         object _close_position_order_type
         int _order_levels
         int _buy_levels

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -787,7 +787,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                 else position.entry_price * (Decimal("1") - self._stop_loss_spread)
             if (top_ask <= stop_loss_price and position.amount > 0):
                 price = market.c_quantize_order_price(self.trading_pair, stop_loss_price)
-                take_profit_orders = [o for o in active_orders if (o.is_buy and position.amount < 0 and o.client_order_id in self._exit_orders)]
+                take_profit_orders = [o for o in active_orders if (not o.is_buy and o.price > stop_loss_price and o.client_order_id in self._exit_orders)]
                 # cancel take profit orders if they exist
                 for old_order in take_profit_orders:
                     self.c_cancel_order(self._market_info, old_order.client_order_id)
@@ -803,7 +803,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                         sells.append(PriceSize(price, size))
             elif (top_bid >= stop_loss_price and position.amount < 0):
                 price = market.c_quantize_order_price(self.trading_pair, stop_loss_price)
-                take_profit_orders = [o for o in active_orders if (not o.is_buy and position.amount > 0 and o.client_order_id in self._exit_orders)]
+                take_profit_orders = [o for o in active_orders if (o.is_buy and o.price < stop_loss_price and o.client_order_id in self._exit_orders)]
                 # cancel take profit orders if they exist
                 for old_order in take_profit_orders:
                     self.c_cancel_order(self._market_info, old_order.client_order_id)

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -460,8 +460,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         market, trading_pair = self._market_info.market, self._market_info.trading_pair
         for idx in self.active_positions.values():
             is_buy = True if idx.amount > 0 else False
-            unrealized_profit = ((market.get_price(trading_pair, is_buy) - idx.entry_price) * idx.amount) if is_buy \
-                else ((market.get_price(trading_pair, is_buy) - idx.entry_price) * idx.amount)
+            unrealized_profit = ((market.get_price(trading_pair, is_buy) - idx.entry_price) * idx.amount)
             data.append([
                 idx.trading_pair,
                 idx.position_side.name,

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -159,7 +159,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         self._last_own_trade_price = Decimal('nan')
         self._ts_peak_bid_price = Decimal('0')
         self._ts_peak_ask_price = Decimal('0')
-        self._ts_exit_orders = []
+        self._exit_orders = []
 
         self.c_add_markets([market_info.market])
 
@@ -629,7 +629,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         cdef:
             ExchangeBase market = self._market_info.market
             list active_orders = self.active_orders
-            list unwanted_exit_orders = [o for o in active_orders if o.client_order_id not in self._ts_exit_orders]
+            list unwanted_exit_orders = [o for o in active_orders if o.client_order_id not in self._exit_orders]
             list buys = []
             list sells = []
 
@@ -653,8 +653,8 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
             take_profit_price = position.entry_price * (Decimal("1") + profit_spread) if position.amount > 0 \
                 else position.entry_price * (Decimal("1") - profit_spread)
             price = market.c_quantize_order_price(self.trading_pair, take_profit_price)
-            old_exit_orders = [o for o in active_orders if (o.price > price and position.amount < 0 and o.client_order_id in self._ts_exit_orders)
-                               or (o.price < price and position.amount > 0 and o.client_order_id in self._ts_exit_orders)]
+            old_exit_orders = [o for o in active_orders if (o.price > price and position.amount < 0 and o.client_order_id in self._exit_orders)
+                               or (o.price < price and position.amount > 0 and o.client_order_id in self._exit_orders)]
             for old_order in old_exit_orders:
                 self.c_cancel_order(self._market_info, old_order.client_order_id)
                 self.logger().info(f"Cancelled previous take profit order {old_order.client_order_id} in favour of new take profit order.")
@@ -687,7 +687,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                 self.logger().info(f"Kindly ensure you do not interract with the exchange through other platforms and restart this strategy.")
             else:
                 # Cancel open order that could potentially close position and affect trailing stop functionality
-                unwanted_exit_orders = [o for o in active_orders if o.client_order_id not in self._ts_exit_orders]
+                unwanted_exit_orders = [o for o in active_orders if o.client_order_id not in self._exit_orders]
                 for order in unwanted_exit_orders:
                     if active_positions[0].amount < 0 and order.is_buy:
                         self.c_cancel_order(self._market_info, order.client_order_id)
@@ -707,9 +707,9 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                     price = market.c_quantize_order_price(self.trading_pair, exit_price)
 
                     # Do some checks to prevent duplicating orders to close positions
-                    exit_order_exists = [o for o in active_orders if o.client_order_id in self._ts_exit_orders]
+                    exit_order_exists = [o for o in active_orders if o.client_order_id in self._exit_orders]
                     create_order = True
-                    self._ts_exit_orders = [] if len(exit_order_exists) == 0 else self._ts_exit_orders
+                    self._exit_orders = [] if len(exit_order_exists) == 0 else self._exit_orders
                     for order in exit_order_exists:
                         if not order.is_buy:
                             create_order = False
@@ -725,9 +725,9 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                         price = market.c_quantize_order_price(self.trading_pair, exit_price)
 
                         # Do some checks to prevent duplicating orders to close positions
-                        exit_order_exists = [o for o in active_orders if o.client_order_id in self._ts_exit_orders]
+                        exit_order_exists = [o for o in active_orders if o.client_order_id in self._exit_orders]
                         create_order = True
-                        self._ts_exit_orders = [] if len(exit_order_exists) == 0 else self._ts_exit_orders
+                        self._exit_orders = [] if len(exit_order_exists) == 0 else self._exit_orders
                         for order in exit_order_exists:
                             if not order.is_buy:
                                 create_order = False
@@ -743,9 +743,9 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                     price = market.c_quantize_order_price(self.trading_pair, exit_price)
 
                     # Do some checks to prevent duplicating orders to close positions
-                    exit_order_exists = [o for o in active_orders if o.client_order_id in self._ts_exit_orders]
+                    exit_order_exists = [o for o in active_orders if o.client_order_id in self._exit_orders]
                     create_order = True
-                    self._ts_exit_orders = [] if len(exit_order_exists) == 0 else self._ts_exit_orders
+                    self._exit_orders = [] if len(exit_order_exists) == 0 else self._exit_orders
                     for order in exit_order_exists:
                         if order.is_buy:
                             create_order = False
@@ -761,9 +761,9 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                         price = market.c_quantize_order_price(self.trading_pair, exit_price)
 
                         # Do some checks to prevent duplicating orders to close positions
-                        exit_order_exists = [o for o in active_orders if o.client_order_id in self._ts_exit_orders]
+                        exit_order_exists = [o for o in active_orders if o.client_order_id in self._exit_orders]
                         create_order = True
-                        self._ts_exit_orders = [] if len(exit_order_exists) == 0 else self._ts_exit_orders
+                        self._exit_orders = [] if len(exit_order_exists) == 0 else self._exit_orders
                         for order in exit_order_exists:
                             if order.is_buy:
                                 create_order = False
@@ -1195,7 +1195,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                     position_action=position_action
                 )
                 if position_action == PositionAction.CLOSE:
-                    self._ts_exit_orders.append(bid_order_id)
+                    self._exit_orders.append(bid_order_id)
                 orders_created = True
         if len(proposal.sells) > 0:
             if self._logging_options & self.OPTION_LOG_CREATE_ORDER:
@@ -1216,7 +1216,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                     position_action=position_action
                 )
                 if position_action == PositionAction.CLOSE:
-                    self._ts_exit_orders.append(ask_order_id)
+                    self._exit_orders.append(ask_order_id)
                 orders_created = True
         if orders_created:
             self.set_timers()

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -76,6 +76,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                  short_profit_taking_spread: Decimal,
                  ts_activation_spread: Decimal,
                  ts_callback_rate: Decimal,
+                 stop_loss_spread: Decimal,
                  close_position_order_type: str,
                  order_levels: int = 1,
                  order_level_spread: Decimal = s_decimal_zero,
@@ -119,6 +120,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         self._short_profit_taking_spread = short_profit_taking_spread
         self._ts_activation_spread = ts_activation_spread
         self._ts_callback_rate = ts_callback_rate
+        self._stop_loss_spread = stop_loss_spread
         self._close_position_order_type = OrderType.MARKET if close_position_order_type == "MARKET" else OrderType.LIMIT
         self._order_levels = order_levels
         self._buy_levels = order_levels

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -787,7 +787,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                 else position.entry_price * (Decimal("1") - self._stop_loss_spread)
             if (top_ask <= stop_loss_price and position.amount > 0):
                 price = market.c_quantize_order_price(self.trading_pair, stop_loss_price)
-                take_profit_orders = [o for o in active_orders if (not o.is_buy and o.price > stop_loss_price and o.client_order_id in self._exit_orders)]
+                take_profit_orders = [o for o in active_orders if (not o.is_buy and o.price > price and o.client_order_id in self._exit_orders)]
                 # cancel take profit orders if they exist
                 for old_order in take_profit_orders:
                     self.c_cancel_order(self._market_info, old_order.client_order_id)
@@ -803,7 +803,7 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
                         sells.append(PriceSize(price, size))
             elif (top_bid >= stop_loss_price and position.amount < 0):
                 price = market.c_quantize_order_price(self.trading_pair, stop_loss_price)
-                take_profit_orders = [o for o in active_orders if (o.is_buy and o.price < stop_loss_price and o.client_order_id in self._exit_orders)]
+                take_profit_orders = [o for o in active_orders if (o.is_buy and o.price < price and o.client_order_id in self._exit_orders)]
                 # cancel take profit orders if they exist
                 for old_order in take_profit_orders:
                     self.c_cancel_order(self._market_info, old_order.client_order_id)

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making_config_map.py
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making_config_map.py
@@ -230,6 +230,13 @@ perpetual_market_making_config_map = {
                   default=Decimal("0"),
                   validator=lambda v: validate_decimal(v, 0, 100, True),
                   prompt_on_new=True),
+    "stop_loss_spread":
+        ConfigVar(key="stop_loss_spread",
+                  prompt="At what spread from position entry price do you want to stop_loss? (Enter 1 for 1%) >>> ",
+                  type_str="decimal",
+                  default=Decimal("0"),
+                  validator=lambda v: validate_decimal(v, 0, 101, False),
+                  prompt_on_new=True),
     "close_position_order_type":
         ConfigVar(key="close_position_order_type",
                   prompt="What order type do you want to use for closing positions? (LIMIT/MARKET) >>> ",

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making_config_map.py
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making_config_map.py
@@ -232,15 +232,14 @@ perpetual_market_making_config_map = {
                   prompt_on_new=True),
     "stop_loss_spread":
         ConfigVar(key="stop_loss_spread",
-                  prompt="At what spread from position entry price do you want to stop_loss? (Enter 1 for 1%) >>> ",
+                  prompt="At what spread from position entry price do you want to place stop_loss order? (Enter 1 for 1%) >>> ",
                   type_str="decimal",
                   default=Decimal("0"),
                   validator=lambda v: validate_decimal(v, 0, 101, False),
                   prompt_on_new=True),
     "close_position_order_type":
         ConfigVar(key="close_position_order_type",
-                  prompt="What order type do you want to use for closing positions? (LIMIT/MARKET) >>> ",
-                  required_if=lambda: perpetual_market_making_config_map.get("position_management").value == "Trailing_stop",
+                  prompt="What order type do you want trailing stop and/or stop loss features to use for closing positions? (LIMIT/MARKET) >>> ",
                   type_str="str",
                   default="LIMIT",
                   validator=lambda s: None if s in {"LIMIT", "MARKET"} else

--- a/hummingbot/strategy/perpetual_market_making/start.py
+++ b/hummingbot/strategy/perpetual_market_making/start.py
@@ -28,6 +28,7 @@ def start(self):
         short_profit_taking_spread = c_map.get("short_profit_taking_spread").value / Decimal('100')
         ts_activation_spread = c_map.get("ts_activation_spread").value / Decimal('100')
         ts_callback_rate = c_map.get("ts_callback_rate").value / Decimal('100')
+        stop_loss_spread = c_map.get("stop_loss_spread").value / Decimal('100')
         close_position_order_type = c_map.get("close_position_order_type").value
         minimum_spread = c_map.get("minimum_spread").value / Decimal('100')
         price_ceiling = c_map.get("price_ceiling").value
@@ -86,6 +87,7 @@ def start(self):
             short_profit_taking_spread = short_profit_taking_spread,
             ts_activation_spread = ts_activation_spread,
             ts_callback_rate = ts_callback_rate,
+            stop_loss_spread = stop_loss_spread,
             close_position_order_type = close_position_order_type,
             order_level_spread=order_level_spread,
             order_level_amount=order_level_amount,

--- a/hummingbot/templates/conf_perpetual_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_perpetual_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Perpetual market making strategy config         ###
 ########################################################
 
-template_version: 3
+template_version: 4
 strategy: null
 
 # derivative and token parameters.
@@ -58,6 +58,9 @@ ts_activation_spread: null
 
 # Callback rate for trailing stop
 ts_callback_rate: null
+
+# Spread from position entry price to place a stop-loss order to close position
+stop_loss_spread: null
 
 # OrderType to use for closing positions when using Trailing stop feature
 close_position_order_type: null


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
**With profit taking feature:**
- A profit taking order would be placed immediately if the position has no opening loss, otherwise it'd monitor position and place a stop-loss order if loss increases to the set stop-loss spread.
- Existing take profit order will be cancelled and stop-loss order will be placed if loss increases to the set stop-loss spread.
-  If stop-loss spread is set too low and LIMIT order is specified to close position in an active market, there's a high probability that the take profit feature would cancel and replace a stop-loss order. Both features might even compete every tick and cancel order previously set by the other.

**With trailing stop feature:**
- A log has been added to this feature to include the price at which the feature would close an active position. Price "NILL" means the market is yet to move enough to have a peak price that'll give a profitable exit price according to the configured parameters for the feature.
- Once a profitable exit price is detected, no stop-loss order should be placed(except for weird cases where the market swings swiftly to an unprofitable price within ticks or configured ts parameters are too low.)
- In the event that no exit price has been detected, an order from the stop-loss feature may be placed if loss increases to the set stop-loss spread. 