### PR TITLE
(feat) Added all_order_books to ScriptBase class

### DIFF
--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -986,3 +986,7 @@ class BinancePerpetualDerivative(DerivativeBase):
                 self.logger().error(f"Error fetching {path}", exc_info=True)
                 self.logger().warning(f"{e}")
                 raise e
+
+    @property
+    def order_book_tracker(self) -> BinancePerpetualOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/bamboo_relay/bamboo_relay_exchange.pyx
+++ b/hummingbot/connector/exchange/bamboo_relay/bamboo_relay_exchange.pyx
@@ -1824,3 +1824,7 @@ cdef class BambooRelayExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> BambooRelayOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
+++ b/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
@@ -1376,3 +1376,7 @@ cdef class BitfinexExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> BitfinexOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/bittrex/bittrex_exchange.pyx
+++ b/hummingbot/connector/exchange/bittrex/bittrex_exchange.pyx
@@ -1060,3 +1060,7 @@ cdef class BittrexExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> BittrexOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
+++ b/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
@@ -1111,3 +1111,7 @@ cdef class CoinbaseProExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> CoinbaseProOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/crypto_com/crypto_com_exchange.py
+++ b/hummingbot/connector/exchange/crypto_com/crypto_com_exchange.py
@@ -829,3 +829,7 @@ class CryptoComExchange(ExchangeBase):
                 )
             )
         return ret_val
+
+    @property
+    def order_book_tracker(self) -> CryptoComOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/dolomite/dolomite_exchange.pyx
+++ b/hummingbot/connector/exchange/dolomite/dolomite_exchange.pyx
@@ -773,3 +773,7 @@ cdef class DolomiteExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> DolomiteOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/dydx/dydx_exchange.pyx
+++ b/hummingbot/connector/exchange/dydx/dydx_exchange.pyx
@@ -1018,3 +1018,7 @@ cdef class DydxExchange(ExchangeBase):
                 amount: Decimal,
                 price: Decimal = s_decimal_NaN) -> TradeFee:
         return self.c_get_fee(base_currency, quote_currency, order_type, order_side, amount, price)
+
+    @property
+    def order_book_tracker(self) -> DydxOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/eterbase/eterbase_exchange.pyx
+++ b/hummingbot/connector/exchange/eterbase/eterbase_exchange.pyx
@@ -1258,3 +1258,7 @@ cdef class EterbaseExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> EterbaseOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.pyx
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.pyx
@@ -1110,3 +1110,7 @@ cdef class KrakenExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> KrakenOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
+++ b/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
@@ -1284,3 +1284,7 @@ cdef class LiquidExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> LiquidOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/loopring/loopring_exchange.pyx
+++ b/hummingbot/connector/exchange/loopring/loopring_exchange.pyx
@@ -964,3 +964,7 @@ cdef class LoopringExchange(ExchangeBase):
                 amount: Decimal,
                 price: Decimal = s_decimal_NaN) -> TradeFee:
         return self.c_get_fee(base_currency, quote_currency, order_type, order_side, amount, price)
+
+    @property
+    def order_book_tracker(self) -> LoopringOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -995,3 +995,7 @@ cdef class PaperTradeExchange(ExchangeBase):
 
     def get_taker_order_type(self):
         return OrderType.LIMIT
+
+    @property
+    def order_book_tracker(self) -> OrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/connector/exchange/radar_relay/radar_relay_exchange.pyx
+++ b/hummingbot/connector/exchange/radar_relay/radar_relay_exchange.pyx
@@ -1088,3 +1088,7 @@ cdef class RadarRelayExchange(ExchangeBase):
 
     def get_order_book(self, trading_pair: str) -> OrderBook:
         return self.c_get_order_book(trading_pair)
+
+    @property
+    def order_book_tracker(self) -> RadarRelayOrderBookTracker:
+        return self._order_book_tracker

--- a/hummingbot/script/script_base.py
+++ b/hummingbot/script/script_base.py
@@ -1,10 +1,11 @@
 import asyncio
 import traceback
 from multiprocessing import Queue
-from typing import List, Optional, Dict, Any, Callable
+from typing import List, Optional, Dict, Any, Callable, Tuple
 from decimal import Decimal
 from statistics import mean, median
 from operator import itemgetter
+import pandas as pd
 from .script_interface import OnTick, OnStatus, PMMParameters, CallNotify, CallLog, PmmMarketInfo, ScriptError
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
@@ -29,6 +30,7 @@ class ScriptBase:
         self.all_total_balances: Dict[str, Dict[str, Decimal]] = None
         # all_available_balances has the same data structure as all_total_balances
         self.all_available_balances: Dict[str, Dict[str, Decimal]] = None
+        self.all_order_books: Dict[str, Dict[str, Tuple[pd.DataFrame, pd.DataFrame]]]
 
     def assign_init(self, parent_queue: Queue, child_queue: Queue, queue_check_interval: float):
         self._parent_queue = parent_queue
@@ -62,6 +64,7 @@ class ScriptBase:
                     self.pmm_parameters = item.pmm_parameters
                     self.all_total_balances = item.all_total_balances
                     self.all_available_balances = item.all_available_balances
+                    self.all_order_books = item.all_order_books
                     self.on_tick()
                 elif isinstance(item, BuyOrderCompletedEvent):
                     self.on_buy_order_completed(item)

--- a/hummingbot/script/script_interface.py
+++ b/hummingbot/script/script_interface.py
@@ -1,5 +1,6 @@
-from typing import Dict
+from typing import Dict, Tuple
 from decimal import Decimal
+import pandas as pd
 
 child_queue = None
 
@@ -117,11 +118,13 @@ class OnTick:
                  pmm_parameters: PMMParameters,
                  all_total_balances: Dict[str, Dict[str, Decimal]],
                  all_available_balances: Dict[str, Dict[str, Decimal]],
+                 all_order_books: Dict[str, Dict[str, Tuple[pd.DataFrame, pd.DataFrame]]]
                  ):
         self.mid_price = mid_price
         self.pmm_parameters = pmm_parameters
         self.all_total_balances = all_total_balances
         self.all_available_balances = all_available_balances
+        self.all_order_books = all_order_books
 
     def __repr__(self):
         return f"{self.__class__.__name__} {str(self.__dict__)}"

--- a/hummingbot/script/script_iterator.pyx
+++ b/hummingbot/script/script_iterator.pyx
@@ -99,7 +99,8 @@ cdef class ScriptIterator(TimeIterator):
                 param_value = getattr(self._strategy, attr)
                 setattr(pmm_strategy, attr, param_value)
         cdef object on_tick = OnTick(self.strategy.get_mid_price(), pmm_strategy,
-                                     self.all_total_balances(), self.all_available_balances())
+                                     self.all_total_balances(), self.all_available_balances(),
+                                     self.all_order_books())
         self._parent_queue.put(on_tick)
 
     def _did_complete_buy_order(self,
@@ -153,3 +154,6 @@ cdef class ScriptIterator(TimeIterator):
             connector = [c for c in self._markets if c.name == exchange][0]
             ret_val[exchange] = {token: connector.get_available_balance(token) for token in balances.keys()}
         return ret_val
+
+    def all_order_books(self):
+        return {market.name: market.order_book_tracker.snapshot for market in self._markets if hasattr(market, "order_book_tracker")}


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

ScriptBase class now has a new attribute called all_order_books with a dictionary.
There's one key per market and values are dictionaries with key:value = trading_pair:Tuple[Bid_OrderBook, Ask_OrderBook].
With OrderBooks being modeled with the pandas dataframe used for snapshots.

Still thinking of a good use case to build a sample script to be included in this PR.

