### PR TITLE
fix/Fixed bug in trade history retrieval for history reconciliation

### DIFF
--- a/hummingbot/connector/connector_base.pxd
+++ b/hummingbot/connector/connector_base.pxd
@@ -13,7 +13,7 @@ cdef class ConnectorBase(NetworkIterator):
         public dict _in_flight_orders_snapshot
         public double _in_flight_orders_snapshot_timestamp
         public set _current_trade_fills
-        public set _exchange_order_ids
+        public dict _exchange_order_ids
 
     cdef str c_buy(self, str trading_pair, object amount, object order_type=*, object price=*, dict kwargs=*)
     cdef str c_sell(self, str trading_pair, object amount, object order_type=*, object price=*, dict kwargs=*)

--- a/hummingbot/connector/connector_base.pyx
+++ b/hummingbot/connector/connector_base.pyx
@@ -57,7 +57,7 @@ cdef class ConnectorBase(NetworkIterator):
         self._in_flight_orders_snapshot = {}  # Dict[order_id:str, InFlightOrderBase]
         self._in_flight_orders_snapshot_timestamp = 0.0
         self._current_trade_fills = set()
-        self._exchange_order_ids = set()
+        self._exchange_order_ids = dict()
 
     @property
     def real_time_balance_update(self) -> bool:
@@ -423,7 +423,7 @@ cdef class ConnectorBase(NetworkIterator):
         """
         self._current_trade_fills.update(current_trade_fills)
 
-    def add_exchange_order_ids_from_market_recorder(self, current_exchange_order_ids: Set[str]):
+    def add_exchange_order_ids_from_market_recorder(self, current_exchange_order_ids: Dict[str, str]):
         """
         Gets updates from new orders in Order table. This is used in method connector _history_reconciliation
         """
@@ -436,4 +436,4 @@ cdef class ConnectorBase(NetworkIterator):
         """
         # Assume (market, exchange_trade_id, trading_pair) are unique. Also order has to be recorded in Order table
         return (not TradeFillOrderDetails(self.display_name, exchange_trade_id, trading_pair) in self._current_trade_fills) and \
-               (exchange_order_id in self._exchange_order_ids)
+               (exchange_order_id in set(self._exchange_order_ids.keys()))

--- a/hummingbot/connector/exchange/binance/binance_exchange.pyx
+++ b/hummingbot/connector/exchange/binance/binance_exchange.pyx
@@ -447,8 +447,8 @@ cdef class BinanceExchange(ExchangeBase):
             tasks=[]
             for trading_pair in self._order_book_tracker._trading_pairs:
                 my_trades_query_args = {'symbol': convert_to_exchange_trading_pair(trading_pair)}
-            tasks.append(self.query_api(self._binance_client.get_my_trades,
-                                        **my_trades_query_args))
+                tasks.append(self.query_api(self._binance_client.get_my_trades,
+                                            **my_trades_query_args))
             self.logger().debug("Polling for order fills of %d trading pairs.", len(tasks))
             exchange_history = await safe_gather(*tasks, return_exceptions=True)
         for trades, trading_pair in zip(exchange_history, self._order_book_tracker._trading_pairs):
@@ -460,14 +460,13 @@ cdef class BinanceExchange(ExchangeBase):
                 continue
             for trade in trades:
                 if self.is_confirmed_new_order_filled_event(str(trade["id"]), str(trade["orderId"]), trading_pair):
-                    client_order_id = get_client_order_id("buy" if trade["isBuyer"] else "sell", trading_pair)
                     # Should check if this is a partial filling of a in_flight order.
                     # In that case, user_stream or _update_order_fills_from_trades will take care when fully filled.
-                    if client_order_id not in self.in_flight_orders:
+                    if not any(trade["id"] in in_flight_order.trade_id_set for in_flight_order in self._in_flight_orders.values()):
                         self.c_trigger_event(self.MARKET_ORDER_FILLED_EVENT_TAG,
                                              OrderFilledEvent(
                                                  trade["time"],
-                                                 client_order_id,
+                                                 get_client_order_id("buy" if trade["isBuyer"] else "sell", trading_pair),
                                                  trading_pair,
                                                  TradeType.BUY if trade["isBuyer"] else TradeType.SELL,
                                                  OrderType.LIMIT_MAKER,  # defaulting to this value since trade info lacks field

--- a/hummingbot/connector/exchange/binance/binance_exchange.pyx
+++ b/hummingbot/connector/exchange/binance/binance_exchange.pyx
@@ -466,7 +466,8 @@ cdef class BinanceExchange(ExchangeBase):
                         self.c_trigger_event(self.MARKET_ORDER_FILLED_EVENT_TAG,
                                              OrderFilledEvent(
                                                  trade["time"],
-                                                 get_client_order_id("buy" if trade["isBuyer"] else "sell", trading_pair),
+                                                 self._exchange_order_ids.get(str(trade["orderId"]),
+                                                                              get_client_order_id("buy" if trade["isBuyer"] else "sell", trading_pair)),
                                                  trading_pair,
                                                  TradeType.BUY if trade["isBuyer"] else TradeType.SELL,
                                                  OrderType.LIMIT_MAKER,  # defaulting to this value since trade info lacks field

--- a/hummingbot/connector/markets_recorder.py
+++ b/hummingbot/connector/markets_recorder.py
@@ -67,7 +67,7 @@ class MarketsRecorder:
                                                                                tf.symbol) for tf in trade_fills})
 
             exchange_order_ids = self.get_orders_for_config_and_market(self._config_file_path, market, True, 2000)
-            market.add_exchange_order_ids_from_market_recorder({o.exchange_order_id for o in exchange_order_ids})
+            market.add_exchange_order_ids_from_market_recorder({o.exchange_order_id: o.id for o in exchange_order_ids})
 
         self._create_order_forwarder: SourceInfoEventForwarder = SourceInfoEventForwarder(self._did_create_order)
         self._fill_order_forwarder: SourceInfoEventForwarder = SourceInfoEventForwarder(self._did_fill_order)
@@ -211,7 +211,7 @@ class MarketsRecorder:
                                                 status=event_type.name)
         session.add(order_record)
         session.add(order_status)
-        market.add_exchange_order_ids_from_market_recorder({evt.exchange_order_id})
+        market.add_exchange_order_ids_from_market_recorder({evt.exchange_order_id: evt.order_id})
         self.save_market_states(self._config_file_path, market, no_commit=True)
         session.commit()
 

--- a/test/integration/test_binance_market.py
+++ b/test/integration/test_binance_market.py
@@ -173,7 +173,7 @@ class BinanceExchangeUnitTest(unittest.TestCase):
 
         self.market_logger = EventLogger()
         self.market._current_trade_fills = set()
-        self.market._exchange_order_ids = set()
+        self.market._exchange_order_ids = dict()
         self.ev_loop.run_until_complete(self.wait_til_ready())
         for event_tag in self.events:
             self.market.add_listener(event_tag, self.market_logger)
@@ -241,7 +241,7 @@ class BinanceExchangeUnitTest(unittest.TestCase):
 
         order_id = self.place_order(True, "LINK-ETH", amount, OrderType.LIMIT, bid_price, self.get_current_nonce(), FixtureBinance.BUY_MARKET_ORDER,
                                     FixtureBinance.WS_AFTER_BUY_1, FixtureBinance.WS_AFTER_BUY_2)
-        self.market.add_exchange_order_ids_from_market_recorder({str(FixtureBinance.BUY_MARKET_ORDER['orderId'])})
+        self.market.add_exchange_order_ids_from_market_recorder({str(FixtureBinance.BUY_MARKET_ORDER['orderId']): "buy-LINKETH-1580093594011279"})
         [order_completed_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCompletedEvent))
         order_completed_event: BuyOrderCompletedEvent = order_completed_event
         trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
@@ -269,7 +269,7 @@ class BinanceExchangeUnitTest(unittest.TestCase):
         quantized_amount = order_completed_event.base_asset_amount
         order_id = self.place_order(False, "LINK-ETH", amount, OrderType.LIMIT, ask_price, 10002, FixtureBinance.SELL_MARKET_ORDER,
                                     FixtureBinance.WS_AFTER_SELL_1, FixtureBinance.WS_AFTER_SELL_2)
-        self.market.add_exchange_order_ids_from_market_recorder({str(FixtureBinance.SELL_MARKET_ORDER['orderId'])})
+        self.market.add_exchange_order_ids_from_market_recorder({str(FixtureBinance.SELL_MARKET_ORDER['orderId']): "sell-LINKETH-1580194659898896"})
         [order_completed_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCompletedEvent))
         order_completed_event: SellOrderCompletedEvent = order_completed_event
         trade_events = [t for t in self.market_logger.event_log
@@ -752,7 +752,7 @@ class BinanceExchangeUnitTest(unittest.TestCase):
                 'isMaker': True,
                 'isBestMatch': True,
             }]
-            self.market.add_exchange_order_ids_from_market_recorder({order_id})
+            self.market.add_exchange_order_ids_from_market_recorder({order_id: "buy-LINKETH-1580093594011279"})
             self.web_app.update_response("get", self.base_api_url, "/api/v3/myTrades",
                                          binance_trades, params={'symbol': 'LINKETH'})
             [market_order_completed] = self.run_parallel(self.market_logger.wait_for(OrderFilledEvent))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Changed way order is searched in in_flight_orders when history reconciliating. Also fixed bug when retrieving trade history