### PR TITLE
Fix / Paper Trade Cancel Orders Loop  - change comparison operator

### DIFF
--- a/hummingbot/core/cpp/LimitOrder.cpp
+++ b/hummingbot/core/cpp/LimitOrder.cpp
@@ -62,7 +62,12 @@ LimitOrder &LimitOrder::operator=(const LimitOrder &other) {
 }
 
 bool operator<(LimitOrder const &a, LimitOrder const &b) {
-    return (bool)(PyObject_RichCompareBool(a.price, b.price, Py_LT));
+    if ((bool)(PyObject_RichCompareBool(a.price, b.price, Py_EQ))) {
+        // return (bool)(PyObject_RichCompareBool(a.quantity, b.quantity, Py_LT));
+        return (bool)(a.clientOrderID < b.clientOrderID);
+    } else {
+        return (bool)(PyObject_RichCompareBool(a.price, b.price, Py_LT));
+    }
 }
 
 std::string LimitOrder::getClientOrderID() const {


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes this issue: #2233 where paper trade orders get stuck in a cancel loop.
std::set uses `!(a < b) && !(b < a)` to check for duplicates.
