### PR TITLE
(fix) history reconciliation trading_pairs list

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_exchange.pyx
+++ b/hummingbot/connector/exchange/binance/binance_exchange.pyx
@@ -437,14 +437,12 @@ cdef class BinanceExchange(ExchangeBase):
                                                      ))
 
     async def _history_reconciliation(self):
-        """
-        Method looks in the exchange history to check for any missing trade in local history.
-        If found, it will trigger an order_filled event to record it in local DB.
-        """
         cdef:
-            # The minimum poll interval for order status is 10 seconds.
-            int64_t last_tick = <int64_t>(self._last_poll_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL)
-            int64_t current_tick = <int64_t>(self._current_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL)
+            # Method looks in the exchange history to check for any missing trade in local history.
+            # If found, it will trigger an order_filled event to record it in local DB.
+            # The minimum poll interval for order status is 120 seconds.
+            int64_t last_tick = <int64_t>(self._last_poll_timestamp / self.LONG_POLL_INTERVAL)
+            int64_t current_tick = <int64_t>(self._current_timestamp / self.LONG_POLL_INTERVAL)
 
         if current_tick > last_tick:
             trading_pairs = self._order_book_tracker._trading_pairs


### PR DESCRIPTION
hist recon now performs its own request to get_my_trades instead of reusing result from _update_order_fills_from_trades.
In that way it doesn't rely on the list of in_flight_orders being unchanged between latest call and the history recon.

