### PR TITLE
refactor / update celocli with v1.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | b
     export NVM_DIR="/home/hummingbot/.nvm" && \
     source "/home/hummingbot/.nvm/nvm.sh" && \
     nvm install 10 && \
-    npm install --only=production -g @celo/celocli@0.0.48 && \
+    npm install --only=production -g @celo/celocli@1.0.3 && \
     nvm cache clear && \
     npm cache clean --force && \
     rm -rf /home/hummingbot/.cache

--- a/hummingbot/market/celo/celo_cli.py
+++ b/hummingbot/market/celo/celo_cli.py
@@ -6,9 +6,11 @@ from hummingbot.market.celo.celo_data_types import CeloExchangeRate, CeloBalance
 
 
 UNIT_MULTIPLIER = Decimal(1e18)
-CELO_BASE = "CGLD"
+CELO_BASE = "CELO"
 CELO_QUOTE = "CUSD"
-SYMBOLS_MAP = {CELO_BASE: "gold", CELO_QUOTE: "usd"}
+CELOCLI_CELO = "CELO"
+CELOCLI_CUSD = "cUSD"
+CELOCLI_LOCKED_CELO = "lockedCELO"
 
 
 def command(commands: List[str]) -> Optional[str]:
@@ -57,13 +59,13 @@ class CeloCLI:
         output = command(["celocli", "account:balance", cls.address])
         lines = output.split("\n")
         raw_balances = {}
-        data_type = ["gold", "lockedGold", "usd", "pending"]
+        data_type = [CELOCLI_CELO, CELOCLI_LOCKED_CELO, CELOCLI_CUSD, "pending"]
         for line in lines:
-            if ":" in line and [key for key in data_type if (key in line)]:
+            if ":" in line and any(key in line for key in data_type):
                 asset, value = line.split(":")
                 raw_balances[asset.strip()] = Decimal(value) / UNIT_MULTIPLIER
-        balances[CELO_BASE] = CeloBalance(CELO_BASE, raw_balances["gold"], raw_balances["lockedGold"])
-        balances[CELO_QUOTE] = CeloBalance(CELO_QUOTE, raw_balances["usd"], Decimal("0"))
+        balances[CELO_BASE] = CeloBalance(CELO_BASE, raw_balances[CELOCLI_CELO], raw_balances[CELOCLI_LOCKED_CELO])
+        balances[CELO_QUOTE] = CeloBalance(CELO_QUOTE, raw_balances[CELOCLI_CUSD], Decimal("0"))
         return balances
 
     @classmethod

--- a/test/connector/fixture_celo.py
+++ b/test/connector/fixture_celo.py
@@ -7,45 +7,44 @@ outputs = {
     # For order_amount of 1
     ('celocli', 'exchange:show', '--amount', str(int(9.95 * UNIT_MULTIPLIER))):
         "Fetching exchange rates...... done\n"
-        f"{str(int(9.95 * UNIT_MULTIPLIER))} cGLD => {str(int(99.5 * UNIT_MULTIPLIER))} cUSD\n"
-        f"{str(int(9.95 * UNIT_MULTIPLIER))} cUSD => {str(int(1 * UNIT_MULTIPLIER))} cGLD",
+        f"{str(int(9.95 * UNIT_MULTIPLIER))} CELO => {str(int(99.5 * UNIT_MULTIPLIER))} cUSD\n"
+        f"{str(int(9.95 * UNIT_MULTIPLIER))} cUSD => {str(int(1 * UNIT_MULTIPLIER))} CELO",
 
     ('celocli', 'exchange:show', '--amount', str(int(1 * UNIT_MULTIPLIER))):
         "Fetching exchange rates...... done\n"
-        f"{str(int(1 * UNIT_MULTIPLIER))} cGLD => {str(int(10.5 * UNIT_MULTIPLIER))} cUSD\n"
-        f"{str(int(1 * UNIT_MULTIPLIER))} cUSD => {str(int(0.095 * UNIT_MULTIPLIER))} cGLD",
+        f"{str(int(1 * UNIT_MULTIPLIER))} CELO => {str(int(10.5 * UNIT_MULTIPLIER))} cUSD\n"
+        f"{str(int(1 * UNIT_MULTIPLIER))} cUSD => {str(int(0.095 * UNIT_MULTIPLIER))} CELO",
 
     # For order_amount of 2
     ('celocli', 'exchange:show', '--amount', str(int(9.9 * 2 * UNIT_MULTIPLIER))):
         "Fetching exchange rates...... done\n"
-        f"{str(int(9.9 * 2 * UNIT_MULTIPLIER))} cGLD => {str(int(99.5 * 2 * UNIT_MULTIPLIER))} cUSD\n"
-        f"{str(int(9.9 * 2 * UNIT_MULTIPLIER))} cUSD => {str(int(1.05 * 2 * UNIT_MULTIPLIER))} cGLD",
+        f"{str(int(9.9 * 2 * UNIT_MULTIPLIER))} CELO => {str(int(99.5 * 2 * UNIT_MULTIPLIER))} cUSD\n"
+        f"{str(int(9.9 * 2 * UNIT_MULTIPLIER))} cUSD => {str(int(1.05 * 2 * UNIT_MULTIPLIER))} CELO",
 
     ('celocli', 'exchange:show', '--amount', str(int(2 * UNIT_MULTIPLIER))):
         "Fetching exchange rates...... done\n"
-        f"{str(int(2 * UNIT_MULTIPLIER))} cGLD => {str(int(10 * 2 * UNIT_MULTIPLIER))} cUSD\n"
-        f"{str(int(2 * UNIT_MULTIPLIER))} cUSD => {str(int(0.095 * 2 * UNIT_MULTIPLIER))} cGLD",
+        f"{str(int(2 * UNIT_MULTIPLIER))} CELO => {str(int(10 * 2 * UNIT_MULTIPLIER))} cUSD\n"
+        f"{str(int(2 * UNIT_MULTIPLIER))} cUSD => {str(int(0.095 * 2 * UNIT_MULTIPLIER))} CELO",
 
 
     ('celocli', 'exchange:show', '--amount', str(int(9.83 * 5 * UNIT_MULTIPLIER))):
         "Fetching exchange rates...... done\n"
-        f"{str(int(9.83 * 5 * UNIT_MULTIPLIER))} cGLD => {str(int(99.5 * 5 * UNIT_MULTIPLIER))} cUSD\n"
-        f"{str(int(9.83 * 5 * UNIT_MULTIPLIER))} cUSD => {str(int(0.99 * 5 * UNIT_MULTIPLIER))} cGLD",
+        f"{str(int(9.83 * 5 * UNIT_MULTIPLIER))} CELO => {str(int(99.5 * 5 * UNIT_MULTIPLIER))} cUSD\n"
+        f"{str(int(9.83 * 5 * UNIT_MULTIPLIER))} cUSD => {str(int(0.99 * 5 * UNIT_MULTIPLIER))} CELO",
 
     ('celocli', 'exchange:show', '--amount', str(int(5 * UNIT_MULTIPLIER))):
         "Fetching exchange rates...... done\n"
-        f"{str(int(5 * UNIT_MULTIPLIER))} cGLD => {str(int(10.1 * 5 * UNIT_MULTIPLIER))} cUSD\n"
-        f"{str(int(5 * UNIT_MULTIPLIER))} cUSD => {str(int(0.095 * 5 * UNIT_MULTIPLIER))} cGLD",
+        f"{str(int(5 * UNIT_MULTIPLIER))} CELO => {str(int(10.1 * 5 * UNIT_MULTIPLIER))} cUSD\n"
+        f"{str(int(5 * UNIT_MULTIPLIER))} cUSD => {str(int(0.095 * 5 * UNIT_MULTIPLIER))} CELO",
 
     ('celocli', 'account:unlock', TEST_ADDRESS, '--password', TEST_PASSWORD):
         "",
 
     ('celocli', 'account:balance', TEST_ADDRESS):
         "All balances expressed in units of 10^-18.\n"
-        "gold: 9007508147186651319\n"
-        "lockedGold: 0\n"
-        "usd: 29630453216355095281\n"
-        "total: 12014917632492453465\n"
+        "CELO: 9007508147186651319\n"
+        "lockedCELO: 0\n"
+        "cUSD: 29630453216355095281\n"
         "pending: 0",
 
     ('celocli', 'exchange:gold', '--from', TEST_ADDRESS, '--value', str(int(1 * UNIT_MULTIPLIER)),

--- a/test/hummingbot/strategy/celo_arb/test_celo_arb.py
+++ b/test/hummingbot/strategy/celo_arb/test_celo_arb.py
@@ -42,7 +42,7 @@ class CeloArbUnitTest(unittest.TestCase):
     end: pd.Timestamp = pd.Timestamp("2019-01-01 01:00:00", tz="UTC")
     start_timestamp: float = start.timestamp()
     end_timestamp: float = end.timestamp()
-    trading_pair = "CGLD-CUSD"
+    trading_pair = "CELO-CUSD"
     base_asset = trading_pair.split("-")[0]
     quote_asset = trading_pair.split("-")[1]
 
@@ -113,8 +113,8 @@ class CeloArbUnitTest(unittest.TestCase):
         """
         order_amount = 1
         trade_profits = get_trade_profits(self.market, self.trading_pair, order_amount)
-        # Sell price at CTP (counter party) 1 CGLD is 9.95 CUSD
-        # At Celo 9.95 CUSD will get you 1 CGLD, so the profit is 0%
+        # Sell price at CTP (counter party) 1 CELO is 9.95 CUSD
+        # At Celo 9.95 CUSD will get you 1 CELO, so the profit is 0%
         celo_buy_trade = trade_profits[0]
         self.assertTrue(celo_buy_trade.is_celo_buy)
         # Can sell at CTP at 9.95
@@ -124,8 +124,8 @@ class CeloArbUnitTest(unittest.TestCase):
         # profit is 0
         self.assertEqual(celo_buy_trade.profit, Decimal("0"))
 
-        # Buy price at CTP (counter party) 1 CGLD at 10.05 USD
-        # at Celo 1 CGLD will get you 10.5 USD, so the profit is (10.5 - 10.05)/10.05 = 0.0447761194
+        # Buy price at CTP (counter party) 1 CELO at 10.05 USD
+        # at Celo 1 CELO will get you 10.5 USD, so the profit is (10.5 - 10.05)/10.05 = 0.0447761194
         celo_sell_trade = trade_profits[1]
         self.assertFalse(celo_sell_trade.is_celo_buy)
         # Can buy price at CTP for 10.05
@@ -141,17 +141,17 @@ class CeloArbUnitTest(unittest.TestCase):
 
         celo_buy_trade = trade_profits[0]
         self.assertTrue(celo_buy_trade.is_celo_buy)
-        # VWAP Sell price (5 CGLD) at CTP is ((9.95 * 1) + (9.85 * 2) + (9.75 * 2))/5 = 9.83
+        # VWAP Sell price (5 CELO) at CTP is ((9.95 * 1) + (9.85 * 2) + (9.75 * 2))/5 = 9.83
         self.assertEqual(celo_buy_trade.ctp_vwap, Decimal("9.83"))
         self.assertEqual(celo_buy_trade.ctp_price, Decimal("9.75"))
-        # for 9.83 * 5 USD, you can get 0.99 * 5 CGLD at Celo, so the price is 9.83/0.99 = 9.92929292929
+        # for 9.83 * 5 USD, you can get 0.99 * 5 CELO at Celo, so the price is 9.83/0.99 = 9.92929292929
         self.assertAlmostEqual(celo_buy_trade.celo_price, Decimal("9.92929292929"))
         # profit is -0.00999999999
         self.assertAlmostEqual(celo_buy_trade.profit, Decimal("-0.00999999999"))
 
         celo_sell_trade = trade_profits[1]
         self.assertFalse(celo_sell_trade.is_celo_buy)
-        # VWAP Buy price (5 CGLD) at CTP is ((10.05 * 1) + (10.15 * 2) + (10.25 * 2))/5 = 10.17
+        # VWAP Buy price (5 CELO) at CTP is ((10.05 * 1) + (10.15 * 2) + (10.25 * 2))/5 = 10.17
         self.assertEqual(celo_sell_trade.ctp_vwap, Decimal("10.17"))
         self.assertEqual(celo_sell_trade.ctp_price, Decimal("10.25"))
         # Can sell price celo at 10.1 each


### PR DESCRIPTION
Update the ticker strings used when parsing `celocli` output. It's up-to-date with v1.0.3. Also updates the `celocli` version installed on the docker image, so that both the parsing code and the command-line tool are aligned.