### PR TITLE
fix/ spot perp finance history error

### DIFF
--- a/hummingbot/client/command/history_command.py
+++ b/hummingbot/client/command/history_command.py
@@ -90,6 +90,8 @@ class HistoryCommand:
             if paper_balances is None:
                 return {}
             return {token: Decimal(str(bal)) for token, bal in paper_balances.items()}
+        elif "perpetual_finance" == market:
+            return await UserBalances.xdai_balances()
         else:
             gateway_eth_connectors = [cs.name for cs in CONNECTOR_SETTINGS.values() if cs.use_ethereum_wallet and
                                       cs.type == ConnectorType.Connector]


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- check for xdai balance when connector is perpetual finance, it's not a clean solution. Perp Fi is Ethereum connector but balances are queried on layer 2.
