### PR TITLE
(fix) change default token list to defi.cmc.eth

### DIFF
--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -155,7 +155,7 @@ main_config_map = {
                   prompt="Specify token list url of a list available on https://tokenlists.org/ >>> ",
                   type_str="str",
                   required_if=lambda: global_config_map["ethereum_wallet"].value is not None,
-                  default="https://wispy-bird-88a7.uniswap.workers.dev/?url=http://tokens.1inch.eth.link"),
+                  default="https://defi.cmc.eth.link/"),
     # Whether or not to invoke cancel_all on exit if marketing making on a open order book DEX (e.g. Radar Relay)
     "on_chain_cancel_on_exit":
         ConfigVar(key="on_chain_cancel_on_exit",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Changes default token list URL to https://defi.cmc.eth since the old 1inch list loads inconsistently.
