### PR TITLE
Fix / Rate Oracle returns None price for `USD`

### DIFF
--- a/hummingbot/core/rate_oracle/rate_oracle.py
+++ b/hummingbot/core/rate_oracle/rate_oracle.py
@@ -95,6 +95,7 @@ class RateOracle(NetworkBase):
     @classmethod
     async def global_rate(cls, token: str) -> Decimal:
         prices = await cls.get_prices()
+        token = "USDT" if token == "USD" else token
         pair = token + "-" + cls.global_token
         return find_rate(prices, pair)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I'm not sure if this is the best way to handle this, but the new rate oracle returns None price for `USD` pairs (e.g. CoinZoom and HitBTC).
This fixes the issue with the `balance` command for me as seen here:
https://github.com/CoinAlpha/hummingbot/pull/3112#issuecomment-808150326

@Nullably could you take a look at this?
