### PR TITLE
Feat / Add auto-fill after `import` command again, configurable with setting

### DIFF
--- a/hummingbot/client/command/config_command.py
+++ b/hummingbot/client/command/config_command.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 no_restart_pmm_keys_in_percentage = ["bid_spread", "ask_spread", "order_level_spread", "inventory_target_base_pct"]
 no_restart_pmm_keys = ["order_amount", "order_levels", "filled_order_delay", "inventory_skew_enabled", "inventory_range_multiplier"]
 global_configs_to_display = ["0x_active_cancels",
+                             "autofill_import",
                              "kill_switch_enabled",
                              "kill_switch_rate",
                              "telegram_enabled",

--- a/hummingbot/client/command/import_command.py
+++ b/hummingbot/client/command/import_command.py
@@ -1,6 +1,7 @@
 import os
 
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.config.config_helpers import (
     update_strategy_config_map_from_file,
     short_strategy_name,
@@ -43,6 +44,9 @@ class ImportCommand:
         self.app.change_prompt(prompt=">>> ")
         if await self.status_check_all():
             self._notify("\nEnter \"start\" to start market making.")
+            autofill_import = global_config_map.get("autofill_import").value
+            if autofill_import is not None:
+                self.app.set_text(autofill_import)
 
     async def prompt_a_file_name(self  # type: HummingbotApplication
                                  ):

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -196,6 +196,14 @@ main_config_map = {
                   default=-100,
                   validator=lambda v: validate_decimal(v, Decimal(-100), Decimal(100)),
                   required_if=lambda: global_config_map["kill_switch_enabled"].value),
+    "autofill_import":
+        ConfigVar(key="autofill_import",
+                  prompt="What to auto-fill in the prompt after each import command? (start/config) >>> ",
+                  type_str="str",
+                  default=None,
+                  validator=lambda s: None if s in {"start",
+                                                    "config"} else "Invalid price type.",
+                  required_if=lambda: False),
     "telegram_enabled":
         ConfigVar(key="telegram_enabled",
                   prompt="Would you like to enable telegram? >>> ",

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -202,7 +202,7 @@ main_config_map = {
                   type_str="str",
                   default=None,
                   validator=lambda s: None if s in {"start",
-                                                    "config"} else "Invalid price type.",
+                                                    "config"} else "Invalid auto-fill prompt.",
                   required_if=lambda: False),
     "telegram_enabled":
         ConfigVar(key="telegram_enabled",

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -3,7 +3,7 @@
 #################################
 
 # For more detailed information: https://docs.hummingbot.io
-template_version: 19
+template_version: 20
 
 # Exchange configs
 bamboo_relay_use_coordinator: false
@@ -100,6 +100,9 @@ ethereum_token_list_url: null
 kill_switch_enabled: null
 # The rate of performance at which you would want the bot to stop trading (-20 = 20%)
 kill_switch_rate: null
+
+# What to auto-fill in the prompt after each import command (start/config)
+autofill_import: null
 
 # DEX active order cancellation
 0x_active_cancels: false


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I discussed this with @mifeng back when the auto-fill `start` after `import` was removed, I really miss the `start` command so I use this in my builds.
Adds configuration to switch between `start` and `config` auto-fill after `import`, using the new `autofill_import` global config setting.