### PR TITLE
feat/ Implement stex connector

### DIFF
--- a/hummingbot/connector/exchange/stex/stex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/stex/stex_api_order_book_data_source.py
@@ -1,0 +1,230 @@
+import asyncio
+import aiohttp
+import logging
+import pandas as pd
+from typing import (
+    Any,
+    AsyncIterable,
+    Dict,
+    List,
+    Optional
+)
+from decimal import Decimal
+import re
+import requests
+import cachetools.func
+import time
+import ujson
+import websockets
+import socketio
+from websockets.exceptions import ConnectionClosed
+from hummingbot.core.utils import async_ttl_cache
+from hummingbot.core.utils.async_utils import safe_gather
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.logger import HummingbotLogger
+from hummingbot.connector.exchange.stex.stex_order_book import StexOrderBook
+from hummingbot.connector.exchange.stex.stex_utils import (convert_to_exchange_trading_pair, convert_from_exchange_trading_pair)
+
+STEX_TICKER_URL = "https://api3.stex.com/public/ticker"
+STEX_DEPTH_URL = "https://api3.stex.com/public/orderbook/{}"
+STEX_CURRENCY_PAIRS_ID_CONVERSION = "https://api3.stex.com/public/currency_pairs/list/ALL"
+STEX_WS_URL = "https://socket.stex.com"
+
+class StexAPIOrderBookDataSource(OrderBookTrackerDataSource):
+
+    MESSAGE_TIMEOUT = 30.0
+    PING_TIMEOUT = 10.0
+
+    _stobds_logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._stobds_logger is None:
+            cls._stobds_logger = logging.getLogger(__name__)
+        return cls._stobds_logger
+
+    def __init__(self,trading_pairs: List[str]):
+        super().__init__(trading_pairs)
+        self._order_book_create_function = lambda: OrderBook()
+        self.trading_pair_id_conversion_dict: Dict[str, int] = {}
+        self.trades_client: socketio.AsyncClient = socketio.AsyncClient()
+        self.diffs_client: socketio.AsyncClient = socketio.AsyncClient()
+
+    @classmethod
+    async def get_last_traded_prices(cls, trading_pairs: List[str]) -> Dict[str, float]:
+        results = dict()
+        async with aiohttp.ClientSession() as client:
+            resp = await client.get(STEX_TICKER_URL)
+            resp_json = await resp.json()
+            for trading_pair in trading_pairs:
+                resp_record = [o for o in resp_json["data"] if o["symbol"] == convert_to_exchange_trading_pair(trading_pair)][0]
+                results[trading_pair] = float(resp_record["last"])
+        return results
+
+    async def get_snapshot(self, client: aiohttp.ClientSession, trading_pair: str) -> Dict[str, Any]:
+        currencyPairId = self.trading_pair_id_conversion_dict.get(trading_pair, None)
+        if not currencyPairId:
+            raise ValueError("Invalid trading pair {} and Currency Pair Id {}".format(trading_pair,currencyPairId))
+
+        params = {} #default 20
+        async with client.get(STEX_DEPTH_URL.format(currencyPairId),params=params) as response:
+            response: aiohttp.ClientResponse = response
+            if response.status != 200:
+                raise IOError(f"Error fetching market snapshot for {trading_pair}.HTTP status is {response.status}.")
+            data: Dict[str,Any] = await response.json()
+            return data
+
+    @staticmethod
+    async def fetch_trading_pairs() -> List[str]:
+        try:
+            async with aiohttp.ClientSession() as client:
+                async with client.get("STEX_CURRENCY_PAIRS_ID_CONVERSION",timeout=10) as response:
+                    if response.status != 200:
+                        raise IOError(f"Error fetching trading pairs from Stex. HTTP status is {response.status}.")
+
+                    raw_trading_pairs = await response.json()
+
+                    trading_pairs = []
+                    for object in raw_trading_pairs["data"]:
+                        converted_trading_pair = convert_from_exchange_trading_pair(object['symbol'])
+                        if converted_trading_pair is not None:
+                            trading_pairs.append(converted_trading_pair)
+                    return trading_pairs
+
+        except Exception:
+            pass
+
+        return []
+
+    async def get_trading_pairs(self) -> List[str]:
+        try:
+            if not self.trading_pair_id_conversion_dict:
+                async with aiohttp.ClientSession() as client:
+                    exchange_currency_pair_response: aiohttp.ClientResponse = await client.get(STEX_CURRENCY_PAIRS_ID_CONVERSION)
+                    if exchange_currency_pair_response.status !=200:
+                        raise IOError(f"Error fetching currency pairs information. HTTP status code is {exchange_currency_pair_response.status}.")
+                    exchange_currency_pair_data = await exchange_currency_pair_response.json()
+                    self._trading_pairs = []
+                    for object in exchange_currency_pair_data["data"]:
+                        trading_pair = convert_from_exchange_trading_pair(object["symbol"])
+                        self._trading_pairs.append(trading_pair)
+                        self.trading_pair_id_conversion_dict.update({trading_pair : object["id"]})
+
+        except Exception:
+            self._trading_pairs = []
+            self.logger().network(
+                "Error getting exchange information.",
+                exe_info=True,
+                app_warning_msg="Error getting active exchange information. Check network connection."
+            )
+
+        return self._trading_pairs
+
+
+    async def get_new_order_book(self, trading_pair: str) -> OrderBook:
+        await self.get_trading_pairs()
+        async with aiohttp.ClientSession() as client:
+            snapshot: Dict[str, Any] = await self.get_snapshot(client, trading_pair)
+            snapshot_timestamp: float = time.time()
+            snapshot_msg: OrderBookMessage = StexOrderBook.snapshot_message_from_exchange(
+                snapshot,
+                snapshot_timestamp,
+                metadata={"trading_pair": trading_pair}
+            )
+            order_book: OrderBook = self.order_book_create_function()
+            order_book.apply_snapshot(snapshot_msg.bids, snapshot_msg.asks, snapshot_msg.update_id)
+            return order_book
+
+    async def on_connect_trade(self):
+        trading_pairs = self._trading_pairs
+        for trading_pair in trading_pairs:
+            currencyPairId = self.trading_pair_id_conversion_dict[trading_pair]
+            event_name = "trade_c{}".format(currencyPairId)
+            await self.trades_client.emit('subscribe',{'channel':event_name,'auth':{}})
+    async def listen_for_trades(self, ev_loop: Optional[asyncio.BaseEventLoop], output: asyncio.Queue):
+        while True:
+            try:
+                await self.trades_client.connect(STEX_WS_URL,transports=["websocket"])
+                self.trades_client.on('connect',self.on_connect_trade)
+                async def data_stream_callback(*msg):
+                    trading_pair = None
+                    for t_pair,id in self.trading_pair_id_conversion_dict.items():
+                        if msg[1]['currency_pair_id']==id:
+                            trading_pair = t_pair
+                            break
+                    if trading_pair is not None:
+                        trade_msg: OrderBookMessage = StexOrderBook.trade_message_from_exchange(msg[1],metadata={"trading_pair": trading_pair})
+                        output.put_nowait(trade_msg)
+
+                self.trades_client.on("App\Events\OrderFillCreated",data_stream_callback)
+                await self.trades_client.wait()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error with WebSocket connection. Retrying after 30 seconds...",exc_info=True)
+                await asyncio.sleep(30.0)
+
+    async def on_connect_diffs(self):
+        trading_pairs = await self.get_trading_pairs()
+        for trading_pair in trading_pairs:
+            currencyPairId = self.trading_pair_id_conversion_dict[trading_pair]
+            event_name = "orderbook_data{}".format(currencyPairId)
+            await self.diffs_client.emit('subscribe',{'channel':event_name,'auth':{}})
+
+    async def listen_for_order_book_diffs(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                await self.diffs_client.connect(STEX_WS_URL,transports=["websocket"])
+                self.diffs_client.on('connect',self.on_connect_diffs)
+                async def data_stream_callback(*msg):
+                    trading_pair = None
+                    for t_pair,id in self.trading_pair_id_conversion_dict.items():
+                        if msg[1]['currency_pair_id']==id:
+                            trading_pair = t_pair
+                            break
+                    if trading_pair is not None:
+                        msg_dict = {"trading_pair": trading_pair,
+                                    "asks":[msg[1]] if msg[1]["type"]=="SELL" else [],
+                                    "bids":[msg[1]] if msg[1]["type"]=="BUY" else []}
+                        order_book_message: OrderBookMessage = StexOrderBook.diff_message_from_exchange(msg_dict,time.time())
+                        output.put_nowait(order_book_message)
+                self.diffs_client.on("App\Events\GlassRowChanged",data_stream_callback)
+                await self.diffs_client.wait()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error with WebSocket connection. Retrying after 30 seconds...",exc_info=True)
+                await asyncio.sleep(30.0)
+
+    async def listen_for_order_book_snapshots(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                trading_pairs: List[str] = await self.get_trading_pairs()
+                async with aiohttp.ClientSession() as client:
+                    for trading_pair in trading_pairs:
+                        try:
+                            snapshot: Dict[str, Any] = await self.get_snapshot(client, trading_pair)
+                            snapshot_message: OrderBookMessage = StexOrderBook.snapshot_message_from_exchange(
+                                snapshot,
+                                timestamp=time.time(),
+                                metadata={"trading_pair": trading_pair}
+                            )
+                            output.put_nowait(snapshot_message)
+                            self.logger().debug(f"Saved order book snapshot for {trading_pair}")
+                            await asyncio.sleep(5.0)
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            self.logger().error("Unexpected error.", exc_info=True)
+                            await asyncio.sleep(5.0)
+                    this_hour: pd.Timestamp = pd.Timestamp.utcnow().replace(minute=0, second=0, microsecond=0)
+                    next_hour: pd.Timestamp = this_hour + pd.Timedelta(hours=1)
+                    delta: float = next_hour.timestamp() - time.time()
+                    await asyncio.sleep(delta)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error.", exc_info=True)
+                await asyncio.sleep(5.0)

--- a/hummingbot/connector/exchange/stex/stex_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/stex/stex_api_user_stream_data_source.py
@@ -1,0 +1,80 @@
+import asyncio
+import aiohttp
+import logging
+from typing import (
+    AsyncIterable,
+    Dict,
+    Optional,
+    Any
+)
+import time
+import ujson
+import socketio
+import pendulum
+import requests
+import os.path
+import json
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.logger import HummingbotLogger
+from hummingbot.connector.exchange.stex.stex_auth import StexAuth
+
+STEX_WS_URL = "https://socket.stex.com"
+
+JSON_SETTINGS = 'settings-websocket.json'
+MESSAGE_TIMEOUT = 3.0
+PING_TIMEOUT = 5.0
+
+class StexAPIUserStreamDataSource(UserStreamTrackerDataSource):
+
+    _stausds_logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._stausds_logger is None:
+            cls._stausds_logger = logging.getLogger(__name__)
+        return cls._stausds_logger
+
+    def __init__(self,stex_auth: StexAuth):
+        self._shared_client: Optional[aiohttp.ClientSession] = None
+        self._last_recv_time: float = 0
+        self._auth_dict: Dict[str, Any] = stex_auth.generate_auth_dict()
+        self.client: socketio.AsyncClient = socketio.AsyncClient()
+        super().__init__()
+
+    @property
+    def last_recv_time(self):
+        return self._last_recv_time
+
+    async def get_access_token(self):
+        return self._auth_dict["access_token"]
+
+    async def _http_client(self) -> aiohttp.ClientSession:
+        if self._shared_client is None or self._shared_client.closed:
+            self._shared_client = aiohttp.ClientSession()
+        return self._shared_client
+
+    async def on_connect_stream(self):
+        auth = {'headers': {'Authorization': 'Bearer ' + self._auth_dict['access_token']}}
+        channel_name = 'private-user_orders_u_{}'.format(self._auth_dict['user_id'])
+        await self.client.emit('subscribe',{'channel': channel_name,'auth': auth})
+
+    async def listen_for_user_stream(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                await self.client.connect(STEX_WS_URL,transports=["websocket"])
+                self.client.on('connect',self.on_connect_stream)
+                async def data_stream_callback(*msg):
+                    self._last_recv_time = time.time()
+                    output.put_nowait(msg)
+                self.client.on(r"App\Events\UserOrder",data_stream_callback)
+                await self.client.wait()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error with Stex WebSocket connection. "
+                                    "Retrying after 30 seconds...", exc_info=True)
+                await asyncio.sleep(30.0)
+
+    async def stop(self):
+        if self._shared_client is not None and not self._shared_client.closed:
+            await self._shared_client.close()

--- a/hummingbot/connector/exchange/stex/stex_auth.py
+++ b/hummingbot/connector/exchange/stex/stex_auth.py
@@ -1,0 +1,36 @@
+import aiohttp
+import pendulum
+import json
+import os
+import requests
+from typing import (
+    Optional,
+    Dict,
+    Any
+)
+JSON_SETTINGS = 'settings-private.json'
+STEX_TOKEN_URL = "https://api3.stex.com/oauth/token"
+class StexAuth:
+    def __init__(self, access_token:str):
+        self.access_token = access_token
+        self.user_id = None
+
+    def get_user_id(self):
+        headers = {'Content-Type': 'application/json', 'User-Agent': 'stex_python_client'}
+        try:
+            headers['Authorization'] = 'Bearer {}'.format(self.access_token)
+            url = "https://api3.stex.com/profile/info"
+            response = requests.get(url,headers=headers)
+            profile_data =  response.json()
+            return profile_data["data"]["user_id"]
+        except Exception as e:
+            raise IOError(f"Error fetching user id from {url}. Response:{response.json()}.")
+
+    def generate_auth_dict(self, data: Optional[Dict[str,str]] = None) -> Dict[str, Any]:
+        if self.user_id is None:
+            self.user_id = self.get_user_id()
+        client = {
+            'access_token': self.access_token,
+            'user_id': self.user_id
+        }
+        return client

--- a/hummingbot/connector/exchange/stex/stex_exchange.pxd
+++ b/hummingbot/connector/exchange/stex/stex_exchange.pxd
@@ -1,0 +1,42 @@
+from hummingbot.connector.exchange_base cimport ExchangeBase
+from hummingbot.core.data_type.transaction_tracker cimport TransactionTracker
+from libc.stdint cimport int32_t
+
+
+cdef class StexExchange(ExchangeBase):
+    cdef:
+        object _user_stream_tracker
+        object _ev_loop
+        object _poll_notifier
+        double _last_timestamp
+        double _poll_interval
+        double _last_pull_timestamp
+        dict _in_flight_orders
+        dict _order_not_found_records
+        TransactionTracker _tx_tracker
+        dict _trading_rules
+        dict _trade_fees
+        double _last_update_trade_fees_timestamp
+        public object _status_polling_task
+        public object _user_stream_event_listener_task
+        public object _user_stream_tracker_task
+        public object _trading_rules_polling_task
+        object _async_scheduler
+        object _set_server_time_offset_task
+        public object _stex_auth
+        object _shared_client
+        dict _asset_pairs
+        int32_t _last_userref
+        object _throttler
+        dict _currency_pair_dict
+        dict _auth_dict
+
+    cdef c_did_timeout_tx(self, str tracking_id)
+    cdef c_start_tracking_order(self,
+                                str order_id,
+                                str exchange_order_id,
+                                str trading_pair,
+                                object trade_type,
+                                object price,
+                                object amount,
+                                object order_type)

--- a/hummingbot/connector/exchange/stex/stex_exchange.pyx
+++ b/hummingbot/connector/exchange/stex/stex_exchange.pyx
@@ -1,0 +1,930 @@
+from libc.stdint cimport int64_t, int32_t
+import aiohttp
+import asyncio
+import math
+from async_timeout import timeout
+from decimal import Decimal
+import logging
+import pandas as pd
+from collections import defaultdict
+from typing import (
+    Any,
+    Dict,
+    List,
+    AsyncIterable,
+    Optional,
+)
+from hummingbot.core.utils.asyncio_throttle import Throttler
+import copy
+from hummingbot.core.utils.async_call_scheduler import AsyncCallScheduler
+from hummingbot.core.clock cimport Clock
+from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.utils.async_utils import (
+    safe_ensure_future,
+    safe_gather,
+)
+from hummingbot.connector.exchange.stex.stex_api_order_book_data_source import StexAPIOrderBookDataSource
+from hummingbot.connector.exchange.stex.stex_auth import StexAuth
+#import hummingbot.connector.exchange.stex.stex_constants as constants
+from hummingbot.connector.exchange.stex.stex_utils import (
+    convert_from_exchange_trading_pair,
+    convert_to_exchange_trading_pair)
+from hummingbot.logger import HummingbotLogger
+from hummingbot.core.event.events import (
+    MarketEvent,
+    BuyOrderCompletedEvent,
+    SellOrderCompletedEvent,
+    OrderFilledEvent,
+    OrderCancelledEvent,
+    BuyOrderCreatedEvent,
+    SellOrderCreatedEvent,
+    MarketTransactionFailureEvent,
+    MarketOrderFailureEvent,
+    OrderType,
+    TradeType,
+    TradeFee
+)
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.connector.exchange.stex.stex_order_book_tracker import StexOrderBookTracker
+from hummingbot.connector.exchange.stex.stex_user_stream_tracker import StexUserStreamTracker
+from hummingbot.connector.exchange.stex.stex_in_flight_order import StexInFlightOrder
+from hummingbot.core.data_type.cancellation_result import CancellationResult
+from hummingbot.core.data_type.transaction_tracker import TransactionTracker
+from hummingbot.connector.trading_rule cimport TradingRule
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
+from hummingbot.core.utils.estimate_fee import estimate_fee
+
+s_logger = None
+s_decimal_0 = Decimal(0)
+s_decimal_NaN = Decimal("NaN")
+JSON_SETTINGS = 'settings-private.json'
+STEX_ROOT_API = "https://api3.stex.com"
+STEX_TIME_URL = "https://api3.stex.com/public/ping"
+STEX_TOKEN_URL = "https://api3.stex.com/oauth/token"
+cdef class StexExchangeTransactionTracker(TransactionTracker):
+    cdef:
+        StexExchange _owner
+
+    def __init__(self, owner):
+        super().__init__()
+        self._owner = owner
+
+    cdef c_did_timeout_tx(self, str tx_id):
+        TransactionTracker.c_did_timeout_tx(self, tx_id)
+        self._owner.c_did_timeout_tx(tx_id)
+
+cdef class StexExchange(ExchangeBase):
+    MARKET_RECEIVED_ASSET_EVENT_TAG = MarketEvent.ReceivedAsset.value
+    MARKET_BUY_ORDER_COMPLETED_EVENT_TAG = MarketEvent.BuyOrderCompleted.value
+    MARKET_SELL_ORDER_COMPLETED_EVENT_TAG = MarketEvent.SellOrderCompleted.value
+    MARKET_ORDER_CANCELLED_EVENT_TAG = MarketEvent.OrderCancelled.value
+    MARKET_TRANSACTION_FAILURE_EVENT_TAG = MarketEvent.TransactionFailure.value
+    MARKET_ORDER_FAILURE_EVENT_TAG = MarketEvent.OrderFailure.value
+    MARKET_ORDER_FILLED_EVENT_TAG = MarketEvent.OrderFilled.value
+    MARKET_BUY_ORDER_CREATED_EVENT_TAG = MarketEvent.BuyOrderCreated.value
+    MARKET_SELL_ORDER_CREATED_EVENT_TAG = MarketEvent.SellOrderCreated.value
+
+    API_CALL_TIMEOUT = 10.0
+
+
+    ORDER_NOT_EXIST_CONFIRMATION_COUNT = 3
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        global s_logger
+        if s_logger is None:
+            s_logger = logging.getLogger(__name__)
+        return s_logger
+
+    def __init__(self,
+                 stex_access_token: str,
+                 trading_pairs: Optional[List[str]] = None,
+                 poll_interval: float = 10.0,
+                 trading_required: bool = True):
+
+        super().__init__()
+        self._trading_required = trading_required
+        self._order_book_tracker = StexOrderBookTracker(trading_pairs=trading_pairs)
+        self._stex_auth = StexAuth(stex_access_token)
+        self._user_stream_tracker = StexUserStreamTracker(stex_auth=self._stex_auth)
+        self._auth_dict: Dict[str, Any] = self._stex_auth.generate_auth_dict()
+        self._ev_loop = asyncio.get_event_loop()
+        self._poll_notifier = asyncio.Event()
+        self._last_timestamp = 0
+        self._poll_interval = poll_interval
+        self._in_flight_orders = {}  # Dict[client_order_id:str, StexnFlightOrder]
+        self._order_not_found_records = {}  # Dict[client_order_id:str, count:int]
+        self._tx_tracker = StexExchangeTransactionTracker(self)
+        self._trading_rules = {}  # Dict[trading_pair:str, TradingRule]
+        self._trade_fees = {}  # Dict[trading_pair:str, (maker_fee_percent:Decimal, taken_fee_percent:Decimal)]
+        self._last_update_trade_fees_timestamp = 0
+        self._status_polling_task = None
+        self._user_stream_tracker_task = None
+        self._user_stream_event_listener_task = None
+        self._trading_rules_polling_task = None
+        self._async_scheduler = AsyncCallScheduler(call_interval=0.5)
+        self._throttler = Throttler(rate_limit = (10.0, 1.0))
+        self._last_pull_timestamp = 0
+        self._shared_client = None
+        self._asset_pairs = {}
+        self._real_time_balance_update = False
+        self._currency_pair_dict = {}
+
+    @property
+    def name(self) -> str:
+        return "stex"
+
+    @property
+    def order_books(self) -> Dict[str, OrderBook]:
+        return self._order_book_tracker.order_books
+
+    @property
+    def stex_auth(self) -> StexAuth:
+        return self._stex_auth
+
+    @property
+    def trading_rules(self) -> Dict[str, StexInFlightOrder]:
+        return self._trading_rules
+
+    @property
+    def in_flight_orders(self) -> Dict[str, StexInFlightOrder]:
+        return self._in_flight_orders
+
+    @property
+    def limit_orders(self) -> List[LimitOrder]:
+        return [
+            in_flight_order.to_limit_order()
+            for in_flight_order in self._in_flight_orders.values()
+        ]
+
+    @property
+    def tracking_states(self) -> Dict[str, Any]:
+        return {
+            order_id: value.to_json()
+            for order_id, value in self._in_flight_orders.items()
+        }
+
+    def restore_tracking_states(self, saved_states: Dict[str, Any]):
+        in_flight_orders: Dict[str, KrakenInFlightOrder] = {}
+        for key, value in saved_states.items():
+            in_flight_orders[key] = StexInFlightOrder.from_json(value)
+        self._in_flight_orders.update(in_flight_orders)
+
+    async def _http_client(self) -> aiohttp.ClientSession:
+        if self._shared_client is None:
+            self._shared_client = aiohttp.ClientSession()
+        return self._shared_client
+
+    async def _api_request(self,
+                           path_url: str,
+                           method:str = 'GET',
+                           format_type: str ='url',
+                           is_auth_required: bool = False,
+                           data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = STEX_ROOT_API + path_url
+        client = await self._http_client()
+        headers = {'Content-Type': 'application/json', 'User-Agent': 'stex_python_client'}
+        if is_auth_required == True:
+            headers['Authorization'] = 'Bearer {}'.format(self._auth_dict["access_token"])
+        if method == 'POST' and format_type == 'url':
+            response_coro = client.post(url = url, headers = headers)
+        if method == 'GET' and format_type == 'url':
+            response_coro = client.get(url = url, headers = headers)
+        if method == 'DELETE' and format_type =='url':
+            response_coro = client.delete(url=url, headers=headers)
+        if method == 'POST' and format_type == 'form':
+            headers['Content-Type'] = 'application/x-www-form-urlencoded'
+            response_coro = client.post(url=url, headers=headers, data=data)
+        async with response_coro as response:
+            if response.status != 200:
+                raise IOError(f"Error fetching data from {url}. Response: {await response.json()}.")
+            try:
+                parsed_response = await response.json()
+                return parsed_response
+            except:
+                raise IOError(f"Error parsing data from {url}.")
+
+    async def _update_balances(self):
+        cdef:
+            dict account_info
+            dict balances
+            dict balance
+            str asset_name
+            set local_asset_names = set(self._account_balances.keys())
+            set remote_asset_names = set()
+            set asset_names_to_remove
+
+        account_info = await self._api_request(method="POST",path_url= "/profile/info", is_auth_required = True)
+        balances = account_info["data"]["approx_balance"]
+        for asset_name, balance in balances.items():
+            free_balance = Decimal(balance['balance'])
+            total_balance = Decimal(balance['total_balance'])
+            self._account_available_balances[asset_name] = free_balance
+            self._account_balances[asset_name] = total_balance
+            remote_asset_names.add(asset_name)
+
+        asset_names_to_remove = local_asset_names.difference(remote_asset_names)
+        for asset_name in asset_names_to_remove:
+            del self._account_available_balances[asset_name]
+            del self._account_balances[asset_name]
+
+    cdef object c_get_fee(self,
+                          str base_currency,
+                          str quote_currency,
+                          object order_type,
+                          object order_side,
+                          object amount,
+                          object price):
+        is_maker = False
+        return estimate_fee("stex", is_maker)
+
+    async def _update_trading_rules(self):
+        cdef:
+            int64_t last_tick = <int64_t>(self._last_timestamp / 60.0)
+            int64_t current_tick = <int64_t>(self._current_timestamp / 60.0)
+        if current_tick > last_tick or len(self._trading_rules) < 1:
+            exchange_info = await self._api_request(method="GET", path_url="/public/currency_pairs/list/ALL")
+            trading_rules_list = self._format_trading_rules(exchange_info["data"])
+            self._trading_rules.clear()
+             # Update currency pair id and trading pair conversion dict for later use
+            for info in exchange_info["data"]:
+                currency_pair = convert_from_exchange_trading_pair(info.get('symbol', None))
+                currency_pair_id = info.get('id', None)
+                if currency_pair:
+                    self._currency_pair_dict[currency_pair] = currency_pair_id
+            for trading_rule in trading_rules_list:
+                self._trading_rules[trading_rule.trading_pair] = trading_rule
+
+    def _format_trading_rules(self, raw_trading_pair_info: List[Dict[str, Any]]) -> List[TradingRule]:
+        cdef:
+            list trading_rules = []
+
+        for info in raw_trading_pair_info:
+            try:
+                trading_pair = convert_from_exchange_trading_pair(info["symbol"])
+                min_order_size = Decimal(str(info["min_order_amount"]))
+                min_price_increment = Decimal(str(info["min_buy_price"])) #min_buy_price or min_sell_price ?
+                currency_decimals = Decimal(str(info["currency_precision"]))
+                market_decimals = Decimal(str(info["market_precision"]))
+                currency_step = Decimal("1") / Decimal(str(math.pow(10, currency_decimals)))
+                market_step = Decimal("1") / Decimal(str(math.pow(10, market_decimals)))
+                trading_rules.append(
+                    TradingRule(trading_pair=trading_pair,
+                                min_order_size=min_order_size,
+                                min_price_increment=min_price_increment,
+                                min_base_amount_increment=currency_step,
+                                min_quote_amount_increment=market_step)
+                )
+            except Exception:
+                self.logger().error(f"Error parsing the trading pair rule {info}. Skipping.", exc_info=True)
+        return trading_rules
+
+    async def get_order_status(self, exchange_order_id: str) -> Dict[str, Any]:
+        """
+        Example:
+        {
+          "success": true,
+          "data": {
+            "id": 828680665,
+            "currency_pair_id": 1,
+            "currency_pair_name": "NXT_BTC",
+            "price": "0.011384",
+            "trigger_price": 0.011385,
+            "initial_amount": "13.942",
+            "processed_amount": "3.724",
+            "type": "SELL",
+            "original_type": "STOP_LIMIT_SELL",
+            "created": "2019-01-17 10:14:48",
+            "timestamp": "1547720088",
+            "status": "PARTIAL"
+            }
+        }
+        """
+        path_url = f"/trading/order/{exchange_order_id}"
+        return await self._api_request(method="GET", path_url=path_url, is_auth_required = True)
+
+    async def _update_order_status(self):
+        cdef:
+            int64_t last_tick = <int64_t>(self._last_poll_timestamp / self.UPDATE_ORDERS_INTERVAL)
+            int64_t current_tick = <int64_t>(self._current_timestamp / self.UPDATE_ORDERS_INTERVAL)
+
+        if len(self._in_flight_orders) > 0:
+            tracked_orders = list(self._in_flight_orders.values())
+            tasks = [await self.get_order_status(o.exchange_order_id) for o in tracked_orders]
+            results = await safe_gather(*tasks, return_exceptions=True)
+
+            for order_update, tracked_order in zip(results, tracked_orders):
+                client_order_id = tracked_order.client_order_id
+
+                if client_order_id not in self._in_flight_orders:
+                    continue
+
+                if isinstance(order_update, Exception):
+                    self.logger().network(
+                        f"Error fetching status update for the order {client_order_id}: {order_update}.",
+                        app_warning_msg=f"Failed to fetch status update for the order {client_order_id}."
+                    )
+                    continue
+
+                if order_update.get("success") is False:
+                    self.logger().debug(f"Error in fetched status update for order {client_order_id}: "
+                                        f"{order_update['message']}")
+                    self.c_cancel(tracked_order.trading_pair, tracked_order.client_order_id)
+                    continue
+
+                update = order_update.get("data")
+
+                if not update:
+                    self._order_not_found_records[client_order_id] = self._order_not_found_records.get(client_order_id, 0) + 1
+                    if self._order_not_found_records[client_order_id] < self.ORDER_NOT_EXIST_CONFIRMATION_COUNT:
+                        continue
+                    self.c_trigger_event(
+                        self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                        MarketOrderFailureEvent(self._current_timestamp, client_order_id, tracked_order.order_type)
+                    )
+                    self.c_stop_tracking_order(client_order_id)
+                    continue
+
+                tracked_order.last_state = order_update["status"]
+                executed_amount_base = Decimal(order_update["processed_amount"])
+                executed_amount_quote = Decimal(order_update["initial_amount"])
+
+                if tracked_order.is_done:
+                    if not tracked_order.is_failure:
+                        if tracked_order.trade_type is TradeType.BUY:
+                            self.logger().info(f"The market buy order {tracked_order.client_order_id} has completed "
+                                               f"according to order status API.")
+                            self.c_trigger_event(self.MARKET_BUY_ORDER_COMPLETED_EVENT_TAG,
+                                                 BuyOrderCompletedEvent(self._current_timestamp,
+                                                                        client_order_id,
+                                                                        tracked_order.base_asset,
+                                                                        tracked_order.quote_asset,
+                                                                        (tracked_order.fee_asset
+                                                                         or tracked_order.quote_asset),
+                                                                        executed_amount_base,
+                                                                        executed_amount_quote,
+                                                                        tracked_order.fee_paid,
+                                                                        tracked_order.order_type))
+                        else:
+                            self.logger().info(f"The market sell order {client_order_id} has completed "
+                                               f"according to order status API.")
+                            self.c_trigger_event(self.MARKET_SELL_ORDER_COMPLETED_EVENT_TAG,
+                                                 SellOrderCompletedEvent(self._current_timestamp,
+                                                                         client_order_id,
+                                                                         tracked_order.base_asset,
+                                                                         tracked_order.quote_asset,
+                                                                         (tracked_order.fee_asset
+                                                                          or tracked_order.quote_asset),
+                                                                         executed_amount_base,
+                                                                         executed_amount_quote,
+                                                                         tracked_order.fee_paid,
+                                                                         tracked_order.order_type))
+                    else:
+                        # check if its a cancelled order
+                        # if its a cancelled order, issue cancel and stop tracking order
+                        if tracked_order.is_cancelled:
+                            self.logger().info(f"Successfully cancelled order {client_order_id}.")
+                            self.c_trigger_event(self.MARKET_ORDER_CANCELLED_EVENT_TAG,
+                                                 OrderCancelledEvent(
+                                                     self._current_timestamp,
+                                                     client_order_id))
+                        else:
+                            self.logger().info(f"The market order {client_order_id} has failed according to "
+                                               f"order status API.")
+                            self.c_trigger_event(self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                                                 MarketOrderFailureEvent(
+                                                     self._current_timestamp,
+                                                     client_order_id,
+                                                     tracked_order.order_type
+                                                 ))
+                    self.c_stop_tracking_order(client_order_id)
+
+    async def _iter_user_event_queue(self) -> AsyncIterable[Dict[str, Any]]:
+        while True:
+            try:
+                yield await self._user_stream_tracker.user_stream.get()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network(
+                    "Unknown error. Retrying after 1 seconds.",
+                    exc_info=True,
+                    app_warning_msg="Could not fetch user events from Stex. Check API key and network connection."
+                )
+                await asyncio.sleep(1.0)
+
+    async def _user_stream_event_listener(self):
+        async for event_message in self._iter_user_event_queue():
+            try:
+                updates: List[Any] = event_message[1]
+                for update in updates:
+                    exchange_order_id = update["id"]
+                    trading_pair = convert_from_exchange_trading_pair(update["currency_pair_name"])
+                    order_status = update["status"]
+                    try:
+                        client_order_id = next(key for key, value in self._in_flight_orders.items()
+                                               if value.exchange_order_id == exchange_order_id)
+                    except StopIteration:
+                        continue
+
+                    if order_status not in ["PROCESSING", "PENDING", "PARTIAL", "FINISHED", "CANCELLED"]:
+                        self.logger().debug(f"Unrecognized order update response - {event_message}")
+                    tracked_order = self._in_flight_orders.get(client_order_id)
+
+                    if tracked_order is None:
+                        continue
+
+                    execute_amount_diff = s_decimal_0
+                    execute_price = Decimal(update["price"])
+                    order_type = update["type"]
+
+                    execute_amount_diff = Decimal(update["processed_amount"])
+                    tracked_order.executed_amount_base += execute_amount_diff
+                    tracked_order.executed_amount_quote += Decimal(execute_amount_diff * execute_price)
+
+                    if execute_amount_diff > s_decimal_0:
+                        self.logger().info(f"Filed {execute_amount_diff} out of {tracked_order.amount} of order "
+                                           f"{order_type.upper()}-{client_order_id}")
+                        self.c_trigger_event(self.MARKET_ORDER_FILLED_EVENT_TAG,
+                                             OrderFilledEvent(
+                                                 self._current_timestamp,
+                                                 tracked_order.client_order_id,
+                                                 tracked_order.trading_pair,
+                                                 tracked_order.trade_type,
+                                                 tracked_order.order_type,
+                                                 execute_price,
+                                                 execute_amount_diff,
+                                                 self.c_get_fee(
+                                                     tracked_order.base_asset,
+                                                     tracked_order.quote_asset,
+                                                     tracked_order.order_type,
+                                                     tracked_order.trade_type,
+                                                     execute_price,
+                                                     execute_amount_diff,
+                                                 ),
+                                                 exchange_trade_id=exchange_order_id
+                                             ))
+
+                    if order_status == "FINISHED":
+                        tracked_order.last_state = order_status
+                        if tracked_order.trade_type is TradeType.BUY:
+                            self.logger().info(f"The LIMIT_BUY order {tracked_order.client_order_id} has completed "
+                                               f"according to order delta websocket API.")
+                            self.c_trigger_event(self.MARKET_BUY_ORDER_COMPLETED_EVENT_TAG,
+                                                 BuyOrderCompletedEvent(
+                                                     self._current_timestamp,
+                                                     tracked_order.client_order_id,
+                                                     tracked_order.base_asset,
+                                                     tracked_order.quote_asset,
+                                                     tracked_order.fee_asset or tracked_order.quote_asset,
+                                                     tracked_order.executed_amount_base,
+                                                     tracked_order.executed_amount_quote,
+                                                     tracked_order.fee_paid,
+                                                     tracked_order.order_type
+                                                 ))
+
+                        elif tracked_order.trade_type is TradeType.SELL:
+                                self.logger().info(f"The LIMIT_SELL order {tracked_order.client_order_id} has completed "
+                                                   f"according to order delta websocket API.")
+                                self.c_trigger_event(self.MARKET_SELL_ORDER_COMPLETED_EVENT_TAG,
+                                                     SellOrderCompletedEvent(
+                                                         self._current_timestamp,
+                                                         tracked_order.client_order_id,
+                                                         tracked_order.base_asset,
+                                                         tracked_order.quote_asset,
+                                                         tracked_order.fee_asset or tracked_order.quote_asset,
+                                                         tracked_order.executed_amount_base,
+                                                         tracked_order.executed_amount_quote,
+                                                         tracked_order.fee_paid,
+                                                         tracked_order.order_type
+                                                     ))
+                        self.c_stop_tracking_order(tracked_order.client_order_id)
+                        continue
+
+                    if order_status == "CANCELLED":
+                            tracked_order.last_state = order_status
+                            self.logger().info(f"The order {tracked_order.client_order_id} has been cancelled "
+                                               f"according to order delta websocket API.")
+                            self.c_trigger_event(self.MARKET_ORDER_CANCELLED_EVENT_TAG,
+                                                 OrderCancelledEvent(self._current_timestamp,
+                                                                     tracked_order.client_order_id))
+                            self.c_stop_tracking_order(tracked_order.client_order_id)
+
+            except asyncio.CancelledError:
+                    raise
+            except Exception as e:
+                self.logger().error(f"Unexpected error in user stream listener loop. {e}", exc_info=True)
+                await asyncio.sleep(5.0)
+
+    async def _status_polling_loop(self):
+        while True:
+            try:
+                self._poll_notifier = asyncio.Event()
+                await self._poll_notifier.wait()
+                await safe_gather(
+                    self._update_balances(),
+                    self._update_order_status(),
+                )
+                self._last_pull_timestamp = self._current_timestamp
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network("Unexpected error while fetching account updates.", exc_info=True,
+                                      app_warning_msg="Could not fetch account updates from Stex. "
+                                                      "Check API key and network connection.")
+                await asyncio.sleep(0.5)
+
+    async def _trading_rules_polling_loop(self):
+        while True:
+            try:
+                await safe_gather(
+                    self._update_trading_rules(),
+                )
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network("Unexpected error while fetching trading rules.", exc_info=True,
+                                      app_warning_msg="Could not fetch new trading rules from Stex. "
+                                                      "Check network connection.")
+                await asyncio.sleep(0.5)
+
+    def status_dict(self) -> Dict[str, bool]:
+        return {
+            "order_books_initialized": self._order_book_tracker.ready,
+            "account_balance": len(self._account_balances) > 0 if self._trading_required else True,
+            "trading_rule_initialized": len(self._trading_rules) > 0
+        }
+
+    @property
+    def ready(self) -> bool:
+        return all(self.status_dict().values())
+
+    cdef c_start(self, Clock clock, double timestamp):
+        self._tx_tracker.c_start(clock, timestamp)
+        ExchangeBase.c_start(self, clock, timestamp)
+
+    cdef c_stop(self, Clock clock):
+        ExchangeBase.c_stop(self, clock)
+        self._async_scheduler.stop()
+
+    async def start_network(self):
+        self._stop_network()
+        self._order_book_tracker.start()
+        self._trading_rules_polling_task = safe_ensure_future(self._trading_rules_polling_loop())
+        if self._trading_required:
+            self._status_polling_task = safe_ensure_future(self._status_polling_loop())
+            self._user_stream_tracker_task = safe_ensure_future(self._user_stream_tracker.start())
+            self._user_stream_event_listener_task = safe_ensure_future(self._user_stream_event_listener())
+
+    def _stop_network(self):
+        self._order_book_tracker.stop()
+        if self._status_polling_task is not None:
+            self._status_polling_task.cancel()
+        if self._user_stream_tracker_task is not None:
+            self._user_stream_tracker_task.cancel()
+        if self._user_stream_event_listener_task is not None:
+            self._user_stream_event_listener_task.cancel()
+        if self._trading_rules_polling_task is not None:
+            self._trading_rules_polling_task.cancel()
+        self._status_polling_task = self._user_stream_tracker_task = \
+            self._user_stream_event_listener_task = None
+
+    async def check_network(self) -> NetworkStatus:
+        try:
+            client = await self._http_client()
+            await client.get(STEX_TIME_URL)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return NetworkStatus.NOT_CONNECTED
+        return NetworkStatus.CONNECTED
+
+    cdef c_tick(self, double timestamp):
+        cdef:
+            int64_t last_tick = <int64_t>(self._last_timestamp / self._poll_interval)
+            int64_t current_tick = <int64_t>(timestamp / self._poll_interval)
+        ExchangeBase.c_tick(self, timestamp)
+        self._tx_tracker.c_tick(timestamp)
+        if current_tick > last_tick:
+            if not self._poll_notifier.is_set():
+                self._poll_notifier.set()
+        self._last_timestamp = timestamp
+
+#order type (BUY / SELL / STOP_LIMIT_BUY / STOP_LIMIT_SELL)
+
+    async def place_order(self,
+                          trading_pair: str,
+                          amount: Decimal,
+                          order_type: OrderType,
+                          is_buy: bool,
+                          price: Optional[Decimal] = s_decimal_NaN):
+
+        currency_pair_id = self._currency_pair_dict.get(trading_pair)
+        path_url = "/trading/orders/{}".format(currency_pair_id)
+        data = {
+            "type": "BUY" if is_buy else "SELL",
+            'amount': amount,
+            'price': price
+        }
+        return await self._api_request(method = 'POST',
+                                       path_url = path_url,
+                                       format_type = 'form',
+                                       data = data,
+                                       is_auth_required = True)
+    async def execute_buy(self,
+                          order_id: str,
+                          trading_pair: str,
+                          amount: Decimal,
+                          order_type: OrderType,
+                          price: Optional[Decimal] = s_decimal_NaN):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+
+        decimal_amount = self.c_quantize_order_amount(trading_pair, amount)
+        decimal_price = self.c_quantize_order_price(trading_pair, price)
+
+        try:
+            order_result = None
+            order_decimal_amount = f"{decimal_amount:f}"
+            if order_type is OrderType.LIMIT:
+                order_decimal_price = f"{decimal_price:f}"
+                order_result = await self.place_order(trading_pair=trading_pair,
+                                                      amount=order_decimal_amount,
+                                                      order_type=order_type,
+                                                      is_buy=True,
+                                                      price=order_decimal_price)
+
+                exchange_order_id = order_result["data"]["id"]
+
+                self.c_start_tracking_order(
+                    order_id,
+                    exchange_order_id,
+                    trading_pair,
+                    TradeType.BUY,
+                    decimal_price,
+                    decimal_amount,
+                    order_type
+                )
+                tracked_order = self._in_flight_orders.get(order_id)
+            if tracked_order is not None:
+                self.logger().info(f"Created {order_type} buy order {order_id} for "
+                                   f"{decimal_amount} {trading_pair}.")
+                tracked_order.exchange_order_id = exchange_order_id
+            self.c_trigger_event(self.MARKET_BUY_ORDER_CREATED_EVENT_TAG,
+                                 BuyOrderCreatedEvent(
+                                     self._current_timestamp,
+                                     order_type,
+                                     trading_pair,
+                                     decimal_amount,
+                                     decimal_price,
+                                     order_id
+                                 ))
+
+        except asyncio.CancelledError:
+            raise
+
+        except Exception as e:
+            self.c_stop_tracking_order(order_id)
+            order_type_str = 'LIMIT'
+            self.logger().network(
+                f"Error submitting buy {order_type_str} order to Stex for "
+                f"{decimal_amount} {trading_pair}"
+                f" {decimal_price}.",
+                exc_info=True,
+                app_warning_msg=f"Failed to submit buy order to Stex. Check API key and network connection."
+            )
+            self.c_trigger_event(self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                                 MarketOrderFailureEvent(self._current_timestamp, order_id, order_type))
+
+    cdef str c_buy(self, str trading_pair, object amount, object order_type=OrderType.LIMIT, object price=s_decimal_NaN,
+                   dict kwargs={}):
+        cdef:
+            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
+            str order_id = str(f"buy-{trading_pair}-{tracking_nonce}")
+        safe_ensure_future(self.execute_buy(order_id, trading_pair, amount, order_type, price=price))
+        return order_id
+
+    async def execute_sell(self,
+                           order_id: str,
+                           trading_pair: str,
+                           amount: Decimal,
+                           order_type: OrderType,
+                           price: Optional[Decimal] = s_decimal_0):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+            object decimal_amount
+            object decimal_price
+            str exchange_order_id
+            object tracked_order
+
+        decimal_amount = self.quantize_order_amount(trading_pair, amount)
+        decimal_price = self.c_quantize_order_price(trading_pair, price)
+
+        try:
+            order_result = None
+            order_decimal_amount = f"{decimal_amount:f}"
+            if order_type is OrderType.LIMIT:
+                order_decimal_price = f"{decimal_price:f}"
+                order_result = await self.place_order(trading_pair=trading_pair,
+                                                      amount=order_decimal_amount,
+                                                      order_type=order_type,
+                                                      is_buy=False,
+                                                      price=order_decimal_price)
+
+                exchange_order_id = order_result["data"]["id"]
+
+                self.c_start_tracking_order(
+                    order_id,
+                    exchange_order_id,
+                    trading_pair,
+                    TradeType.SELL,
+                    decimal_price,
+                    decimal_amount,
+                    order_type,
+                )
+
+            else:
+                raise ValueError(f"Invalid OrderType {order_type}. Aborting.")
+
+
+            tracked_order = self._in_flight_orders.get(order_id)
+            if tracked_order is not None:
+                self.logger().info(f"Created {order_type} sell order {order_id} for "
+                                   f"{decimal_amount} {trading_pair}.")
+                tracked_order.exchange_order_id = exchange_order_id
+
+            self.c_trigger_event(self.MARKET_SELL_ORDER_CREATED_EVENT_TAG,
+                                 SellOrderCreatedEvent(
+                                     self._current_timestamp,
+                                     order_type,
+                                     trading_pair,
+                                     decimal_amount,
+                                     decimal_price,
+                                     order_id
+                                 ))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.c_stop_tracking_order(order_id)
+            order_type_str = 'LIMIT'
+            self.logger().network(
+                f"Error submitting sell {order_type_str} order to Stex for "
+                f"{decimal_amount} {trading_pair} "
+                f"{decimal_price}.",
+                exc_info=True,
+                app_warning_msg=f"Failed to submit sell order to Stex. Check API key and network connection."
+            )
+            self.c_trigger_event(self.MARKET_ORDER_FAILURE_EVENT_TAG,
+                                 MarketOrderFailureEvent(self._current_timestamp, order_id, order_type))
+
+    cdef str c_sell(self, str trading_pair, object amount, object order_type=OrderType.LIMIT, object price=s_decimal_NaN,dict kwargs={}):
+        cdef:
+            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
+            str order_id = str(f"sell-{trading_pair}-{tracking_nonce}")
+        safe_ensure_future(self.execute_sell(order_id, trading_pair, amount, order_type, price=price))
+        return order_id
+
+    async def execute_cancel(self, trading_pair: str, order_id: str):
+        try:
+            tracked_order = self._in_flight_orders.get(order_id)
+            if tracked_order is None:
+                raise ValueError(f"Failed to cancel order – {order_id}. Order not found.")
+
+            path_url = "/trading/order/" + str(order_id)
+
+            cancel_result = await self._api_request(method="DELETE",
+                                                    path_url=path_url,
+                                                    is_auth_required=True
+                                                    )
+            accepted_orders = cancel_result["data"]["put_into_processing_queue"]
+            rejected_orders = cancel_result["data"]["not_put_into_processing_queue"]
+
+            if cancel_result["success"]==False or (len(accepted_orders)==0 and len(rejected_orders)==0):
+                self.logger().warning(f"Error cancelling order on Stex",exc_info=True)
+            else:
+                self.c_stop_tracking_order(order_id)
+                self.logger().info(f"Successfully cancelled order {order_id}.")
+                self.c_trigger_event(self.MARKET_ORDER_CANCELLED_EVENT_TAG,
+                                     OrderCancelledEvent(self._current_timestamp,order_id))
+            return {"origClientOrderId": order_id}
+
+        except Exception as e:
+            self.logger().warning(f"Error cancelling order on Kraken",
+                                  exc_info=True)
+
+    cdef c_cancel(self, str trading_pair, str order_id):
+        safe_ensure_future(self.execute_cancel(trading_pair, order_id))
+        return order_id
+
+    async def cancel_all(self, timeout_seconds: float) -> List[CancellationResult]:
+        incomplete_orders = [(key, o) for (key, o) in self._in_flight_orders.items() if not o.is_done]
+        tasks = [self.execute_cancel(o.trading_pair, key) for (key, o) in incomplete_orders]
+        order_id_set = set([key for (key, o) in incomplete_orders])
+        successful_cancellations = []
+
+        try:
+            async with timeout(timeout_seconds):
+                cancellation_results = await safe_gather(*tasks, return_exceptions=True)
+                for cr in cancellation_results:
+                    if isinstance(cr, Exception):
+                        continue
+                    if isinstance(cr, dict) and "origClientOrderId" in cr:
+                        client_order_id = cr.get("origClientOrderId")
+                        order_id_set.remove(client_order_id)
+                        successful_cancellations.append(CancellationResult(client_order_id, True))
+
+        except Exception:
+            self.logger().network(
+                f"Unexpected error cancelling orders.",
+                exc_info=True,
+                app_warning_msg="Failed to cancel order with Stex. Check API key and network connection."
+            )
+
+        failed_cancellations = [CancellationResult(oid, False) for oid in order_id_set]
+        return successful_cancellations + failed_cancellations
+
+    cdef OrderBook c_get_order_book(self, str trading_pair):
+        cdef:
+            dict order_books = self._order_book_tracker.order_books
+
+        if trading_pair not in order_books:
+            raise ValueError(f"No order book exists for '{trading_pair}'.")
+        return order_books[trading_pair]
+
+    cdef c_did_timeout_tx(self, str tracking_id):
+        self.c_trigger_event(self.MARKET_TRANSACTION_FAILURE_EVENT_TAG,
+                             MarketTransactionFailureEvent(self._current_timestamp, tracking_id))
+
+    cdef c_start_tracking_order(self,
+                                str order_id,
+                                str exchange_order_id,
+                                str trading_pair,
+                                object trade_type,
+                                object price,
+                                object amount,
+                                object order_type):
+        self._in_flight_orders[order_id] = StexInFlightOrder(
+            client_order_id=order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=trading_pair,
+            trade_type=trade_type,
+            price=price,
+            amount=amount,
+            order_type=order_type,
+        )
+
+    cdef c_stop_tracking_order(self, str order_id):
+        if order_id in self._in_flight_orders:
+            del self._in_flight_orders[order_id]
+        if order_id in self._order_not_found_records:
+            del self._order_not_found_records[order_id]
+
+    cdef object c_get_order_price_quantum(self, str trading_pair, object price):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+        return trading_rule.min_price_increment
+
+    cdef object c_get_order_size_quantum(self, str trading_pair, object order_size):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+        return Decimal(trading_rule.min_base_amount_increment)
+
+    cdef object c_quantize_order_amount(self, str trading_pair, object amount, object price=s_decimal_0):
+        cdef:
+            TradingRule trading_rule = self._trading_rules[trading_pair]
+            object quantized_amount = ExchangeBase.c_quantize_order_amount(self, trading_pair, amount)
+
+        global s_decimal_0
+        if quantized_amount < trading_rule.min_order_size:
+            return s_decimal_0
+
+        return quantized_amount
+
+    def get_price(self, trading_pair: str, is_buy: bool) -> Decimal:
+        return self.c_get_price(trading_pair, is_buy)
+
+    def buy(self, trading_pair: str, amount: Decimal, order_type=OrderType.MARKET,
+            price: Decimal = s_decimal_NaN, **kwargs) -> str:
+        return self.c_buy(trading_pair, amount, order_type, price, kwargs)
+
+    def sell(self, trading_pair: str, amount: Decimal, order_type=OrderType.MARKET,
+             price: Decimal = s_decimal_NaN, **kwargs) -> str:
+        return self.c_sell(trading_pair, amount, order_type, price, kwargs)
+
+    def cancel(self, trading_pair: str, client_order_id: str):
+        return self.c_cancel(trading_pair, client_order_id)
+
+    def get_fee(self,
+                base_currency: str,
+                quote_currency: str,
+                order_type: OrderType,
+                order_side: TradeType,
+                amount: Decimal,
+                price: Decimal = s_decimal_NaN) -> TradeFee:
+        return self.c_get_fee(base_currency, quote_currency, order_type, order_side, amount, price)
+
+    def get_order_book(self, trading_pair: str) -> OrderBook:
+        return self.c_get_order_book(trading_pair)

--- a/hummingbot/connector/exchange/stex/stex_in_flight_order.pxd
+++ b/hummingbot/connector/exchange/stex/stex_in_flight_order.pxd
@@ -1,0 +1,6 @@
+from hummingbot.connector.in_flight_order_base cimport InFlightOrderBase
+
+cdef class KrakenInFlightOrder(InFlightOrderBase):
+    cdef:
+        public object trade_id_set
+        public int userref

--- a/hummingbot/connector/exchange/stex/stex_in_flight_order.pyx
+++ b/hummingbot/connector/exchange/stex/stex_in_flight_order.pyx
@@ -1,0 +1,73 @@
+from decimal import Decimal
+from typing import (
+    Any,
+    Dict
+)
+
+from hummingbot.core.event.events import (
+    OrderType,
+    TradeType
+)
+from hummingbot.connector.in_flight_order_base import InFlightOrderBase
+
+s_decimal_0 = Decimal(0)
+
+# states : "PROCESSING", "PENDING", "PARTIAL", "FINISHED", "CANCELLED"
+
+cdef class StexInFlightOrder(InFlightOrderBase):
+    def __init__(self,
+                 client_order_id: str,
+                 exchange_order_id: str,
+                 trading_pair: str,
+                 order_type: OrderType,
+                 trade_type: TradeType,
+                 price: Decimal,
+                 amount: Decimal,
+                 initial_state: str = "PROCESSING"):
+        super().__init__(
+            client_order_id,
+            exchange_order_id,
+            trading_pair,
+            order_type,
+            trade_type,
+            price,
+            amount,
+            initial_state
+        )
+        self.trade_id_set = set()
+
+    @property
+    def is_done(self) -> bool:
+        return self.last_state in {"FINISHED"}
+
+    @property
+    def is_failure(self) -> bool:
+        return self.last_state in {"CANCELLED"}
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.last_state in {"CANCELLED"}
+
+    @property
+    def is_open(self) -> bool:
+        return self.last_state in {"PROCESSING", "PENDING", "PARTIAL"}
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> InFlightOrderBase:
+        cdef:
+            StexInFlightOrder retval = KrakenInFlightOrder(
+                client_order_id=data["client_order_id"],
+                exchange_order_id=data["exchange_order_id"],
+                trading_pair=data["trading_pair"],
+                order_type=getattr(OrderType, data["order_type"]),
+                trade_type=getattr(TradeType, data["trade_type"]),
+                price=Decimal(data["price"]),
+                amount=Decimal(data["amount"]),
+                initial_state=data["last_state"]
+            )
+        retval.executed_amount_base = Decimal(data["executed_amount_base"])
+        retval.executed_amount_quote = Decimal(data["executed_amount_quote"])
+        retval.fee_asset = data["fee_asset"]
+        retval.fee_paid = Decimal(data["fee_paid"])
+        retval.last_state = data["last_state"]
+        return retval

--- a/hummingbot/connector/exchange/stex/stex_order_book.pxd
+++ b/hummingbot/connector/exchange/stex/stex_order_book.pxd
@@ -1,0 +1,4 @@
+from hummingbot.core.data_type.order_book cimport OrderBook
+
+cdef class StexOrderBook(OrderBook):
+    pass

--- a/hummingbot/connector/exchange/stex/stex_order_book.pyx
+++ b/hummingbot/connector/exchange/stex/stex_order_book.pyx
@@ -1,0 +1,76 @@
+import logging
+from typing import (
+    Dict,
+    Optional
+)
+from hummingbot.logger import HummingbotLogger
+from hummingbot.core.event.events import TradeType
+from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.core.data_type.order_book_message import (
+    OrderBookMessage,
+    OrderBookMessageType
+)
+
+_stob_logger = None
+
+cdef class StexOrderBook(OrderBook):
+    def logger(cls) -> HummingbotLogger:
+        global _stob_logger
+        if _stob_logger is None:
+            _stob_logger = logging.getLogger(__name__)
+        return _stob_logger
+
+    @classmethod
+    def snapshot_message_from_exchange(cls,
+                                       msg: Dict[str, any],
+                                       timestamp: float,
+                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        msg_ts = int(timestamp * 1e-3)
+        bids_data = []
+        asks_data = []
+        for bid in msg["data"]["bid"]:
+            data = [bid["price"],bid["amount"]]
+            bids_data.append(data)
+        for ask in msg["data"]["ask"]:
+            data = [ask["price"],ask["amount"]]
+            asks_data.append(data)
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": msg["trading_pair"],
+            "update_id": msg_ts,
+            "bids": bids_data,
+            "asks": asks_data
+        }, timestamp=timestamp * 1e-3)
+
+    @classmethod
+    def diff_message_from_exchange(cls,msg: Dict[str, any],timestamp: Optional[float] = None,metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        msg_ts = int(timestamp * 1e-3)
+        return OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": msg["trading_pair"],
+            "update_id": msg_ts,
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=timestamp * 1e-3)
+
+    @classmethod
+    def trade_message_from_exchange(cls, msg, metadata: Optional[Dict] = None):
+        if metadata:
+            msg.update(metadata)
+        msg_ts = int(msg["timestamp"] * 1e-3)
+        return OrderBookMessage(OrderBookMessageType.TRADE, {
+            "trading_pair": msg["trading_pair"],
+            "trade_type": float(TradeType.SELL.value) if msg["order_type"] == "SELL" else float(TradeType.BUY.value),
+            "trade_id": msg['id'],
+            "update_id": msg_ts,
+            "price": msg["price"],
+            "amount": msg["amount"]
+        }, timestamp=msg_ts)
+
+    @classmethod
+    def from_snapshot(cls, msg: OrderBookMessage) -> "OrderBook":
+        retval = StexOrderBook()
+        retval.apply_snapshot(msg.bids, msg.asks, msg.update_id)
+        return retval

--- a/hummingbot/connector/exchange/stex/stex_order_book_tracker.py
+++ b/hummingbot/connector/exchange/stex/stex_order_book_tracker.py
@@ -1,0 +1,138 @@
+import asyncio
+import logging
+import time
+from collections import deque, defaultdict
+from typing import (
+    Deque,
+    Dict,
+    List,
+    Optional
+)
+from hummingbot.logger import HummingbotLogger
+from hummingbot.core.data_type.order_book_tracker import (
+    OrderBookTracker
+)
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.connector.exchange.stex.stex_api_order_book_data_source import StexAPIOrderBookDataSource
+from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.utils.async_utils import wait_til
+
+class StexOrderBookTracker(OrderBookTracker):
+    _stobt_logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._stobt_logger is None:
+            cls._stobt_logger = logging.getLogger(__name__)
+        return cls._stobt_logger
+
+    def __init__(self, trading_pairs: List[str]):
+        super().__init__(StexAPIOrderBookDataSource(trading_pairs), trading_pairs)
+        self._order_book_diff_stream: asyncio.Queue = asyncio.Queue()
+        self._order_book_snapshot_stream: asyncio.Queue = asyncio.Queue()
+        self._ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        self._saved_message_queues: Dict[str, Deque[OrderBookMessage]] = defaultdict(lambda: deque(maxlen=1000))
+
+    @property
+    def data_source(self) -> OrderBookTrackerDataSource:
+        if not self._data_source:
+            self._data_source = StexAPIOrderBookDataSource(trading_pairs=self._trading_pairs)
+        return self._data_source
+    @property
+    def exchange_name(self) -> (str):
+        return "stex"
+
+    async def _order_book_diff_router(self):
+        """
+        Route the real-time order book diff messages to the correct order book.
+        """
+        last_message_timestamp: float = time.time()
+        messages_queued: int = 0
+        messages_accepted: int = 0
+        messages_rejected: int = 0
+
+        while True:
+            try:
+                ob_message: OrderBookMessage = await self._order_book_diff_stream.get()
+                trading_pair: str = ob_message.trading_pair
+
+                if trading_pair not in self._tracking_message_queues:
+                    messages_queued += 1
+                    self._saved_message_queues[trading_pair].append(ob_message)
+                    continue
+                message_queue: asyncio.Queue = self._tracking_message_queues[trading_pair]
+                # Check the order book's initial update ID. If it's larger, don't bother.
+                order_book: OrderBook = self._order_books[trading_pair]
+
+                if order_book.snapshot_uid > ob_message.update_id:
+                    messages_rejected += 1
+                    continue
+                await message_queue.put(ob_message)
+                messages_accepted += 1
+
+                # Log some statistics.
+                now: float = time.time()
+                if int(now / 60.0) > int(last_message_timestamp / 60.0):
+                    self.logger().debug("Diff messages processed: %d, rejected: %d, queued: %d",
+                                        messages_accepted,
+                                        messages_rejected,
+                                        messages_queued)
+                    messages_accepted = 0
+                    messages_rejected = 0
+                    messages_queued = 0
+
+                last_message_timestamp = now
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unknown error. Retrying after 5 seconds.", exc_info=True)
+                await asyncio.sleep(5.0)
+
+    async def _track_single_book(self, trading_pair: str):
+        past_diffs_window: Deque[OrderBookMessage] = deque()
+        self._past_diffs_windows[trading_pair] = past_diffs_window
+
+        message_queue: asyncio.Queue = self._tracking_message_queues[trading_pair]
+        order_book: OrderBook = self._order_books[trading_pair]
+        last_message_timestamp: float = time.time()
+        diff_messages_accepted: int = 0
+
+        while True:
+            try:
+                message: OrderBookMessage = None
+                saved_messages: Deque[OrderBookMessage] = self._saved_message_queues[trading_pair]
+
+                # Process saved messages first if there are any
+                if len(saved_messages) > 0:
+                    message = saved_messages.popleft()
+                else:
+                    message = await message_queue.get()
+
+                if message.type is OrderBookMessageType.DIFF:
+                    order_book.apply_diffs(message.bids, message.asks, message.update_id)
+                    past_diffs_window.append(message)
+                    while len(past_diffs_window) > self.PAST_DIFF_WINDOW_SIZE:
+                        past_diffs_window.popleft()
+                    diff_messages_accepted += 1
+
+                    # Output some statistics periodically.
+                    now: float = time.time()
+                    if int(now / 60.0) > int(last_message_timestamp / 60.0):
+                        self.logger().debug("Processed %d order book diffs for %s.",
+                                            diff_messages_accepted, trading_pair)
+                        diff_messages_accepted = 0
+                    last_message_timestamp = now
+                elif message.type is OrderBookMessageType.SNAPSHOT:
+                    past_diffs: List[OrderBookMessage] = list(past_diffs_window)
+                    order_book.restore_from_snapshot_and_diffs(message, past_diffs)
+                    self.logger().debug("Processed order book snapshot for %s.", trading_pair)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network(
+                    f"Unexpected error tracking order book for {trading_pair}.",
+                    exc_info=True,
+                    app_warning_msg="Unexpected error tracking order book. Retrying after 5 seconds."
+                )
+                await asyncio.sleep(5.0)

--- a/hummingbot/connector/exchange/stex/stex_user_stream_tracker.py
+++ b/hummingbot/connector/exchange/stex/stex_user_stream_tracker.py
@@ -1,0 +1,46 @@
+import asyncio
+import logging
+from typing import (
+    Optional
+)
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.logger import HummingbotLogger
+from hummingbot.core.data_type.user_stream_tracker import UserStreamTracker
+from hummingbot.core.utils.async_utils import (
+    safe_ensure_future,
+    safe_gather,
+)
+from hummingbot.connector.exchange.stex.stex_api_user_stream_data_source import StexAPIUserStreamDataSource
+from hummingbot.connector.exchange.stex.stex_auth import StexAuth
+
+class StexUserStreamTracker(UserStreamTracker):
+    _stust_logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._stust_logger is None:
+            cls._stust_logger = logging.getLogger(__name__)
+        return cls._stust_logger
+
+    def __init__(self,
+                 stex_auth: StexAuth):
+        super().__init__()
+        self._ev_loop: asyncio.events.AbstractEventLoop = asyncio.get_event_loop()
+        self._data_source: Optional[UserStreamTrackerDataSource] = None
+        self._user_stream_tracking_task: Optional[asyncio.Task] = None
+        self._stex_auth: StexAuth = stex_auth
+
+    @property
+    def data_source(self) -> UserStreamTrackerDataSource:
+        if not self._data_source:
+            self._data_source = StexAPIUserStreamDataSource(stex_auth=self._stex_auth)
+        return self._data_source
+
+    def exchange_name(self) -> str:
+        return "stex"
+
+    async def start(self):
+        self._user_stream_tracking_task = safe_ensure_future(
+            self.data_source.listen_for_user_stream(self._ev_loop, self._user_stream)
+        )
+        await safe_gather(self._user_stream_tracking_task)

--- a/hummingbot/connector/exchange/stex/stex_utils.py
+++ b/hummingbot/connector/exchange/stex/stex_utils.py
@@ -1,0 +1,30 @@
+import re
+from typing import (
+    Optional,
+    Tuple)
+
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.client.config.config_methods import using_exchange
+
+
+CENTRALIZED = True
+
+EXAMPLE_PAIR = "ZRX-ETH"
+
+DEFAULT_FEES = [0.2, 0.2]
+
+def convert_from_exchange_trading_pair(exchange_trading_pair: str) -> str:
+    return exchange_trading_pair.replace("_", "-")
+
+
+def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
+    return hb_trading_pair.replace("-", "_")
+
+KEYS = {
+    "stex_access_token":
+        ConfigVar(key="stex_access_token",
+                  prompt="Enter your Stex access token >>> ",
+                  required_if=using_exchange("stex"),
+                  is_secure=True,
+                  is_connect_key=True),
+}

--- a/hummingbot/templates/conf_fee_overrides_TEMPLATE.yml
+++ b/hummingbot/templates/conf_fee_overrides_TEMPLATE.yml
@@ -3,7 +3,7 @@
 ########################################
 
 # For more detailed information: https://docs.hummingbot.io
-template_version: 6
+template_version: 7
 
 # Exchange trading fees, the values are in percentage value, e.g. 0.1 for 0.1%.
 # If the value is left blank, the default value (from corresponding market connector) will be used.
@@ -83,3 +83,6 @@ probit_taker_fee:
 
 probit_kr_maker_fee:
 probit_kr_taker_fee:
+
+stex_maker_fee:
+stex_taker_fee:

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -3,7 +3,7 @@
 #################################
 
 # For more detailed information: https://docs.hummingbot.io
-template_version: 20
+template_version: 21
 
 # Exchange configs
 bamboo_relay_use_coordinator: false
@@ -88,6 +88,8 @@ probit_secret_key: null
 
 probit_kr_api_key: null
 probit_kr_secret_key: null
+
+stex_access_token: null
 
 # Ethereum wallet address: required for trading on a DEX
 ethereum_wallet: null

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ def main():
         "hummingbot.connector.exchange.eterbase",
         "hummingbot.connector.exchange.beaxy",
         "hummingbot.connector.exchange.hitbtc",
+        "hummingbot.connector.exchange.stex",
         "hummingbot.connector.derivative",
         "hummingbot.connector.derivative.binance_perpetual",
         "hummingbot.script",

--- a/test/integration/test_stex_api_order_book_data_source.py
+++ b/test/integration/test_stex_api_order_book_data_source.py
@@ -1,0 +1,52 @@
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+from hummingbot.connector.exchange.stex.stex_api_order_book_data_source import StexAPIOrderBookDataSource
+from hummingbot.core.data_type.order_book_tracker_entry import OrderBookTrackerEntry
+import asyncio
+import aiohttp
+import logging
+from typing import (
+    Dict,
+    Optional,
+    Any,
+    List,
+)
+import pandas as pd
+import unittest
+
+class StexAPIOrderBookDataSourceUnitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.order_book_data_source: StexAPIOrderBookDataSource = StexAPIOrderBookDataSource(["ABS-BTC", "ABET-BTC", "ACRYL-BTC"])
+
+    def run_async(self, task):
+        return self.ev_loop.run_until_complete(task)
+
+    def test_get_trading_pairs(self):
+        trading_pairs: List[str] = self.run_async(self.order_book_data_source.get_trading_pairs())
+        self.assertIn("ABS-BTC", trading_pairs)
+
+    async def get_snapshot(self):
+        async with aiohttp.ClientSession() as client:
+            trading_pairs: List[str] = await self.order_book_data_source.get_trading_pairs()
+            trading_pair: str = trading_pairs[0]
+            try:
+                snapshot: Dict[str, Any] = await self.order_book_data_source.get_snapshot(client, trading_pair)
+                return snapshot
+            except Exception:
+                return None
+
+    def test_get_snapshot(self):
+        snapshot: Optional[Dict[str, Any]] = self.run_async(self.get_snapshot())
+        self.assertIsNotNone(snapshot)
+        self.assertIn(snapshot["data"]['ask'][0]['currency_pair_id'],[935])
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_stex_api_user_stream_data_source.py
+++ b/test/integration/test_stex_api_user_stream_data_source.py
@@ -1,0 +1,33 @@
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+from hummingbot.connector.exchange.stex.stex_api_user_stream_data_source import StexAPIUserStreamDataSource
+from hummingbot.connector.exchange.stex.stex_auth import StexAuth
+import asyncio
+import logging
+import unittest
+import conf
+
+
+class StexAPIOrderBookDataSourceUnitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.stex_auth = StexAuth(conf.stex_access_token)
+        cls.user_stream_data_source: StexAPIUserStreamDataSource = StexAPIUserStreamDataSource(stex_auth=cls.stex_auth)
+
+    def run_async(self, task):
+        return self.ev_loop.run_until_complete(task)
+
+    def test_get_auth_token(self):
+        self.token: str = self.run_async(self.user_stream_data_source.get_access_token())
+        self.assertIsInstance(self.token, str)
+        self.run_async(self.user_stream_data_source.stop())
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_stex_market.py
+++ b/test/integration/test_stex_market.py
@@ -1,0 +1,414 @@
+import time
+from os import unlink
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+from hummingbot.connector.exchange.stex.stex_exchange import StexExchange
+from hummingbot.connector.exchange.stex.stex_utils import convert_to_exchange_trading_pair
+from hummingbot.connector.markets_recorder import MarketsRecorder
+from hummingbot.model.sql_connection_manager import (
+    SQLConnectionManager,
+    SQLConnectionType
+)
+from hummingbot.model.market_state import MarketState
+from hummingbot.model.order import Order
+from hummingbot.model.trade_fill import TradeFill
+from hummingbot.core.event.events import (
+    OrderType
+)
+from hummingbot.core.event.event_logger import EventLogger
+from hummingbot.core.event.events import (
+    MarketEvent,
+    BuyOrderCompletedEvent,
+    SellOrderCompletedEvent,
+    OrderFilledEvent,
+    OrderCancelledEvent,
+    BuyOrderCreatedEvent,
+    SellOrderCreatedEvent,
+    TradeFee,
+    TradeType,
+)
+from hummingbot.core.clock import (
+    Clock,
+    ClockMode
+)
+from hummingbot.client.config.fee_overrides_config_map import fee_overrides_config_map
+import asyncio
+import contextlib
+import logging
+from typing import (
+    Optional,
+    List,
+)
+from decimal import Decimal
+import unittest
+import conf
+
+PAIR = "LOG-BTC"
+BASE = "LOG"
+QUOTE = "BTC"
+
+class StexExchangeUnitTest(unittest.TestCase):
+    events: List[MarketEvent] = [
+        MarketEvent.ReceivedAsset,
+        MarketEvent.BuyOrderCompleted,
+        MarketEvent.SellOrderCompleted,
+        MarketEvent.OrderFilled,
+        MarketEvent.OrderCancelled,
+        MarketEvent.TransactionFailure,
+        MarketEvent.BuyOrderCreated,
+        MarketEvent.SellOrderCreated,
+        MarketEvent.OrderCancelled
+    ]
+
+    market: StexExchange
+    market_logger: EventLogger
+    stack: contextlib.ExitStack
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+
+        cls.clock: Clock = Clock(ClockMode.REALTIME)
+        
+        cls.market: StexExchange = StexExchange(stex_access_token = conf.stex_access_token, trading_pairs = ["LOG-BTC"],poll_interval=10,trading_required=False)
+
+        cls.count = 0
+
+        print("Initializing Stex market... this will take about a minute. ")
+        cls.clock.add_iterator(cls.market)
+        cls.stack = contextlib.ExitStack()
+        cls._clock = cls.stack.enter_context(cls.clock)
+        cls.ev_loop.run_until_complete(cls.wait_til_ready())
+        print("Ready.")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.stack.close()
+
+    @classmethod
+    async def wait_til_ready(cls):
+        while True:
+            now = time.time()
+            next_iteration = now // 1.0 + 1
+            if cls.market.ready:
+                break
+            else:
+                await cls._clock.run_til(next_iteration)
+            cls.count += 1
+            await asyncio.sleep(1.0)
+
+    def setUp(self):
+        self.db_path: str = realpath(join(__file__, "../stex_test.sqlite"))
+        try:
+            unlink(self.db_path)
+        except FileNotFoundError:
+            pass
+
+        self.market_logger = EventLogger()
+        for event_tag in self.events:
+            self.market.add_listener(event_tag, self.market_logger)
+
+    def tearDown(self):
+        for event_tag in self.events:
+            self.market.remove_listener(event_tag, self.market_logger)
+        self.market_logger = None
+
+    async def run_parallel_async(self, *tasks):
+        future: asyncio.Future = asyncio.ensure_future(asyncio.gather(*tasks))
+        while not future.done():
+            now = time.time()
+            next_iteration = now // 1.0 + 1
+            await self.clock.run_til(next_iteration)
+        return future.result()
+
+    def run_parallel(self, *tasks):
+        return self.run_async(self.run_parallel_async(*tasks))
+
+    def run_async(self, task):
+        return self.ev_loop.run_until_complete(task)
+
+    def sleep(self, t=1.0):
+        self.run_parallel(asyncio.sleep(t))
+
+    def test_get_fee(self):
+        buy_trade_fee: TradeFee = self.market.get_fee(BASE, QUOTE, OrderType.LIMIT, TradeType.BUY, 1)
+        self.assertGreater(buy_trade_fee.percent, 0)
+        self.assertEqual(len(buy_trade_fee.flat_fees), 0)
+        sell_trade_fee: TradeFee = self.market.get_fee(BASE, QUOTE, OrderType.LIMIT, TradeType.SELL, 1, Decimal(4000))
+        self.assertGreater(sell_trade_fee.percent, 0)
+        self.assertEqual(len(sell_trade_fee.flat_fees), 0)
+
+    def test_fee_overrides_config(self):
+        fee_overrides_config_map["stex_taker_fee"].value = None
+        taker_fee: TradeFee = self.market.get_fee("LOG", "BTC", OrderType.LIMIT, TradeType.BUY, Decimal(1),
+                                                  Decimal('0.1'))
+        self.assertAlmostEqual(Decimal("0.002"), taker_fee.percent)
+        fee_overrides_config_map["stex_taker_fee"].value = Decimal('0.2')
+        taker_fee: TradeFee = self.market.get_fee("LOG", "BTC", OrderType.LIMIT, TradeType.BUY, Decimal(1),
+                                                  Decimal('0.1'))
+        self.assertAlmostEqual(Decimal("0.002"), taker_fee.percent)
+
+    def place_order(self, is_buy, trading_pair, amount, order_type, price):
+        order_id = None
+        if is_buy:
+            order_id = self.market.buy(trading_pair, amount, order_type, price)
+        else:
+            order_id = self.market.sell(trading_pair, amount, order_type, price)
+        return order_id
+
+    def cancel_order(self, trading_pair, order_id):
+        self.market.cancel(trading_pair, order_id)
+
+    def test_limit_taker_buy(self):
+        self.assertGreater(self.market.get_balance(QUOTE), 6)
+        trading_pair = PAIR
+
+        self.sleep(3)
+        price: Decimal = self.market.get_price(trading_pair, True)
+        amount: Decimal = Decimal("0.02")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        order_id = self.place_order(
+            True,
+            trading_pair,
+            quantized_amount,
+            OrderType.LIMIT,
+            price
+        )
+        [order_completed_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCompletedEvent))
+        order_completed_event: BuyOrderCompletedEvent = order_completed_event
+        trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
+                                                if isinstance(t, OrderFilledEvent) and t.amount is not None]
+        base_amount_traded: Decimal = sum(t.amount for t in trade_events)
+        quote_amount_traded: Decimal = sum(t.amount * t.price for t in trade_events)
+
+        self.assertTrue([evt.order_type == OrderType.LIMIT for evt in trade_events])
+        self.assertEqual(order_id, order_completed_event.order_id)
+        self.assertAlmostEqual(quantized_amount, order_completed_event.base_asset_amount)
+        self.assertEqual(BASE, order_completed_event.base_asset)
+        self.assertEqual(QUOTE, order_completed_event.quote_asset)
+        self.assertAlmostEqual(base_amount_traded, order_completed_event.base_asset_amount)
+        self.assertAlmostEqual(quote_amount_traded, order_completed_event.quote_asset_amount)
+        self.assertTrue(any([isinstance(event, BuyOrderCreatedEvent) and event.order_id == order_id
+                             for event in self.market_logger.event_log]))
+        # Reset the logs
+        self.market_logger.clear()
+
+    def test_limit_sell(self):
+        self.assertGreater(self.market.get_balance(BASE), 0.02)
+        trading_pair = PAIR
+
+        self.sleep(3)
+        price: Decimal = self.market.get_price(trading_pair, False)
+        amount: Decimal = Decimal("0.02")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        order_id = self.place_order(
+            False,
+            trading_pair,
+            quantized_amount,
+            OrderType.LIMIT,
+            price
+        )
+        [order_completed_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCompletedEvent))
+        order_completed_event: SellOrderCompletedEvent = order_completed_event
+        trade_events: List[OrderFilledEvent] = [t for t in self.market_logger.event_log
+                                                if isinstance(t, OrderFilledEvent) and t.amount is not None]
+        base_amount_traded: Decimal = sum(t.amount for t in trade_events)
+        quote_amount_traded: Decimal = sum(t.amount * t.price for t in trade_events)
+
+        self.assertTrue([evt.order_type == OrderType.LIMIT for evt in trade_events])
+        self.assertEqual(order_id, order_completed_event.order_id)
+        self.assertAlmostEqual(quantized_amount, order_completed_event.base_asset_amount)
+        self.assertEqual(BASE, order_completed_event.base_asset)
+        self.assertEqual(QUOTE, order_completed_event.quote_asset)
+        self.assertAlmostEqual(base_amount_traded, order_completed_event.base_asset_amount)
+        self.assertAlmostEqual(quote_amount_traded, order_completed_event.quote_asset_amount)
+        self.assertTrue(any([isinstance(event, SellOrderCreatedEvent) and event.order_id == order_id
+                             for event in self.market_logger.event_log]))
+        # Reset the logs
+        self.market_logger.clear()
+
+    def underpriced_limit_buy(self):
+        self.assertGreater(self.market.get_balance(QUOTE), 4)
+        trading_pair = PAIR
+
+        current_bid_price: Decimal = self.market.get_price(trading_pair, True)
+        bid_price: Decimal = current_bid_price * Decimal('0.005')
+        quantized_bid_price: Decimal = self.market.quantize_order_price(trading_pair, bid_price)
+
+        amount: Decimal = Decimal("0.02")
+        quantized_amount: Decimal = self.market.quantize_order_amount(trading_pair, amount)
+
+        order_id = self.place_order(
+            True,
+            trading_pair,
+            quantized_amount,
+            OrderType.LIMIT_MAKER,
+            quantized_bid_price
+        )
+
+        return order_id
+
+    def underpriced_limit_buy_multiple(self, num):
+        order_ids = []
+        for _ in range(num):
+            order_ids.append(self.underpriced_limit_buy())
+            self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
+        return order_ids
+
+    def test_cancel_order(self):
+        order_id = self.underpriced_limit_buy()
+        self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
+
+        self.cancel_order(PAIR, order_id)
+
+        [order_cancelled_event] = self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+        order_cancelled_event: OrderCancelledEvent = order_cancelled_event
+        self.assertEqual(order_cancelled_event.order_id, order_id)
+
+    def test_cancel_all(self):
+        order_ids = self.underpriced_limit_buy_multiple(2)
+
+        cancelled_orders = self.run_async(self.market.cancel_all(10.))
+        self.assertEqual([order.order_id for order in cancelled_orders], order_ids)
+        self.assertTrue([order.success for order in cancelled_orders])
+
+    def test_order_saving_and_restoration(self):
+        config_path: str = "test_config"
+        strategy_name: str = "test_strategy"
+        sql: SQLConnectionManager = SQLConnectionManager(SQLConnectionType.TRADE_FILLS, db_path=self.db_path)
+        order_id: Optional[str] = None
+        recorder: MarketsRecorder = MarketsRecorder(sql, [self.market], config_path, strategy_name)
+        recorder.start()
+
+        try:
+            self.assertEqual(0, len(self.market.tracking_states))
+
+            # Try to put limit buy order for 0.02 ETH at fraction of USDC market price, and watch for order creation event.
+            order_id = self.underpriced_limit_buy()
+            [order_created_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
+            order_created_event: BuyOrderCreatedEvent = order_created_event
+            self.assertEqual(order_id, order_created_event.order_id)
+
+            # Verify tracking states
+            self.assertEqual(1, len(self.market.tracking_states))
+            self.assertEqual(order_id, list(self.market.tracking_states.keys())[0])
+
+            # Verify orders from recorder
+            recorded_orders: List[Order] = recorder.get_orders_for_config_and_market(config_path, self.market)
+            self.assertEqual(1, len(recorded_orders))
+            self.assertEqual(order_id, recorded_orders[0].id)
+
+            # Verify saved market states
+            saved_market_states: MarketState = recorder.get_market_states(config_path, self.market)
+            self.assertIsNotNone(saved_market_states)
+            self.assertIsInstance(saved_market_states.saved_state, dict)
+            self.assertGreater(len(saved_market_states.saved_state), 0)
+
+            # Close out the current market and start another market.
+            self.clock.remove_iterator(self.market)
+            for event_tag in self.events:
+                self.market.remove_listener(event_tag, self.market_logger)
+            self.market: StexExchange = StexExchange(
+            conf.stex_access_token,
+            trading_pairs=[PAIR]
+            )
+            for event_tag in self.events:
+                self.market.add_listener(event_tag, self.market_logger)
+            recorder.stop()
+            recorder = MarketsRecorder(sql, [self.market], config_path, strategy_name)
+            recorder.start()
+            saved_market_states = recorder.get_market_states(config_path, self.market)
+            self.clock.add_iterator(self.market)
+            self.assertEqual(0, len(self.market.limit_orders))
+            self.assertEqual(0, len(self.market.tracking_states))
+            self.market.restore_tracking_states(saved_market_states.saved_state)
+            self.assertEqual(1, len(self.market.limit_orders))
+            self.assertEqual(1, len(self.market.tracking_states))
+
+            # Cancel the order and verify that the change is saved.
+            self.market.cancel(PAIR, order_id)
+            self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+            order_id = None
+            self.assertEqual(0, len(self.market.limit_orders))
+            self.assertEqual(0, len(self.market.tracking_states))
+            saved_market_states = recorder.get_market_states(config_path, self.market)
+            self.assertEqual(0, len(saved_market_states.saved_state))
+        finally:
+            if order_id is not None:
+                self.market.cancel(PAIR, order_id)
+                self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+
+            recorder.stop()
+            unlink(self.db_path)
+
+    def test_order_fill_record(self):
+        config_path: str = "test_config"
+        strategy_name: str = "test_strategy"
+        sql: SQLConnectionManager = SQLConnectionManager(SQLConnectionType.TRADE_FILLS, db_path=self.db_path)
+        order_id: Optional[str] = None
+        recorder: MarketsRecorder = MarketsRecorder(sql, [self.market], config_path, strategy_name)
+        recorder.start()
+
+        try:
+            # Try to buy 0.02 ETH from the exchange, and watch for completion event.
+            price: Decimal = self.market.get_price(PAIR, True)
+            amount: Decimal = Decimal("0.02")
+            quantized_amount: Decimal = self.market.quantize_order_amount(PAIR, amount)
+            order_id = self.place_order(
+                True,
+                PAIR,
+                quantized_amount,
+                OrderType.LIMIT,
+                price
+            )
+            [buy_order_completed_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCompletedEvent))
+
+            # Reset the logs
+            self.market_logger.clear()
+
+            # Try to sell back the same amount of ETH to the exchange, and watch for completion event.
+            price: Decimal = self.market.get_price(PAIR, False)
+            amount = buy_order_completed_event.base_asset_amount
+            quantized_amount: Decimal = self.market.quantize_order_amount(PAIR, amount)
+            order_id = self.place_order(
+                False,
+                PAIR,
+                quantized_amount,
+                OrderType.LIMIT,
+                price
+            )
+            [sell_order_completed_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCompletedEvent))
+
+            # Query the persisted trade logs
+            trade_fills: List[TradeFill] = recorder.get_trades_for_config(config_path)
+            self.assertGreaterEqual(len(trade_fills), 2)
+            buy_fills: List[TradeFill] = [t for t in trade_fills if t.trade_type == "BUY"]
+            sell_fills: List[TradeFill] = [t for t in trade_fills if t.trade_type == "SELL"]
+            self.assertGreaterEqual(len(buy_fills), 1)
+            self.assertGreaterEqual(len(sell_fills), 1)
+
+            order_id = None
+
+        finally:
+            if order_id is not None:
+                self.market.cancel(PAIR, order_id)
+                self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
+
+            recorder.stop()
+            unlink(self.db_path)
+
+    def test_pair_convesion(self):
+        for pair in self.market.trading_rules:
+            self.assertTrue(pair in self.market.order_books)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_stex_order_book_tracker.py
+++ b/test/integration/test_stex_order_book_tracker.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+from hummingbot.connector.exchange.stex.stex_order_book_tracker import StexOrderBookTracker
+from hummingbot.connector.exchange.stex.stex_api_order_book_data_source import StexAPIOrderBookDataSource
+import asyncio
+import logging
+import unittest
+
+
+class StexOrderBookTrackerUnitTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.order_book_tracker: StexOrderBookTracker = StexOrderBookTracker(trading_pairs=["ABS-BTC", "ABET-BTC", "ACRYL-BTC"])
+        cls.order_book_tracker.start()
+        cls.ev_loop.run_until_complete(cls.wait_til_tracker_ready())
+
+    @classmethod
+    async def wait_til_tracker_ready(cls):
+        while True:
+            if len(cls.order_book_tracker.order_books) > 0:
+                print("Initialized real-time order books.")
+                return
+            await asyncio.sleep(1)
+
+    def run_async(self, task):
+        return self.ev_loop.run_until_complete(task)
+
+    def test_data_source(self):
+        self.assertIsInstance(self.order_book_tracker.data_source, StexAPIOrderBookDataSource)
+
+    def test_name(self):
+        self.assertEqual(self.order_book_tracker.exchange_name, "stex")
+
+    def test_start_stop(self):
+        self.assertTrue(asyncio.isfuture(self.order_book_tracker._order_book_snapshot_router_task))
+        self.order_book_tracker.stop()
+        self.assertIsNone(self.order_book_tracker._order_book_snapshot_router_task)
+        self.order_book_tracker.start()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_stex_user_stream_tracker.py
+++ b/test/integration/test_stex_user_stream_tracker.py
@@ -1,0 +1,35 @@
+from os.path import join, realpath
+import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
+
+from hummingbot.connector.exchange.stex.stex_user_stream_tracker import StexUserStreamTracker
+from hummingbot.connector.exchange.stex.stex_auth import StexAuth
+from hummingbot.core.utils.async_utils import safe_ensure_future
+import asyncio
+import logging
+import unittest
+import conf
+
+
+class StexUserStreamTrackerUnitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
+        cls.stex_auth = StexAuth(conf.stex_access_token)
+        cls.user_stream_tracker: StexUserStreamTracker = StexUserStreamTracker(stex_auth=cls.stex_auth)
+        cls.user_stream_tracker_task: asyncio.Task = safe_ensure_future(cls.user_stream_tracker.start())
+
+    def run_async(self, task):
+        return self.ev_loop.run_until_complete(task)
+
+    def test_user_stream(self):
+        self.ev_loop.run_until_complete(asyncio.sleep(20.0))
+        print(self.user_stream_tracker.user_stream)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Issue : #2634 

This pull request contains the implementation of a connector for stex exchange. Some highlights are as follows:
- User needs to generate an access tokens for server-2-server integrations for websockets subscription and using private endpoints.
- Stex uses Socketio at the background of the websocket data provider. So we need to use Socketio Async client (instead of websockets)
- Stex allows LIMIT orders and STOP LIMIT orders through API endpoints. I am not sure whether hummingbot allows STOP LIMIT orders. So, currently this connector only supports LIMIT orders.
- Also, some components of `stex_exchange.py` needs to be tested more thoroughly by placing some orders and cancelling them.

Some supporting documentation for websockets and api endpoints:

- [Websocket API](https://docs.google.com/document/d/1CaD7qV6UzSJ72DMY0qLHnRgabhadVV0Kxc2_lhEFWKA/edit#)
- [REST API](https://apidocs.stex.com/#/)