### PR TITLE
Fix/avellaneda eta calculation

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -576,8 +576,8 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                 self._kappa = self._gamma / (Decimal.exp((max_spread_around_reserved_price * self._gamma - (vol * self._gamma) **2) / 2) - 1)
 
             # ETA
-
-            q_where_to_decay_order_amount = self.c_calculate_target_inventory() * (1 - self._inventory_risk_aversion)
+            # Want order_amount to be 10% of the original number if q is in the opposite extreme from target inventory
+            q_where_to_decay_order_amount = Decimal.ln(Decimal("10")) * self.c_calculate_target_inventory() / self._inventory_risk_aversion
             self._eta = s_decimal_one
             if q_where_to_decay_order_amount != s_decimal_zero:
                 self._eta = self._eta / q_where_to_decay_order_amount

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -577,7 +577,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
             # ETA
             # Want order_amount to be 10% of the original number if q is in the opposite extreme from target inventory
-            q_where_to_decay_order_amount = Decimal.ln(Decimal("10")) * self.c_calculate_target_inventory() / self._inventory_risk_aversion
+            q_where_to_decay_order_amount = self.c_calculate_target_inventory() / (self._inventory_risk_aversion * Decimal.ln(Decimal("10")))
             self._eta = s_decimal_one
             if q_where_to_decay_order_amount != s_decimal_zero:
                 self._eta = self._eta / q_where_to_decay_order_amount


### PR DESCRIPTION
Fixed eta calculation. Now at the maximum distance from inventory_target, opposing order decays 90% from original amount

**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

With this change in case inventory_risk_aversion is the maximum possible and inventory_target is the furthest possible (i.e. inventory_target = 100% with initial inventory = 0), opposing order will reduce its order_amount in 90%.
On the other side, if inventory_risk_aversion is the minimum possible, it won't matter distance to inventory_target, it will always have symmetrical orders in both sides.

* Example with inventory_risk_aversion almost equal to 0

![image](https://user-images.githubusercontent.com/14949838/115752656-b0a1f200-a370-11eb-97cd-5003739726ef.png)

With inventory_target far from the current inventory, anyways order_amounts are equal to config value

![image](https://user-images.githubusercontent.com/14949838/115752783-d29b7480-a370-11eb-9974-4941c799c7cc.png)


* Example with inventory_risk_aversion almost equal to 1 and inventory the furthest possible from target

![image](https://user-images.githubusercontent.com/14949838/115753235-59e8e800-a371-11eb-94a1-da05a9d72d02.png)

In this extreme case opposing order's order_amount = 0.1 * config order_amount

![image](https://user-images.githubusercontent.com/14949838/115754747-e8aa3480-a372-11eb-8a2d-9cd5f639de9b.png)


