### PR TITLE
fix/converts pct to decimal for proper calculations

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -546,7 +546,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         quote_asset_amount = market.get_balance(quote_asset)
         base_value = base_asset_amount * price
         inventory_value = base_value + quote_asset_amount
-        target_inventory_value = inventory_value * self._inventory_target_base_pct
+        target_inventory_value = inventory_value * (self._inventory_target_base_pct / Decimal("100"))
         return market.c_quantize_order_amount(trading_pair, Decimal(str(target_inventory_value / price)))
 
     cdef c_recalculate_parameters(self):

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -814,12 +814,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         base_balance, quote_balance = self.c_get_adjusted_available_balance(self.active_orders)
 
         total_order_size = calculate_total_order_size(self._order_amount, self._order_level_amount, self._order_levels)
-        _inventory_target_base_pct = self._inventory_target_base_pct / Decimal("100")
+        _inventory_target_base_ratio = self._inventory_target_base_pct / Decimal("100")
         bid_ask_ratios = c_calculate_bid_ask_ratios_from_base_asset_ratio(
             float(base_balance),
             float(quote_balance),
             float(self.get_price()),
-            float(_inventory_target_base_pct),
+            float(_inventory_target_base_ratio),
             float(total_order_size * self._inventory_range_multiplier)
         )
         bid_adj_ratio = Decimal(bid_ask_ratios.bid_ratio)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -451,7 +451,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                             if total_value > s_decimal_zero
                             else s_decimal_zero)
         quote_asset_ratio = Decimal("1") - base_asset_ratio if total_value > 0 else 0
-        target_base_ratio = self._inventory_target_base_pct
+        target_base_ratio = self._inventory_target_base_pct / Decimal("100")
         inventory_range_multiplier = self._inventory_range_multiplier
         target_base_amount = (total_value * target_base_ratio
                               if price > s_decimal_zero
@@ -814,11 +814,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         base_balance, quote_balance = self.c_get_adjusted_available_balance(self.active_orders)
 
         total_order_size = calculate_total_order_size(self._order_amount, self._order_level_amount, self._order_levels)
+        _inventory_target_base_pct = self._inventory_target_base_pct / Decimal("100")
         bid_ask_ratios = c_calculate_bid_ask_ratios_from_base_asset_ratio(
             float(base_balance),
             float(quote_balance),
             float(self.get_price()),
-            float(self._inventory_target_base_pct),
+            float(_inventory_target_base_pct),
             float(total_order_size * self._inventory_range_multiplier)
         )
         bid_adj_ratio = Decimal(bid_ask_ratios.bid_ratio)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Upon review by @PassionateAngler in Discord (https://discord.com/channels/530578568154054663/745411750832373870/837295061527298068) it became apparent that the intended functionality does not behave as expected.

Due to the use of whole Decimal value and no conversion to a fractional Decimal the `inventory_target_base_pct` used throughout calculations is passed along and multiplied out creating very large numbers depending on the amounts in a portfolio.

For an example using $5000, with a 1 ETH @ $2500 price point and a 50 `inventory_target_base_pct` there is never a scenario where

https://github.com/CoinAlpha/hummingbot/blob/ec9ac5d0eeeb4b0523aa2c998bfaf8443af7a157/hummingbot/strategy/pure_market_making/inventory_skew_calculator.pyx#L53

is conditionally False.

Due to the fact that 

https://github.com/CoinAlpha/hummingbot/blob/ec9ac5d0eeeb4b0523aa2c998bfaf8443af7a157/hummingbot/strategy/pure_market_making/inventory_skew_calculator.pyx#L43

is accepting 50 as the `target_base_asset_ratio` as passed through

https://github.com/CoinAlpha/hummingbot/blob/ec9ac5d0eeeb4b0523aa2c998bfaf8443af7a157/hummingbot/strategy/pure_market_making/pure_market_making.pyx#L821

This means that the `left_inventory_ratio` is always used, and when calculated through, the numbers don't make sense. Therefore this fix simply takes the pct and divides by Decimal("100") to ensure correct multiplication through.

`left_inventory_ratio` multiplied out with an example portfolio of $5000, with a 1 ETH @ $2500 price point
<img width="584" alt="Screen Shot 2021-04-29 at 8 05 32 AM" src="https://user-images.githubusercontent.com/1007667/116554137-d70fe200-a8c8-11eb-910f-74e82e8a2aa1.png">

`right_inventory_ratio` multiplied out with an example portfolio of $5000, with a 1 ETH @ $2500 price point
<img width="561" alt="Screen Shot 2021-04-29 at 8 07 22 AM" src="https://user-images.githubusercontent.com/1007667/116554151-dbd49600-a8c8-11eb-9134-22517ef192c3.png">

`left_inventory_ratio` multiplied out with an example portfolio of $5000, with a 1 ETH @ $2500 price point (fixed)
<img width="601" alt="Screen Shot 2021-04-29 at 8 10 44 AM" src="https://user-images.githubusercontent.com/1007667/116554460-35d55b80-a8c9-11eb-94f2-143506c87a4a.png">

The examples above indicate that selecting a 50% (as described in the mapping of the config variable) you would expect to see a `target_base_asset_value` of $5000 * 50 which isn't **exactly** what I assume we're expecting.

