### PR TITLE
[0.39] Feat/avellaneda vol sensibility

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -36,6 +36,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _min_spread
         object _max_spread
         object _vol_to_spread_multiplier
+        object _volatility_sensibility
         object _inventory_risk_aversion
         object _kappa
         object _gamma

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -75,7 +75,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                  min_spread: Decimal = Decimal("0.15"),
                  max_spread: Decimal = Decimal("2"),
                  vol_to_spread_multiplier: Decimal = Decimal("1.3"),
-                 volatility_sensibility: Decimal = Decimal("20.0"),
+                 volatility_sensibility: Decimal = Decimal("0.2"),
                  inventory_risk_aversion: Decimal = Decimal("0.5"),
                  order_book_depth_factor: Decimal = Decimal("0.1"),
                  risk_factor: Decimal = Decimal("0.5"),
@@ -421,7 +421,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                     if (self._gamma is None) or (self._kappa is None) or \
                             (self._parameters_based_on_spread and
                              self.volatility_diff_from_last_parameter_calculation(self.get_volatility()) >
-                             (self._vol_to_spread_multiplier - 1)):
+                             self._volatility_sensibility):
                         self.c_recalculate_parameters()
                     self.c_calculate_reserved_price_and_optimal_spread()
 

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -75,6 +75,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                  min_spread: Decimal = Decimal("0.15"),
                  max_spread: Decimal = Decimal("2"),
                  vol_to_spread_multiplier: Decimal = Decimal("1.3"),
+                 volatility_sensibility: Decimal = Decimal("20.0"),
                  inventory_risk_aversion: Decimal = Decimal("0.5"),
                  order_book_depth_factor: Decimal = Decimal("0.1"),
                  risk_factor: Decimal = Decimal("0.5"),
@@ -114,6 +115,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._min_spread = min_spread
         self._max_spread = max_spread
         self._vol_to_spread_multiplier = vol_to_spread_multiplier
+        self._volatility_sensibility = volatility_sensibility
         self._inventory_risk_aversion = inventory_risk_aversion
         self._avg_vol = AverageVolatilityIndicator(volatility_buffer_size, 1)
         self._last_sampling_timestamp = 0

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -143,11 +143,11 @@ avellaneda_market_making_config_map = {
                   prompt_on_new=True),
     "vol_to_spread_multiplier":
         ConfigVar(key="vol_to_spread_multiplier",
-                  prompt="Enter the Volatility threshold multiplier (Should be greater than 1.0): "
+                  prompt="Enter the Volatility threshold multiplier: "
                          "(If market volatility multiplied by this value is above the minimum spread, it will increase the minimum and maximum spread value) >>>",
                   type_str="decimal",
                   required_if=lambda: avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_decimal(v, 1, 10, inclusive=False),
+                  validator=lambda v: validate_decimal(v, 0, 10, inclusive=True),
                   prompt_on_new=True),
     "volatility_sensibility":
         ConfigVar(key="volatility_sensibility",

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -149,6 +149,12 @@ avellaneda_market_making_config_map = {
                   required_if=lambda: avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
                   validator=lambda v: validate_decimal(v, 1, 10, inclusive=False),
                   prompt_on_new=True),
+    "volatility_sensibility":
+        ConfigVar(key="volatility_sensibility",
+                  prompt="Enter volatility change threshold to trigger parameter recalculation>>> ",
+                  type_str="decimal",
+                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=True),
+                  default=20),
     "inventory_risk_aversion":
         ConfigVar(key="inventory_risk_aversion",
                   prompt="Enter Inventory risk aversion between 0 and 1: (For values close to 0.999 spreads will be more "

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -44,7 +44,7 @@ def start(self):
             min_spread = c_map.get("min_spread").value / Decimal(100)
             max_spread = c_map.get("max_spread").value / Decimal(100)
             vol_to_spread_multiplier = c_map.get("vol_to_spread_multiplier").value
-            volatility_sensibility = c_map.get("volatility_sensibility").value
+            volatility_sensibility = c_map.get("volatility_sensibility").value / Decimal('100')
             inventory_risk_aversion = c_map.get("inventory_risk_aversion").value
         else:
             min_spread = max_spread = vol_to_spread_multiplier = inventory_risk_aversion = volatility_sensibility = None

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -44,9 +44,10 @@ def start(self):
             min_spread = c_map.get("min_spread").value / Decimal(100)
             max_spread = c_map.get("max_spread").value / Decimal(100)
             vol_to_spread_multiplier = c_map.get("vol_to_spread_multiplier").value
+            volatility_sensibility = c_map.get("volatility_sensibility").value
             inventory_risk_aversion = c_map.get("inventory_risk_aversion").value
         else:
-            min_spread = max_spread = vol_to_spread_multiplier = inventory_risk_aversion = None
+            min_spread = max_spread = vol_to_spread_multiplier = inventory_risk_aversion = volatility_sensibility = None
             order_book_depth_factor = c_map.get("order_book_depth_factor").value
             risk_factor = c_map.get("risk_factor").value
             order_amount_shape_factor = c_map.get("order_amount_shape_factor").value
@@ -71,6 +72,7 @@ def start(self):
             min_spread=min_spread,
             max_spread=max_spread,
             vol_to_spread_multiplier=vol_to_spread_multiplier,
+            volatility_sensibility=volatility_sensibility,
             inventory_risk_aversion=inventory_risk_aversion,
             order_book_depth_factor=order_book_depth_factor,
             risk_factor=risk_factor,

--- a/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Avellaneda market making strategy config    ###
 ########################################################
 
-template_version: 1
+template_version: 2
 strategy: null
 
 # Exchange and token parameters.
@@ -42,6 +42,7 @@ parameters_based_on_spread: null
 min_spread: null
 max_spread: null
 vol_to_spread_multiplier: null
+volatility_sensibility: null
 inventory_risk_aversion: null
 order_book_depth_factor: null
 risk_factor: null


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Added `volatility_sensibility` parameter which will determine how much volatility has to change in % in order to recalculate parameters. In this way, `vol_to_spread_multiplier` is only responsible of spread adapting to volatility and nothing else (until now `vol_to_spread_multiplier` was used for both the recalculation threshold and the spreads).

