### PR TITLE
Fix wrong module references in tests

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import path_util        # noqa: F401
+import bin.path_util        # noqa: F401
 import asyncio
 import errno
 import socket

--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import bin.path_util        # noqa: F401
+import path_util        # noqa: F401
 import asyncio
 import errno
 import socket

--- a/test/connector/connector/uniswap/test_uniswap_connector.py
+++ b/test/connector/connector/uniswap/test_uniswap_connector.py
@@ -28,7 +28,6 @@ from hummingbot.client.config.global_config_map import global_config_map
 
 global_config_map['gateway_api_host'].value = "localhost"
 global_config_map['gateway_api_port'].value = 5000
-global_config_map['ethgasstation_gas_enabled'].value = False
 global_config_map['manual_gas_price'].value = 50
 global_config_map.get("ethereum_chain_name").value = "kovan"
 

--- a/test/connector/exchange/ascend_ex/test_ascend_ex_auth.py
+++ b/test/connector/exchange/ascend_ex/test_ascend_ex_auth.py
@@ -12,7 +12,7 @@ from typing import Dict, Any
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_auth import AscendExAuth
 from hummingbot.logger.struct_logger import METRICS_LOG_LEVEL
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_constants import REST_URL
-from hummingbot.connector.exchange.ascend_ex.ascend_ex_util import get_rest_url_private
+from hummingbot.connector.exchange.ascend_ex.ascend_ex_utils import get_rest_url_private
 
 sys.path.insert(0, realpath(join(__file__, "../../../../../")))
 logging.basicConfig(level=METRICS_LOG_LEVEL)

--- a/test/integration/test_bamboo_relay_market_coordinated.py
+++ b/test/integration/test_bamboo_relay_market_coordinated.py
@@ -41,7 +41,7 @@ from hummingbot.core.utils.async_utils import (
     safe_gather,
 )
 from hummingbot.logger import NETWORK
-from hummingbot.connector.exchange.bamboo_relay.bamboo_relay_market import BambooRelayExchange
+from hummingbot.connector.exchange.bamboo_relay.bamboo_relay_exchange import BambooRelayExchange
 from hummingbot.core.event.events import OrderType
 from hummingbot.connector.markets_recorder import MarketsRecorder
 from hummingbot.model.market_state import MarketState

--- a/test/integration/test_bamboo_relay_market_uncoordinated.py
+++ b/test/integration/test_bamboo_relay_market_uncoordinated.py
@@ -43,7 +43,7 @@ from hummingbot.core.utils.async_utils import (
     safe_gather,
 )
 from hummingbot.logger import NETWORK
-from hummingbot.connector.exchange.bamboo_relay.bamboo_relay_market import BambooRelayExchange
+from hummingbot.connector.exchange.bamboo_relay.bamboo_relay_exchange import BambooRelayExchange
 from hummingbot.core.event.events import OrderType
 from hummingbot.connector.markets_recorder import MarketsRecorder
 from hummingbot.model.market_state import MarketState

--- a/test/integration/test_composite_order_book.py
+++ b/test/integration/test_composite_order_book.py
@@ -3,125 +3,125 @@ from os.path import join, realpath
 import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
 
 import pandas as pd
-from typing import (
-    List,
-    Dict,
-    Tuple)
+# from typing import (
+#    List,
+#    Dict,
+#    Tuple)
 import unittest
-from hummingsim.backtest.backtest_market import BacktestMarket
-from hummingsim.backtest.ddex_order_book_loader import DDEXOrderBookLoader
-from hummingsim.backtest.market import Market
-from hummingsim.strategy.unit_test_strategy import UnitTestStrategy
+# from hummingsim.backtest.backtest_market import BacktestMarket
+# from hummingsim.backtest.ddex_order_book_loader import DDEXOrderBookLoader
+# from hummingsim.backtest.market import Market
+# from hummingsim.strategy.unit_test_strategy import UnitTestStrategy
 from hummingbot.core.clock import (
     ClockMode,
     Clock
 )
 from hummingbot.core.event.events import (
-    MarketEvent,
-    OrderFilledEvent,
+    # MarketEvent,
+    # OrderFilledEvent,
     TradeType,
 )
-from hummingbot.core.event.event_listener import EventListener
+# from hummingbot.core.event.event_listener import EventListener
 
 
-class CompositeOrderBookTestStrategy(UnitTestStrategy):
-    """
-    Makes market orders and record fill events
-    """
+# class CompositeOrderBookTestStrategy(UnitTestStrategy):
+#     """
+#     Makes market orders and record fill events
+#     """
+#
+#     class OrderFilledEventLogger(EventListener):
+#         def __init__(self, owner: "CompositeOrderBookTestStrategy"):
+#             self._owner: "CompositeOrderBookTestStrategy" = owner
+#
+#         def __call__(self, order_filled_event: OrderFilledEvent):
+#             self._owner.log_order_filled_event(order_filled_event)
+#
+#     def __init__(self, market: Market, trades: Dict[str, Tuple[str, float]]):
+#         super().__init__(market)
+#         self.trades = trades
+#         self.tick_size = 5
+#         self._order_filled_event_timestamps: List[float] = []
+#         self._order_filled_events: List[OrderFilledEvent] = []
+#         self._trade_logger: CompositeOrderBookTestStrategy.OrderFilledEventLogger = self.OrderFilledEventLogger(self)
+#         market.add_listener(MarketEvent.OrderFilled, self._trade_logger)
+#
+#         self.start_printing = False
+#
+#     def log_order_filled_event(self, evt: OrderFilledEvent):
+#         self._order_filled_event_timestamps.append(self.current_timestamp)
+#         self._order_filled_events.append(evt)
+#
+#     def process_tick(self):
+#         if self.current_timestamp in self.trades:
+#             for trade in self.trades[self.current_timestamp]:
+#                 if trade[1] == "buy":
+#                     self.market.buy(trade[0], trade[2])
+#                 elif trade[1] == "sell":
+#                     self.market.sell(trade[0], trade[2])
+#             self.start_printing = True
+#
+#         composite_ob = self.market.get_order_book("WETH-DAI")
+#         composite_bids = list(composite_ob.bid_entries())
+#         composite_asks = list(composite_ob.ask_entries())
+#
+#         if not self.start_printing:
+#             return
+#
+#         original_bids = list(composite_ob.original_bid_entries())
+#         original_asks = list(composite_ob.original_ask_entries())
+#
+#         filled_bids = list(composite_ob.traded_order_book.bid_entries())
+#         filled_asks = list(composite_ob.traded_order_book.ask_entries())
+#
+#         order_books_top = [composite_bids[i] + composite_asks[i] + original_bids[i] + original_asks[i] for i in range(5)]
+#
+#         filled_order_books = []
+#         for i in range(max(len(filled_bids), len(filled_asks))):
+#             if i + 1 > len(filled_bids):
+#                 fb = (None, None, None)
+#             else:
+#                 fb = filled_bids[i]
+#             if i + 1 > len(filled_asks):
+#                 fa = (None, None, None)
+#             else:
+#                 fa = filled_asks[i]
+#             filled_order_books.append(fb + fa)
+#
+#         print(str(pd.Timestamp(self.current_timestamp, unit="s", tz="UTC")) + "\n" +
+#               pd.DataFrame(data=filled_order_books,
+#                            columns=['filled_bid_price', 'filled_bid_amount', 'uid',
+#                                     'filled_ask_price', 'filled_ask_amount', 'uid'
+#                                     ]
+#                            ).to_string()
+#               )
+#
+#         print(str(pd.Timestamp(self.current_timestamp, unit="s", tz="UTC")) + "\n" +
+#               pd.DataFrame(data=order_books_top,
+#                            columns=['composite_bid_price', 'composite_bid_amount', 'uid',
+#                                     'composite_ask_price', 'composite_ask_amount', 'uid',
+#                                     'original_bid_price', 'original_bid_amount', 'uid',
+#                                     'original_ask_price', 'original_ask_amount', 'uid',
+#                                     ]
+#                            ).to_string()
+#               )
+#
+#     @property
+#     def order_filled_events(self) -> pd.DataFrame:
+#         retval: pd.DataFrame = pd.DataFrame(data=self._order_filled_events,
+#                                             columns=OrderFilledEvent._fields,
+#                                             index=pd.Index(self._order_filled_event_timestamps, dtype="float64"))
+#         retval.index = (retval.index * 1e9).astype("int64").astype("datetime64[ns]")
+#         return retval
 
-    class OrderFilledEventLogger(EventListener):
-        def __init__(self, owner: "CompositeOrderBookTestStrategy"):
-            self._owner: "CompositeOrderBookTestStrategy" = owner
-
-        def __call__(self, order_filled_event: OrderFilledEvent):
-            self._owner.log_order_filled_event(order_filled_event)
-
-    def __init__(self, market: Market, trades: Dict[str, Tuple[str, float]]):
-        super().__init__(market)
-        self.trades = trades
-        self.tick_size = 5
-        self._order_filled_event_timestamps: List[float] = []
-        self._order_filled_events: List[OrderFilledEvent] = []
-        self._trade_logger: CompositeOrderBookTestStrategy.OrderFilledEventLogger = self.OrderFilledEventLogger(self)
-        market.add_listener(MarketEvent.OrderFilled, self._trade_logger)
-
-        self.start_printing = False
-
-    def log_order_filled_event(self, evt: OrderFilledEvent):
-        self._order_filled_event_timestamps.append(self.current_timestamp)
-        self._order_filled_events.append(evt)
-
-    def process_tick(self):
-        if self.current_timestamp in self.trades:
-            for trade in self.trades[self.current_timestamp]:
-                if trade[1] == "buy":
-                    self.market.buy(trade[0], trade[2])
-                elif trade[1] == "sell":
-                    self.market.sell(trade[0], trade[2])
-            self.start_printing = True
-
-        composite_ob = self.market.get_order_book("WETH-DAI")
-        composite_bids = list(composite_ob.bid_entries())
-        composite_asks = list(composite_ob.ask_entries())
-
-        if not self.start_printing:
-            return
-
-        original_bids = list(composite_ob.original_bid_entries())
-        original_asks = list(composite_ob.original_ask_entries())
-
-        filled_bids = list(composite_ob.traded_order_book.bid_entries())
-        filled_asks = list(composite_ob.traded_order_book.ask_entries())
-
-        order_books_top = [composite_bids[i] + composite_asks[i] + original_bids[i] + original_asks[i] for i in range(5)]
-
-        filled_order_books = []
-        for i in range(max(len(filled_bids), len(filled_asks))):
-            if i + 1 > len(filled_bids):
-                fb = (None, None, None)
-            else:
-                fb = filled_bids[i]
-            if i + 1 > len(filled_asks):
-                fa = (None, None, None)
-            else:
-                fa = filled_asks[i]
-            filled_order_books.append(fb + fa)
-
-        print(str(pd.Timestamp(self.current_timestamp, unit="s", tz="UTC")) + "\n" +
-              pd.DataFrame(data=filled_order_books,
-                           columns=['filled_bid_price', 'filled_bid_amount', 'uid',
-                                    'filled_ask_price', 'filled_ask_amount', 'uid'
-                                    ]
-                           ).to_string()
-              )
-
-        print(str(pd.Timestamp(self.current_timestamp, unit="s", tz="UTC")) + "\n" +
-              pd.DataFrame(data=order_books_top,
-                           columns=['composite_bid_price', 'composite_bid_amount', 'uid',
-                                    'composite_ask_price', 'composite_ask_amount', 'uid',
-                                    'original_bid_price', 'original_bid_amount', 'uid',
-                                    'original_ask_price', 'original_ask_amount', 'uid',
-                                    ]
-                           ).to_string()
-              )
-
-    @property
-    def order_filled_events(self) -> pd.DataFrame:
-        retval: pd.DataFrame = pd.DataFrame(data=self._order_filled_events,
-                                            columns=OrderFilledEvent._fields,
-                                            index=pd.Index(self._order_filled_event_timestamps, dtype="float64"))
-        retval.index = (retval.index * 1e9).astype("int64").astype("datetime64[ns]")
-        return retval
-
-
+@unittest.skip("The test seems to be out of date. It requires the hummingsim component that is not present")
 class CompositeOrderBookTest(unittest.TestCase):
     start: pd.Timestamp = pd.Timestamp("2019-01-25", tz="UTC")
     end: pd.Timestamp = pd.Timestamp("2019-01-26", tz="UTC")
 
     def setUp(self):
-        self.weth_dai_data = DDEXOrderBookLoader("WETH-DAI", "WETH", "DAI")
+        # self.weth_dai_data = DDEXOrderBookLoader("WETH-DAI", "WETH", "DAI")
         self.clock = Clock(ClockMode.BACKTEST, 1.0, self.start.timestamp(), self.end.timestamp())
-        self.market = BacktestMarket()
+        # self.market = BacktestMarket()
         self.market.add_data(self.weth_dai_data)
         self.market.set_balance("WETH", 200.0)
         self.market.set_balance("DAI", 20000.0)
@@ -220,35 +220,35 @@ class CompositeOrderBookTest(unittest.TestCase):
             if filled_ask_price in original_ask_dict:
                 self.assertTrue(original_ask_dict[filled_ask_price][0] >= filled_ask_entry[0])
 
-    def test_market_order(self):
-        trades = {
-            pd.Timestamp("2019-01-25 00:00:10+00:00").timestamp(): [
-                ("WETH-DAI", "buy", 5.0),
-                ("WETH-DAI", "sell", 5.0)
-            ]
-        }
-        strategy: CompositeOrderBookTestStrategy = CompositeOrderBookTestStrategy(self.market, trades)
-        self.clock.add_iterator(strategy)
-        self.clock.backtest_til(self.start.timestamp() + 10)
-
-        self.verify_filled_order_recorded(strategy.order_filled_events, self.market.get_order_book("WETH-DAI"))
-        self.verify_composite_order_book_correctness(self.market.get_order_book("WETH-DAI"))
-
-        self.clock.backtest_til(self.start.timestamp() + 70)
-
-        self.verify_composite_order_book_cleanup(strategy.order_filled_events, self.market.get_order_book("WETH-DAI"))
-
-    def test_composite_order_book_adjustment(self):
-        trades = {
-            pd.Timestamp("2019-01-25 00:02:15+00:00").timestamp(): [
-                ("WETH-DAI", "sell", 93.53 + 23.65)
-            ]
-        }
-        strategy: CompositeOrderBookTestStrategy = CompositeOrderBookTestStrategy(self.market, trades)
-        self.clock.add_iterator(strategy)
-        self.clock.backtest_til(self.start.timestamp() + 60 * 2 + 15)
-        self.clock.backtest_til(self.start.timestamp() + 60 * 2 + 25)
-        self.verify_composite_order_book_adjustment(self.market.get_order_book("WETH-DAI"))
+    # def test_market_order(self):
+    #     trades = {
+    #         pd.Timestamp("2019-01-25 00:00:10+00:00").timestamp(): [
+    #             ("WETH-DAI", "buy", 5.0),
+    #             ("WETH-DAI", "sell", 5.0)
+    #         ]
+    #     }
+    #     strategy: CompositeOrderBookTestStrategy = CompositeOrderBookTestStrategy(self.market, trades)
+    #     self.clock.add_iterator(strategy)
+    #     self.clock.backtest_til(self.start.timestamp() + 10)
+    #
+    #     self.verify_filled_order_recorded(strategy.order_filled_events, self.market.get_order_book("WETH-DAI"))
+    #     self.verify_composite_order_book_correctness(self.market.get_order_book("WETH-DAI"))
+    #
+    #     self.clock.backtest_til(self.start.timestamp() + 70)
+    #
+    #     self.verify_composite_order_book_cleanup(strategy.order_filled_events, self.market.get_order_book("WETH-DAI"))
+    #
+    # def test_composite_order_book_adjustment(self):
+    #     trades = {
+    #         pd.Timestamp("2019-01-25 00:02:15+00:00").timestamp(): [
+    #             ("WETH-DAI", "sell", 93.53 + 23.65)
+    #         ]
+    #     }
+    #     strategy: CompositeOrderBookTestStrategy = CompositeOrderBookTestStrategy(self.market, trades)
+    #     self.clock.add_iterator(strategy)
+    #     self.clock.backtest_til(self.start.timestamp() + 60 * 2 + 15)
+    #     self.clock.backtest_til(self.start.timestamp() + 60 * 2 + 25)
+    #     self.verify_composite_order_book_adjustment(self.market.get_order_book("WETH-DAI"))
 
 
 if __name__ == "__main__":

--- a/test/integration/test_huobi_market_mock.py
+++ b/test/integration/test_huobi_market_mock.py
@@ -43,7 +43,7 @@ from hummingbot.core.utils.async_utils import (
     safe_gather,
 )
 from hummingbot.logger.struct_logger import METRICS_LOG_LEVEL
-from hummingbot.connector.exchange.huobi.huobi_Exchange import HuobiExchange
+from hummingbot.connector.exchange.huobi.huobi_exchange import HuobiExchange
 from hummingbot.connector.exchange.huobi.huobi_order_book import HuobiOrderBook
 from hummingbot.core.event.events import OrderType
 from hummingbot.connector.markets_recorder import MarketsRecorder


### PR DESCRIPTION
I made some changes to import statements in some tests, that where referencing to incorrect or inexistent modules.
The module with more changes is test/integration/test_composite_order_book.py. I had to mark the test as skipped since it has dependencies with hummingsim, that is no longer a module inside the client project. For the test to run without failing I also had to comment out several parts. I did not remove it so that we can discuss how to replace it.