### PR TITLE
Fix/stop while live status active

### DIFF
--- a/hummingbot/client/command/status_command.py
+++ b/hummingbot/client/command/status_command.py
@@ -124,7 +124,7 @@ class StatusCommand:
             if live:
                 await self.stop_live_update()
                 self.app.live_updates = True
-                while self.app.live_updates:
+                while self.app.live_updates and self.strategy:
                     script_status = '\n Status from script would not appear here. ' \
                                     'Simply run the status command without "--live" to see script status.'
                     await self.cls_display_delay(


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Quick fix to prevent the live status update command from running once the strategy has been stopped.

https://app.zenhub.com/workspaces/hummingbot-5f340755c5e17300167a8f30/issues/coinalpha/hummingbot/3467
https://github.com/CoinAlpha/hummingbot/issues/3467
