### PR TITLE
Add coverage checks to github workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -97,7 +97,7 @@ jobs:
           ./compile
 
       # Install tools for coverage calculation
-      - name: Install Hummingbot
+      - name: Install Coverage Tools
         if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -96,16 +96,6 @@ jobs:
           conda env export
           ./compile
 
-      # Install tools for coverage calculation
-      - name: Install Coverage Tools
-        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
-        shell: bash -l {0}
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda activate hummingbot
-          conda install coverage
-          pip install diff-cover
-
       - name: Run stable tests and global coverage
         if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,13 +95,36 @@ jobs:
           conda activate hummingbot
           conda env export
           ./compile
-      - name: Run stable tests
+
+      # Install tools for coverage calculation
+      - name: Install Hummingbot
+        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
+        shell: bash -l {0}
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate hummingbot
+          conda install coverage
+          pip install diff-cover
+
+      - name: Run stable tests and global coverage
         if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate hummingbot
-          find test/hummingbot/ -iname "test_*.py" | xargs nosetests -d -v
+          git fetch --all -q
+          git symbolic-ref HEAD refs/remotes/origin/$GITHUB_HEAD_REF
+          find test/hummingbot/ -iname "test_*.py" | xargs nosetests -v --with-coverage --cover-inclusive --cover-package=hummingbot --cover-xml --cover-min-percentage=45
+
+      - name: Validate changes coverage
+        if: steps.program-changes.outputs.cache-hit != 'true' || steps.conda-dependencies.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate hummingbot
+          git fetch --all -q
+          git symbolic-ref HEAD refs/remotes/origin/$GITHUB_HEAD_REF
+          diff-cover --compare-branch=origin/$GITHUB_BASE_REF --fail-under=50 coverage.xml
 
       # Notify results to discord
       - uses: actions/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ debug.log
 /certs
 *.pem
 gateway.env
+
+# Coverage
+.coverage
+/cover/
+coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 .PHONY: test
 
+.ONESHELL:
+
 test:
-	nosetests -d -v test/test*.py
+	find test/hummingbot/ -iname "test_*.py" | xargs nosetests -v -d
+
+coverage:
+	conda install -y coverage
+	find test/hummingbot/ -iname "test_*.py" | xargs nosetests -v -d --with-coverage --cover-inclusive --cover-package=hummingbot --cover-xml --cover-html

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,4 @@ test:
 	find test/hummingbot/ -iname "test_*.py" | xargs nosetests -v -d
 
 coverage:
-	conda install -y coverage
 	find test/hummingbot/ -iname "test_*.py" | xargs nosetests -v -d --with-coverage --cover-inclusive --cover-package=hummingbot --cover-xml --cover-html

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -11,7 +11,7 @@ dependencies:
   - bzip2=1.0.8=h7b6447c_0
   - ca-certificates=2020.1.1=0
   - certifi=2019.11.28=py38_0
-  - coverage=5.5=py38h9ed2024_2
+  - coverage=5.5
   - cython=0.29.15=py38he6710b0_0
   - hdf5=1.10.4=hb1b8bf9_0
   - intel-openmp=2020.0=166

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -11,6 +11,7 @@ dependencies:
   - bzip2=1.0.8=h7b6447c_0
   - ca-certificates=2020.1.1=0
   - certifi=2019.11.28=py38_0
+  - coverage=5.5=py38h9ed2024_2
   - cython=0.29.15=py38he6710b0_0
   - hdf5=1.10.4=hb1b8bf9_0
   - intel-openmp=2020.0=166
@@ -83,6 +84,7 @@ dependencies:
     - dateparser==0.7.4
     - decorator==4.4.2
     - deprecated==1.2.7
+    - diff-cover==5.1.2
     - distlib==0.3.0
     - dydx-python==0.11.2
     - dydx-v3-python==1.0.0

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -8,6 +8,7 @@ dependencies:
   - bzip2=1.0.8=he774522_0
   - ca-certificates=2020.1.1=0
   - certifi=2019.11.28=py38_0
+  - coverage=5.5=py38h9ed2024_2
   - cython=0.29.15=py38ha925a31_0
   - hdf5=1.10.4=h7ebc959_0
   - icc_rt=2019.0.0=h0cc432a_1
@@ -77,6 +78,7 @@ dependencies:
     - dateparser==0.7.4
     - decorator==4.4.2
     - deprecated==1.2.7
+    - diff-cover==5.1.2
     - distlib==0.3.0
     - dydx-python==0.11.2
     - dydx-v3-python==1.0.0

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -8,7 +8,7 @@ dependencies:
   - bzip2=1.0.8=he774522_0
   - ca-certificates=2020.1.1=0
   - certifi=2019.11.28=py38_0
-  - coverage=5.5=py38h9ed2024_2
+  - coverage=5.5
   - cython=0.29.15=py38ha925a31_0
   - hdf5=1.10.4=h7ebc959_0
   - icc_rt=2019.0.0=h0cc432a_1

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - bzip2=1.0.8=h1de35cc_0
   - ca-certificates=2020.6.24=0
   - certifi=2020.6.20=py38_0
-  - coverage=5.5=py38h9ed2024_2
+  - coverage=5.5
   - cython=0.29.15=py38h0a44026_0
   - hdf5=1.10.4=hfa1e0ec_0
   - intel-openmp=2019.4=233

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - bzip2=1.0.8=h1de35cc_0
   - ca-certificates=2020.6.24=0
   - certifi=2020.6.20=py38_0
+  - coverage=5.5=py38h9ed2024_2
   - cython=0.29.15=py38h0a44026_0
   - hdf5=1.10.4=hfa1e0ec_0
   - intel-openmp=2019.4=233
@@ -79,6 +80,7 @@ dependencies:
     - dateparser==0.7.4
     - decorator==4.4.2
     - deprecated==1.2.7
+    - diff-cover==5.1.2
     - distlib==0.3.0
     - dydx-python==0.11.2
     - dydx-v3-python==1.0.0


### PR DESCRIPTION
Add coverage checks to github workflow.
There are two calculations of coverage. The global coverage for the whole project is calculated by nosetests as part of the unit tests run. That run generates the file coverage.xml, with the details. It is configured to fail if the coverage is less than 45%.
Then there is a coverage calculated based on the changes included in the PR compared to the base branch. The changes only coverage is calculated with diff-cover, using the coverage.xml file. This validation fails if the coverage is under 50%.

https://app.zenhub.com/workspaces/hummingbot-5f340755c5e17300167a8f30/issues/coinalpha/hummingbot/3469
https://github.com/CoinAlpha/hummingbot/issues/3469