### PR TITLE
Change in MockWebSocketServer to use daemon threads

### DIFF
--- a/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
+++ b/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
@@ -14,12 +14,12 @@ class MockWebSocketServerFactoryTest(unittest.TestCase):
         cls._mock = cls._patcher.start()
         cls._mock.side_effect = MockWebSocketServerFactory.reroute_ws_connect
         # need to wait a bit for the server to be available
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.2))
+        cls.ev_loop.run_until_complete(asyncio.wait_for(cls.ws_server.wait_til_started(), 1))
 
     @classmethod
     def tearDownClass(cls) -> None:
-        cls._patcher.stop()
         cls.ws_server.stop()
+        cls._patcher.stop()
 
     async def _test_web_socket(self):
         uri = "wss://www.google.com/ws/"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Change the implementation of MockWebSocketServer to use daemon threads, that will be automatically stopped once the application run finishes.
