### PR TITLE
fix/mock web socket server test connection error

### DIFF
--- a/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
+++ b/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
@@ -23,20 +23,30 @@ class MockWebSocketServerFactoryTest(unittest.TestCase):
 
     async def _test_web_socket(self):
         uri = "wss://www.google.com/ws/"
-        async with websockets.connect(uri) as websocket:
-            await MockWebSocketServerFactory.send_str(uri, "aaa")
-            answer = await websocket.recv()
-            print(answer)
-            self.assertEqual("aaa", answer)
-            await MockWebSocketServerFactory.send_json(uri, data={"foo": "bar"})
-            answer = await websocket.recv()
-            print(answer)
-            answer = json.loads(answer)
-            self.assertEqual(answer["foo"], "bar")
-            await self.ws_server.websocket.send("xxx")
-            answer = await websocket.recv()
-            print(answer)
-            self.assertEqual("xxx", answer)
+
+        # Retry up to 3 times if there is any error connecting to the mock server address and port
+        for retry_attempt in range(1, 4):
+            try:
+                async with websockets.connect(uri) as websocket:
+                    await MockWebSocketServerFactory.send_str(uri, "aaa")
+                    answer = await websocket.recv()
+                    print(answer)
+                    self.assertEqual("aaa", answer)
+                    await MockWebSocketServerFactory.send_json(uri, data={"foo": "bar"})
+                    answer = await websocket.recv()
+                    print(answer)
+                    answer = json.loads(answer)
+                    self.assertEqual(answer["foo"], "bar")
+                    await self.ws_server.websocket.send("xxx")
+                    answer = await websocket.recv()
+                    print(answer)
+                    self.assertEqual("xxx", answer)
+            except OSError:
+                # Continue retrying
+                continue
+
+            # Stop the retries cycle
+            break
 
     def test_web_socket(self):
         asyncio.get_event_loop().run_until_complete(self._test_web_socket())


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Add retry logic to the mock web socket server test when there are problems to connect to the running mock server. The test will retry up to three times before failing.