### PR TITLE
fix/ KuCoin balance pulling from both "Trading" and "Main" accounts

### DIFF
--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.pyx
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.pyx
@@ -281,12 +281,13 @@ cdef class KucoinExchange(ExchangeBase):
                         self.logger().debug(f"Event: {event_message}")
                         continue
                 elif event_type == "message" and event_topic == "/account/balance":
-                    currency = convert_asset_from_exchange(execution_data["currency"])
-                    available_balance = Decimal(execution_data["available"])
-                    total_balance = Decimal(execution_data["total"])
-                    self._account_balances.update({currency: total_balance})
-                    self._account_available_balances.update({currency: available_balance})
-                    continue
+                    if "trade" in execution_data["relationEvent"]:
+                        currency = convert_asset_from_exchange(execution_data["currency"])
+                        available_balance = Decimal(execution_data["available"])
+                        total_balance = Decimal(execution_data["total"])
+                        self._account_balances.update({currency: total_balance})
+                        self._account_available_balances.update({currency: available_balance})
+                        continue
                 else:
                     continue
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Resolves #2971

It appears the KuCoin account balance updates have another attribute, `relationEvent`. This differentiates the Main and Trading account update.

With this, only balance from **Trading** account will be reflected within Hummingbot.
