### PR TITLE
fix/mock web socket threads sync

### DIFF
--- a/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
+++ b/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
@@ -30,16 +30,15 @@ class MockWebSocketServerFactoryTest(unittest.TestCase):
                 async with websockets.connect(uri) as websocket:
                     await MockWebSocketServerFactory.send_str(uri, "aaa")
                     answer = await websocket.recv()
-                    print(answer)
                     self.assertEqual("aaa", answer)
+
                     await MockWebSocketServerFactory.send_json(uri, data={"foo": "bar"})
                     answer = await websocket.recv()
-                    print(answer)
                     answer = json.loads(answer)
                     self.assertEqual(answer["foo"], "bar")
+
                     await self.ws_server.websocket.send("xxx")
                     answer = await websocket.recv()
-                    print(answer)
                     self.assertEqual("xxx", answer)
             except OSError:
                 # Continue retrying


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Add synchronization at thread level in the mock web socket server factory to only send messages using the websocket of a web server once it has been already initialized. The synchronization is done using a thread safe Event object.
