### PR TITLE
fix/ `HangingOrderTracker` prematurely considering active orders as hanging orders

### DIFF
--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -168,7 +168,9 @@ class HangingOrdersTracker:
         for order_pair in self.current_created_pairs_of_orders:
             if order_pair.contains_order(order):
                 unfilled_order = order_pair.get_unfilled_order()
-                return unfilled_order.client_order_id == order.client_order_id
+                if unfilled_order:
+                    return unfilled_order.client_order_id == order.client_order_id
+                break
 
         return False
 

--- a/test/hummingbot/strategy/test_hanging_orders_tracker.py
+++ b/test/hummingbot/strategy/test_hanging_orders_tracker.py
@@ -269,3 +269,8 @@ class TestHangingOrdersTracker(unittest.TestCase):
         # Case (2b) Order is tracked and corresponding order is filled
         self.tracker.did_fill_order(limit_buy_order)
         self.assertTrue(self.tracker.is_order_to_be_added_to_hanging_orders(limit_sell_order))
+
+        # Case (2c) Order is tracker and both orders are filled
+        self.tracker.did_fill_order(limit_sell_order)
+        self.assertFalse(self.tracker.is_order_to_be_added_to_hanging_orders(limit_buy_order))
+        self.assertFalse(self.tracker.is_order_to_be_added_to_hanging_orders(limit_sell_order))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

It appears the `HangingOrderTracker` is considering orders to be hanging orders prematurely.
An active order is considered to be a hanging order iff the corresponding order pair has been filled.

Blocks #3268 