### PR TITLE
Fix/ Kucoin paper trade 

### DIFF
--- a/hummingbot/connector/exchange/kucoin/kucoin_order_book_tracker.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_order_book_tracker.py
@@ -33,7 +33,7 @@ class KucoinOrderBookTracker(OrderBookTracker):
 
     def __init__(self,
                  trading_pairs: List[str],
-                 auth: KucoinAuth):
+                 auth: KucoinAuth = None):
         super().__init__(KucoinAPIOrderBookDataSource(trading_pairs, auth), trading_pairs)
         self._auth = auth
         self._order_book_diff_stream: asyncio.Queue = asyncio.Queue()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Use order book level2 at 100 entries (https://docs.kucoin.com/#get-part-order-book-aggregated) on paper trade mode, this is the most detailed order book we can get when authentication is not required. 

**Tests performed by developer**
Manually test running PMM strategy on Kucoin in both paper trade and normal trading mode.

**Hints for QA team**
None

**Notes to document writer**
Please mention this Kucoin paper trade order book limitation on our documentation.