### PR TITLE
fix/ Issue where NDAX connector will always remain not ready

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -129,9 +129,9 @@ class NdaxExchange(ExchangeBase):
         A dictionary of statuses of various exchange's components. Used to determine if the connector is ready
         """
         return {
-            "account_id_initialized": self.account_id,
+            "account_id_initialized": self.account_id if self._trading_required else True,
             "order_books_initialized": self._order_book_tracker.ready,
-            "account_balance": len(self._account_balance) > 0 if self._trading_required else True,
+            "account_balance": len(self._account_balances) > 0 if self._trading_required else True,
             "trading_rule_initialized": len(self._trading_rules) > 0,
             "user_stream_initialized":
                 self._user_stream_tracker.data_source.last_recv_time > 0 if self._trading_required else True,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Account balance variable used in `status_dict` is incorrect.
Also included additional conditions to ensure `account_id` is initialized should the `_trading_required` config be `True`.

Note for developer:
- Simple fix to the `status_dict` property

No testing required by QA.
