### PR TITLE
Fix/ndax use domain to get instruments

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
@@ -142,7 +142,7 @@ class NdaxAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         "timestamp": max([entry.actionDateTime for entry in orderbook_entries])}
 
     async def get_new_order_book(self, trading_pair: str) -> OrderBook:
-        snapshot: Dict[str, Any] = await self.get_order_book_data(trading_pair)
+        snapshot: Dict[str, Any] = await self.get_order_book_data(trading_pair, self._domain)
         snapshot_timestamp: int = int(time.time() * 1e3)
 
         snapshot_msg: OrderBookMessage = NdaxOrderBook.snapshot_message_from_exchange(

--- a/hummingbot/connector/exchange/ndax/ndax_order_book_tracker.py
+++ b/hummingbot/connector/exchange/ndax/ndax_order_book_tracker.py
@@ -27,7 +27,7 @@ class NdaxOrderBookTracker(OrderBookTracker):
         return cls._logger
 
     def __init__(self, trading_pairs: Optional[List[str]] = None, domain: Optional[str] = None):
-        super().__init__(NdaxAPIOrderBookDataSource(trading_pairs), trading_pairs, domain)
+        super().__init__(NdaxAPIOrderBookDataSource(trading_pairs, domain), trading_pairs, domain)
 
         self._domain = domain
         self._ev_loop: asyncio.BaseEventLoop = asyncio.get_event_loop()

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_utils.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_utils.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from hummingbot.connector.exchange.ndax import ndax_constants as CONSTANTS, ndax_utils as utils
+
+
+class NdaxUtilsTests(TestCase):
+
+    def test_trading_pair_convertion(self):
+        trading_pair = "BTC-USDT"
+        self.assertEqual("BTCUSDT", utils.convert_to_exchange_trading_pair(trading_pair))
+
+    @patch('hummingbot.connector.exchange.ndax.ndax_utils.get_tracking_nonce_low_res')
+    def test_client_order_id_creation(self, nonce_provider_mock):
+        nonce_provider_mock.return_value = 1000
+        self.assertEqual(str(1000), utils.get_new_client_order_id(True, "BTC-USDT"))
+
+    def test_rest_api_url(self):
+        url = utils.rest_api_url(None)
+        self.assertEqual(CONSTANTS.REST_URLS.get("ndax_main"), url)
+
+        url = utils.rest_api_url("ndax_main")
+        self.assertEqual(CONSTANTS.REST_URLS.get("ndax_main"), url)
+
+        url = utils.rest_api_url("ndax_testnet")
+        self.assertEqual(CONSTANTS.REST_URLS.get("ndax_testnet"), url)
+
+    def test_wss_url(self):
+        url = utils.wss_url(None)
+        self.assertEqual(CONSTANTS.WSS_URLS.get("ndax_main"), url)
+
+        url = utils.wss_url("ndax_main")
+        self.assertEqual(CONSTANTS.WSS_URLS.get("ndax_main"), url)
+
+        url = utils.wss_url("ndax_testnet")
+        self.assertEqual(CONSTANTS.WSS_URLS.get("ndax_testnet"), url)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix in the logic that initializes the instruments for NDAX. The function was receiving the incorrect domain.

**Tests performed by the developer**
Tested manually by running the TWAP strategy against NDAX test server.
