### PR TITLE
fix/ NDAX `_create_order()` not handling rejected requests

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -416,6 +416,10 @@ class NdaxExchange(ExchangeBase):
                 is_auth_required=True
             )
 
+            if send_order_results["status"] == "Rejected":
+                raise ValueError(f"Order is rejected by the API. "
+                                 f"Parameters: {params} Error Msg: {send_order_results['errormsg']}")
+
             exchange_order_id = str(send_order_results["OrderId"])
             tracked_order = self._in_flight_orders.get(order_id)
             if tracked_order is not None:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Include additional logic to handle `Rejected` SendOrder request.

Includes 1 new unit test to ensure adequate handling of `Rejected` request
