### PR TITLE
Fix/change websocket iterator in user stream

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
@@ -116,6 +116,7 @@ class NdaxAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
         Args:
             trading_pair (str): Trading pair of the particular orderbook.
+            domain (str): The label of the variant of the connector that is being used.
 
         Returns:
             Dict[str, any]: Parsed API Response.

--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -171,6 +171,11 @@ class NdaxExchange(ExchangeBase):
             if not order.is_done
         }
 
+    async def initialized_account_id(self) -> int:
+        if not self._account_id:
+            self._account_id = await self._get_account_id()
+        return self._account_id
+
     def restore_tracking_states(self, saved_states: Dict[str, Any]):
         """
         Restore in-flight orders from the saved tracking states(from local db). This is such that the connector can pick
@@ -247,8 +252,6 @@ class NdaxExchange(ExchangeBase):
         self._order_book_tracker.start()
         self._trading_rules_polling_task = safe_ensure_future(self._trading_rules_polling_loop())
         if self._trading_required:
-            if not self._account_id:
-                self._account_id = await self._get_account_id()
             self._status_polling_task = safe_ensure_future(self._status_polling_loop())
             self._user_stream_tracker_task = safe_ensure_future(self._user_stream_tracker.start())
             self._user_stream_event_listener_task = safe_ensure_future(self._user_stream_event_listener())
@@ -389,7 +392,7 @@ class NdaxExchange(ExchangeBase):
             params = {
                 "InstrumentId": trading_pair_ids[trading_pair],
                 "OMSId": 1,
-                "AccountId": self.account_id,
+                "AccountId": await self.initialized_account_id(),
                 "ClientOrderId": int(order_id),
                 "Side": 0 if trade_type == TradeType.BUY else 1,
                 "Quantity": amount,
@@ -517,7 +520,7 @@ class NdaxExchange(ExchangeBase):
 
             body_params = {
                 "OMSId": 1,
-                "AccountId": self.account_id,
+                "AccountId": await self.initialized_account_id(),
                 "OrderId": await tracked_order.get_exchange_order_id()
             }
 
@@ -554,7 +557,7 @@ class NdaxExchange(ExchangeBase):
     async def get_open_orders(self) -> List[OpenOrder]:
         query_params = {
             "OMSId": 1,
-            "AccountId": self.account_id,
+            "AccountId": await self.initialized_account_id(),
         }
         open_orders: List[Dict[str, Any]] = await self._api_request(method="GET",
                                                                     path_url=CONSTANTS.GET_OPEN_ORDERS_PATH_URL,
@@ -670,14 +673,9 @@ class NdaxExchange(ExchangeBase):
         local_asset_names = set(self._account_balances.keys())
         remote_asset_names = set()
 
-        # When the balances are requested by the client to test the connection, the account id will not be
-        # initialized yet
-        if not self._account_id:
-            self._account_id = await self._get_account_id()
-
         params = {
             "OMSId": 1,
-            "AccountId": self.account_id
+            "AccountId": await self.initialized_account_id()
         }
         account_positions: List[Dict[str, Any]] = await self._api_request(
             method="GET",
@@ -743,7 +741,7 @@ class NdaxExchange(ExchangeBase):
 
             query_params = {
                 "OMSId": 1,
-                "AccountId": self.account_id,
+                "AccountId": await self.initialized_account_id(),
                 "OrderId": int(ex_order_id),
             }
 
@@ -774,7 +772,7 @@ class NdaxExchange(ExchangeBase):
         for trading_pair in self._trading_pairs:
             query_params = {
                 "OMSId": 1,
-                "AccountId": self.account_id,
+                "AccountId": await self.initialized_account_id(),
                 "UserId": self._auth.uid,
                 "InstrumentId": trading_pair_ids[trading_pair],
                 "StartTimestamp": min_ts,
@@ -792,7 +790,10 @@ class NdaxExchange(ExchangeBase):
         parsed_history_resps: List[Dict[str, Any]] = []
         for resp in raw_responses:
             if not isinstance(resp, Exception):
-                parsed_history_resps.append(resp)
+                # When there are no results, the GetTradesHistory endpoint returns a list with an empty list inside
+                # That empty list should not be processed.
+                if len(resp) > 0:
+                    parsed_history_resps.append(resp)
             else:
                 self.logger().error(f"Error fetching order status. Response: {resp}")
 

--- a/hummingbot/connector/exchange/ndax/ndax_utils.py
+++ b/hummingbot/connector/exchange/ndax/ndax_utils.py
@@ -3,7 +3,7 @@ from typing import Optional
 from hummingbot.client.config.config_methods import using_exchange
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.connector.exchange.ndax import ndax_constants as CONSTANTS
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce_low_res
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
 CENTRALIZED = True
 
@@ -24,7 +24,7 @@ def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
 
 
 def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
-    ts_micro_sec: int = get_tracking_nonce_low_res()
+    ts_micro_sec: int = get_tracking_nonce()
     return f"{int(ts_micro_sec)}"
 
 

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -723,7 +723,8 @@ class NdaxExchangeTests(TestCase):
     def test_update_order_status(self, mock_api):
 
         # Simulates order being tracked
-        order: NdaxInFlightOrder = NdaxInFlightOrder("0", "2628", self.trading_pair, OrderType.LIMIT, TradeType.SELL, Decimal(str(41720.83)), Decimal("1"))
+        order: NdaxInFlightOrder = NdaxInFlightOrder("0", "2628", self.trading_pair, OrderType.LIMIT, TradeType.SELL,
+                                                     Decimal(str(41720.83)), Decimal("1"))
         self.exchange._in_flight_orders.update({
             order.client_order_id: order
         })
@@ -831,7 +832,8 @@ class NdaxExchangeTests(TestCase):
     def test_update_order_status_error_response(self, mock_api):
 
         # Simulates order being tracked
-        order: NdaxInFlightOrder = NdaxInFlightOrder("0", "2628", self.trading_pair, OrderType.LIMIT, TradeType.SELL, Decimal(str(41720.83)), Decimal("1"))
+        order: NdaxInFlightOrder = NdaxInFlightOrder("0", "2628", self.trading_pair, OrderType.LIMIT, TradeType.SELL,
+                                                     Decimal(str(41720.83)), Decimal("1"))
         self.exchange._in_flight_orders.update({
             order.client_order_id: order
         })
@@ -1024,7 +1026,8 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(trading_rule.min_price_increment, Decimal(str(mock_response[0]["PriceIncrement"])))
         self.assertEqual(trading_rule.min_base_amount_increment, Decimal(str(mock_response[0]["QuantityIncrement"])))
 
-    @patch("hummingbot.connector.exchange.ndax.ndax_exchange.NdaxExchange._update_trading_rules", new_callable=AsyncMock)
+    @patch("hummingbot.connector.exchange.ndax.ndax_exchange.NdaxExchange._update_trading_rules",
+           new_callable=AsyncMock)
     def test_trading_rules_polling_loop(self, mock_update):
         # No Side Effects expected
         mock_update.return_value = None
@@ -1035,7 +1038,8 @@ class NdaxExchangeTests(TestCase):
                 asyncio.wait_for(self.exchange_task, 1.0)
             )
 
-    @patch("hummingbot.connector.exchange.ndax.ndax_exchange.NdaxExchange._update_trading_rules", new_callable=AsyncMock)
+    @patch("hummingbot.connector.exchange.ndax.ndax_exchange.NdaxExchange._update_trading_rules",
+           new_callable=AsyncMock)
     def test_trading_rules_polling_loop_cancels(self, mock_update):
         mock_update.side_effect = asyncio.CancelledError
 
@@ -1048,7 +1052,8 @@ class NdaxExchangeTests(TestCase):
 
         self.assertEqual(0, self.exchange._last_poll_timestamp)
 
-    @patch("hummingbot.connector.exchange.ndax.ndax_exchange.NdaxExchange._update_trading_rules", new_callable=AsyncMock)
+    @patch("hummingbot.connector.exchange.ndax.ndax_exchange.NdaxExchange._update_trading_rules",
+           new_callable=AsyncMock)
     def test_trading_rules_polling_loop_exception_raised(self, mock_update):
         mock_update.side_effect = lambda: self._create_exception_and_unlock_test_with_event(
             Exception("Dummy test error"))
@@ -1134,8 +1139,9 @@ class NdaxExchangeTests(TestCase):
         # Order ID is simply a timestamp. The assertion below checks if it is created within 1 sec
         self.assertTrue((int(time.time() * 1e3) - int(order_id)) < 1 * 1e3)
 
-    @patch("hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
-           new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
+        new_callable=AsyncMock)
     @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)
     def test_create_limit_order(self, mock_post, mock_get_instrument_ids):
         mock_get_instrument_ids.return_value = {
@@ -1167,7 +1173,8 @@ class NdaxExchangeTests(TestCase):
         )
 
         self.assertEqual(1, len(self.exchange.in_flight_orders))
-        self._is_logged("INFO", f"Created {OrderType.LIMIT.name} {TradeType.BUY.name} order {123} for {Decimal(1.0)} {self.trading_pair}")
+        self._is_logged("INFO",
+                        f"Created {OrderType.LIMIT.name} {TradeType.BUY.name} order {123} for {Decimal(1.0)} {self.trading_pair}")
 
         tracked_order: NdaxInFlightOrder = self.exchange.in_flight_orders["1"]
         self.assertEqual(tracked_order.client_order_id, "1")
@@ -1178,8 +1185,9 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(tracked_order.amount, Decimal(1.0))
         self.assertEqual(tracked_order.trade_type, TradeType.BUY)
 
-    @patch("hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
-           new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
+        new_callable=AsyncMock)
     @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)
     def test_create_market_order(self, mock_post, mock_get_instrument_ids):
         mock_get_instrument_ids.return_value = {
@@ -1211,7 +1219,8 @@ class NdaxExchangeTests(TestCase):
         )
 
         self.assertEqual(1, len(self.exchange.in_flight_orders))
-        self._is_logged("INFO", f"Created {OrderType.MARKET.name} {TradeType.BUY.name} order {123} for {Decimal(1.0)} {self.trading_pair}")
+        self._is_logged("INFO",
+                        f"Created {OrderType.MARKET.name} {TradeType.BUY.name} order {123} for {Decimal(1.0)} {self.trading_pair}")
 
         tracked_order: NdaxInFlightOrder = self.exchange.in_flight_orders["1"]
         self.assertEqual(tracked_order.client_order_id, "1")
@@ -1221,8 +1230,9 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(tracked_order.amount, Decimal(1.0))
         self.assertEqual(tracked_order.trade_type, TradeType.BUY)
 
-    @patch("hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
-           new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
+        new_callable=AsyncMock)
     @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)
     def test_create_order_cancels(self, mock_post, mock_get_instrument_ids):
         mock_get_instrument_ids.return_value = {
@@ -1252,8 +1262,9 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(1, len(self.exchange.in_flight_orders))
 
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
-    @patch("hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
-           new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
+        new_callable=AsyncMock)
     def test_create_order_below_min_order_size_exception_raised(self, mock_get_instrument_ids, mock_main_app):
         mock_get_instrument_ids.return_value = {
             self.trading_pair: 5
@@ -1282,8 +1293,9 @@ class NdaxExchangeTests(TestCase):
         self._is_logged("NETWORK", f"Error submitting {TradeType.BUY.name} {OrderType.LIMIT.name} order to NDAX")
 
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
-    @patch("hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
-           new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source.NdaxAPIOrderBookDataSource.get_instrument_ids",
+        new_callable=AsyncMock)
     @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)
     def test_create_order_api_returns_error_exception_raised(self, mock_post, mock_get_instrument_ids, mock_main_app):
         mock_get_instrument_ids.return_value = {
@@ -1347,6 +1359,79 @@ class NdaxExchangeTests(TestCase):
         )
 
         self.assertEqual(result, order.client_order_id)
+
+    @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)
+    @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
+    def test_execute_cancel_all_success(self, mock_get_request, mock_post_request):
+        order: NdaxInFlightOrder = NdaxInFlightOrder(
+            client_order_id="0",
+            exchange_order_id="123",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal(10.0),
+            amount=Decimal(1.0))
+
+        self.exchange._in_flight_orders.update({
+            order.client_order_id: order
+        })
+
+        # Simulate _trading_pair_id_map initialized.
+        self.exchange._order_book_tracker.data_source._trading_pair_id_map.update({
+            self.trading_pair: 5
+        })
+
+        mock_open_orders_response = [
+            {
+                "Side": "Buy",
+                "OrderId": 123,
+                "Price": 10.0,
+                "Quantity": 1.0,
+                "DisplayQuantity": 1.0,
+                "Instrument": 5,
+                "Account": 1,
+                "OrderType": "Limit",
+                "ClientOrderId": 0,
+                "OrderState": "Working",
+                "ReceiveTime": 0,
+                "ReceiveTimeTicks": 0,
+                "OrigQuantity": 1.0,
+                "QuantityExecuted": 0.0,
+                "AvgPrice": 0.0,
+                "CounterPartyId": 0,
+                "ChangeReason": "Unknown",
+                "OrigOrderId": 0,
+                "OrigClOrdId": 0,
+                "EnteredBy": 0,
+                "IsQuote": False,
+                "InsideAsk": 0.0,
+                "InsideAskSize": 0.0,
+                "InsideBid": 0.0,
+                "InsideBidSize": 0.0,
+                "LastTradePrice": 0.0,
+                "RejectReason": "",
+                "IsLockedIn": False,
+                "CancelReason": "",
+                "OMSId": 1
+            },
+        ]
+        self._set_mock_response(mock_get_request, 200, mock_open_orders_response)
+
+        mock_response = {
+            "result": True,
+            "errormsg": None,
+            "errorcode": 0,
+            "detail": None
+        }
+        self._set_mock_response(mock_post_request, 200, mock_response)
+
+        cancellation_results = asyncio.new_event_loop().run_until_complete(
+            self.exchange.cancel_all(10)
+        )
+
+        self.assertEqual(1, len(cancellation_results))
+        self.assertEqual("0", cancellation_results[0].order_id)
+        self.assertTrue(cancellation_results[0].success)
 
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
     @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -58,6 +58,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange.logger().setLevel(1)
         self.exchange.logger().addHandler(self)
+        self.exchange._account_id = 1
 
     def tearDown(self) -> None:
         self.tracker_task and self.tracker_task.cancel()

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_utils.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_utils.py
@@ -10,7 +10,7 @@ class NdaxUtilsTests(TestCase):
         trading_pair = "BTC-USDT"
         self.assertEqual("BTCUSDT", utils.convert_to_exchange_trading_pair(trading_pair))
 
-    @patch('hummingbot.connector.exchange.ndax.ndax_utils.get_tracking_nonce_low_res')
+    @patch('hummingbot.connector.exchange.ndax.ndax_utils.get_tracking_nonce')
     def test_client_order_id_creation(self, nonce_provider_mock):
         nonce_provider_mock.return_value = 1000
         self.assertEqual(str(1000), utils.get_new_client_order_id(True, "BTC-USDT"))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Change in the implementation of the web socket received messages iterator in the NDAX user stream data source. Now it reuses the functionality already present in the NDAX web socket, that also takes care of sending a ping request regularly to keep the connection alive.
I also added a fix to the issue that was causing error in the cancel_all functionality from the connector.
Includes the fix to an error caused by the account_id being referenced before it was initialized by the start_network logic (it is required for the cancel_all logic kicked off by the start command)