### PR TITLE
fix/ NDAX fetching inactive markets

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
@@ -46,7 +46,6 @@ class NdaxAPIOrderBookDataSource(OrderBookTrackerDataSource):
         """
         cls._trading_pair_id_map.clear()
 
-        results = {}
         params = {
             "OMSId": 1
         }
@@ -56,10 +55,11 @@ class NdaxAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 if response.status == 200:
                     resp_json: Dict[str, Any] = await response.json()
 
-                    for instrument in resp_json:
-                        results.update({
-                            f"{instrument['Product1Symbol']}-{instrument['Product2Symbol']}": int(instrument["InstrumentId"])
-                        })
+                    results = {
+                        f"{instrument['Product1Symbol']}-{instrument['Product2Symbol']}": int(instrument["InstrumentId"])
+                        for instrument in resp_json
+                        if instrument["SessionStatus"] == "Running"
+                    }
         cls._trading_pair_id_map = results
 
     @classmethod

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_api_order_book_data_source.py
@@ -95,16 +95,33 @@ class NdaxAPIOrderBookDataSourceUnitTests(unittest.TestCase):
 
     @patch("aiohttp.ClientSession.get")
     def test_init_trading_pair_ids(self, mock_api):
-        mock_response: List[Any] = [{
-            "Product1Symbol": self.base_asset,
-            "Product2Symbol": self.quote_asset,
-            "InstrumentId": self.instrument_id,
-        }]
+        mock_response: List[Any] = [
+            {
+                "Product1Symbol": self.base_asset,
+                "Product2Symbol": self.quote_asset,
+                "InstrumentId": self.instrument_id,
+                "SessionStatus": "Running"
+            },
+            {
+                "Product1Symbol": "ANOTHER_ACTIVE",
+                "Product2Symbol": "MARKET",
+                "InstrumentId": 2,
+                "SessionStatus": "Running"
+            },
+            {
+                "Product1Symbol": "NOT_ACTIVE",
+                "Product2Symbol": "MARKET",
+                "InstrumentId": 3,
+                "SessionStatus": "Stopped"
+            }
+        ]
 
         self.set_mock_response(mock_api, 200, mock_response)
 
         self.ev_loop.run_until_complete(self.data_source.init_trading_pair_ids())
+        self.assertEqual(2, len(self.data_source._trading_pair_id_map))
         self.assertEqual(1, self.data_source._trading_pair_id_map[self.trading_pair])
+        self.assertEqual(2, self.data_source._trading_pair_id_map["ANOTHER_ACTIVE-MARKET"])
 
     @patch("aiohttp.ClientSession.get")
     def test_get_last_traded_prices(self, mock_api):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x]  You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Addresses an issue raised by @RC-13 regarding autocomplete listing markets not available on the exchange.

> - Some trading pairs like BTC-USD, BTC-USDT, and MATIC-CAD are shown in the market autocomplete list but don't exist in the exchange. Using this market result in an unhandled error

For Developers
- Modified logic in `NdaxAPIOrderBookDataSource.init_trading_pair_ids()`
- Modified respective unit tests

For QA
- Test that inactive markets are no longer listed in autocomplete.