### PR TITLE
Fix/ndax order book diff entry removal

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
@@ -140,7 +140,9 @@ class NdaxAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 response: List[Any] = await response.json()
                 orderbook_entries: List[NdaxOrderBookEntry] = [NdaxOrderBookEntry(*entry) for entry in response]
                 return {"data": orderbook_entries,
-                        "timestamp": max([entry.actionDateTime for entry in orderbook_entries])}
+                        "timestamp": (max([entry.actionDateTime for entry in orderbook_entries])
+                                      if orderbook_entries
+                                      else int(time.time() * 1e3))}
 
     async def get_new_order_book(self, trading_pair: str) -> OrderBook:
         snapshot: Dict[str, Any] = await self.get_order_book_data(trading_pair, self._domain)

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_order_book_message.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_order_book_message.py
@@ -1,0 +1,82 @@
+import time
+
+from unittest import TestCase
+
+from hummingbot.connector.exchange.ndax.ndax_order_book_message import NdaxOrderBookMessage, NdaxOrderBookEntry
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+class NdaxOrderBookMessageTests(TestCase):
+
+    def test_equality_based_on_type_and_timestamp(self):
+        message = NdaxOrderBookMessage(message_type=OrderBookMessageType.SNAPSHOT,
+                                       content={"data": []},
+                                       timestamp=10000000)
+        equal_message = NdaxOrderBookMessage(message_type=OrderBookMessageType.SNAPSHOT,
+                                             content={"data": []},
+                                             timestamp=10000000)
+        message_with_different_type = NdaxOrderBookMessage(message_type=OrderBookMessageType.DIFF,
+                                                           content={"data": []},
+                                                           timestamp=10000000)
+        message_with_different_timestamp = NdaxOrderBookMessage(message_type=OrderBookMessageType.SNAPSHOT,
+                                                                content={"data": []},
+                                                                timestamp=90000000)
+
+        self.assertEqual(message, message)
+        self.assertEqual(message, equal_message)
+        self.assertNotEqual(message, message_with_different_type)
+        self.assertNotEqual(message, message_with_different_timestamp)
+
+    def test_equal_messages_have_equal_hash(self):
+        message = NdaxOrderBookMessage(message_type=OrderBookMessageType.SNAPSHOT,
+                                       content={"data": []},
+                                       timestamp=10000000)
+        equal_message = NdaxOrderBookMessage(message_type=OrderBookMessageType.SNAPSHOT,
+                                             content={"data": []},
+                                             timestamp=10000000)
+
+        self.assertEqual(hash(message), hash(equal_message))
+
+    def test_delete_buy_order_book_entry_always_has_zero_amount(self):
+        entries = [NdaxOrderBookEntry(mdUpdateId=1,
+                                      accountId=1,
+                                      actionDateTime=1627935956059,
+                                      actionType=2,
+                                      lastTradePrice=42211.51,
+                                      orderId=1,
+                                      price=41508.19,
+                                      productPairCode=5,
+                                      quantity=1.5,
+                                      side=0)]
+        content = {"data": entries}
+        message = NdaxOrderBookMessage(message_type=OrderBookMessageType.DIFF,
+                                       content=content,
+                                       timestamp=time.time())
+        bids = message.bids
+
+        self.assertEqual(1, len(bids))
+        self.assertEqual(41508.19, bids[0].price)
+        self.assertEqual(0.0, bids[0].amount)
+        self.assertEqual(1, bids[0].update_id)
+
+    def test_delete_sell_order_book_entry_always_has_zero_amount(self):
+        entries = [NdaxOrderBookEntry(mdUpdateId=1,
+                                      accountId=1,
+                                      actionDateTime=1627935956059,
+                                      actionType=2,
+                                      lastTradePrice=42211.51,
+                                      orderId=1,
+                                      price=41508.19,
+                                      productPairCode=5,
+                                      quantity=1.5,
+                                      side=1)]
+        content = {"data": entries}
+        message = NdaxOrderBookMessage(message_type=OrderBookMessageType.DIFF,
+                                       content=content,
+                                       timestamp=time.time())
+        asks = message.asks
+
+        self.assertEqual(1, len(asks))
+        self.assertEqual(41508.19, asks[0].price)
+        self.assertEqual(0.0, asks[0].amount)
+        self.assertEqual(1, asks[0].update_id)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR includes two fixes:
- Ensure the updates received regarding order book events of type DELETE are processed as deletes, even if their amount is not zero.
- Ensure requesting order book data from the exchange does not fail when the response does not include events.

**Tests performed by the developer**
Added unit tests to cover the new scenarios.
