### PR TITLE
Fix/ NDAX GetTradesHistory not filtering by StartTimestamp

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -776,7 +776,6 @@ class NdaxExchange(ExchangeBase):
                 "UserId": self._auth.uid,
                 "InstrumentId": trading_pair_ids[trading_pair],
                 "StartTimestamp": min_ts,
-                "EndTimestamp": int(time.time() * 1e3),
             }
             trade_history_tasks.append(
                 asyncio.create_task(self._api_request(method="POST",

--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -770,18 +770,18 @@ class NdaxExchange(ExchangeBase):
         trading_pair_ids: Dict[str, int] = await self._order_book_tracker.data_source.get_instrument_ids()
 
         for trading_pair in self._trading_pairs:
-            query_params = {
+            body_params = {
                 "OMSId": 1,
                 "AccountId": await self.initialized_account_id(),
                 "UserId": self._auth.uid,
                 "InstrumentId": trading_pair_ids[trading_pair],
                 "StartTimestamp": min_ts,
-                "EndTimestamp": int(time.time()),
+                "EndTimestamp": int(time.time() * 1e3),
             }
             trade_history_tasks.append(
-                asyncio.create_task(self._api_request(method="GET",
+                asyncio.create_task(self._api_request(method="POST",
                                                       path_url=CONSTANTS.GET_TRADES_HISTORY_PATH_URL,
-                                                      params=query_params,
+                                                      data=body_params,
                                                       is_auth_required=True)))
 
         raw_responses: List[Dict[str, Any]] = await safe_gather(*trade_history_tasks, return_exceptions=True)

--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -763,7 +763,7 @@ class NdaxExchange(ExchangeBase):
             else:
                 self.logger().error(f"Error fetching order status. Response: {resp}")
 
-        min_ts: int = min([int(order_status["ReceiveTime"] // 1e3)
+        min_ts: int = min([int(order_status["ReceiveTime"])
                            for order_status in parsed_status_responses])
 
         trade_history_tasks = []

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -720,8 +720,9 @@ class NdaxExchangeTests(TestCase):
 
         self.assertEqual(Decimal(str(10.0)), self.exchange.get_balance(self.base_asset))
 
+    @patch("aiohttp.ClientSession.post", new_callable=AsyncMock)
     @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
-    def test_update_order_status(self, mock_api):
+    def test_update_order_status(self, mock_order_status, mock_trade_history):
 
         # Simulates order being tracked
         order: NdaxInFlightOrder = NdaxInFlightOrder("0", "2628", self.trading_pair, OrderType.LIMIT, TradeType.SELL,
@@ -732,7 +733,7 @@ class NdaxExchangeTests(TestCase):
         self.assertTrue(1, len(self.exchange.in_flight_orders))
 
         # Add FullyExecuted GetOrderStatus API Response
-        self._set_mock_response(mock_api, 200, {
+        self._set_mock_response(mock_order_status, 200, {
             "Side": "Sell",
             "OrderId": 2628,
             "Price": 41720.830000000000000000000000,
@@ -780,7 +781,7 @@ class NdaxExchangeTests(TestCase):
         })
 
         # Add TradeHistory API Response
-        self._set_mock_response(mock_api, 200, {
+        self._set_mock_response(mock_trade_history, 200, {
             "OMSId": 1,
             "ExecutionId": 245936,
             "TradeId": 252851,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Addresses an issue with the `GetTradesHistory` endpoint where the filters are not applied appropriately.

For Developers
- Update the `GET` request to a `POST` request and include the relevant parameters as body parameters
- `StartTimestamp` and `EndTimestamp` parameters are in milliseconds (seconds * 1000)
- Update the relevant unit tests

For QA
- Nothing much changes, ensure that status polling is working as intended.
