### PR TITLE
fix/ NDAX still listing inactive markets in autocomplete

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
@@ -107,7 +107,9 @@ class NdaxAPIOrderBookDataSource(OrderBookTrackerDataSource):
                                   params=params) as response:
                 if response.status == 200:
                     resp_json: Dict[str, Any] = await response.json()
-                    return [f"{instrument['Product1Symbol']}-{instrument['Product2Symbol']}" for instrument in resp_json]
+                    return [f"{instrument['Product1Symbol']}-{instrument['Product2Symbol']}"
+                            for instrument in resp_json
+                            if instrument["SessionStatus"] == "Running"]
                 return []
 
     @classmethod


### PR DESCRIPTION

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Addresses issue where autocomplete is still fetching inactive markets.

**Developer Notes**
Added condition to filter markets by its `SessionStatus` in `fetch_trading_pairs()`
Modified unit tests for `fetch_trading_pairs()`

**Note for QA**
Verify that inactive markets are no longer listed in autocomplete.
