### PR TITLE
Fix/increase ndax order book snapshot frequency

### DIFF
--- a/test/hummingbot/connector/exchange/ndax/test_ndax_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_api_order_book_data_source.py
@@ -360,17 +360,17 @@ class NdaxAPIOrderBookDataSourceUnitTests(unittest.TestCase):
         self.assertTrue(second_msg.type == OrderBookMessageType.DIFF)
 
     @patch("websockets.connect", new_callable=AsyncMock)
-    def test_websocket_connection_initialization_raises_cancel_exception(self, mock_ws):
+    def test_websocket_connection_creation_raises_cancel_exception(self, mock_ws):
         mock_ws.side_effect = asyncio.CancelledError
 
         with self.assertRaises(asyncio.CancelledError):
-            asyncio.get_event_loop().run_until_complete(self.data_source._init_websocket_connection())
+            asyncio.get_event_loop().run_until_complete(self.data_source._create_websocket_connection())
 
     @patch("websockets.connect", new_callable=AsyncMock)
-    def test_websocket_connection_initialization_raises_exception_after_loging(self, mock_ws):
+    def test_websocket_connection_creation_raises_exception_after_loging(self, mock_ws):
         mock_ws.side_effect = Exception
 
         with self.assertRaises(Exception):
-            asyncio.get_event_loop().run_until_complete(self.data_source._init_websocket_connection())
+            asyncio.get_event_loop().run_until_complete(self.data_source._create_websocket_connection())
 
         self.assertTrue(self._is_logged("NETWORK", "Unexpected error occurred during ndax WebSocket Connection ()"))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I have changed the frequency of full order book snapshot captures by the client. It was 1 hour and it is now 5 minutes. We need to do this because NDAX is not sending reliable updates for the order book entries.

**Tests performed by the developer**
I executed a PMM strategy connected to the production NDAX account. I validated that any difference is solved every 5 minutes.
