### PR TITLE
Feat/Add broker ID to Huobi connector

### DIFF
--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -52,7 +52,8 @@ from hummingbot.connector.exchange.huobi.huobi_in_flight_order import HuobiInFli
 from hummingbot.connector.exchange.huobi.huobi_order_book_tracker import HuobiOrderBookTracker
 from hummingbot.connector.exchange.huobi.huobi_utils import (
     convert_to_exchange_trading_pair,
-    convert_from_exchange_trading_pair)
+    convert_from_exchange_trading_pair,
+    BROKER_ID)
 from hummingbot.connector.trading_rule cimport TradingRule
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.exchange.huobi.huobi_user_stream_tracker import HuobiUserStreamTracker
@@ -811,7 +812,7 @@ cdef class HuobiExchange(ExchangeBase):
                    dict kwargs={}):
         cdef:
             int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = f"buy-{trading_pair}-{tracking_nonce}"
+            str order_id = f"{BROKER_ID}-buy-{trading_pair}-{tracking_nonce}"
 
         safe_ensure_future(self.execute_buy(order_id, trading_pair, amount, order_type, price))
         return order_id
@@ -881,7 +882,7 @@ cdef class HuobiExchange(ExchangeBase):
                     dict kwargs={}):
         cdef:
             int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = f"sell-{trading_pair}-{tracking_nonce}"
+            str order_id = f"{BROKER_ID}-sell-{trading_pair}-{tracking_nonce}"
         safe_ensure_future(self.execute_sell(order_id, trading_pair, amount, order_type, price))
         return order_id
 

--- a/hummingbot/connector/exchange/huobi/huobi_utils.py
+++ b/hummingbot/connector/exchange/huobi/huobi_utils.py
@@ -16,6 +16,8 @@ EXAMPLE_PAIR = "ETH-USDT"
 
 DEFAULT_FEES = [0.2, 0.2]
 
+BROKER_ID = "AAc484720a"
+
 
 def split_trading_pair(trading_pair: str) -> Optional[Tuple[str, str]]:
     try:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

A Hummingbot's broker id assigned by Huobi is added as a prefix to order-id (client-order-id)

**Tests performed by the developer**:

Ran a live pure market making strategy on Huobi and printed in logs the "client-order-id" parameter that's being sent to the exchange.
