### PR TITLE
Fix/improve performance binance perpetual derivative tests

### DIFF
--- a/test/hummingbot/connector/derivative/test_binance_perpetual_market.py
+++ b/test/hummingbot/connector/derivative/test_binance_perpetual_market.py
@@ -20,8 +20,9 @@ class BinancePerpetualDerivativeUnitTest(unittest.TestCase):
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
         cls.symbol = f"{cls.base_asset}{cls.quote_asset}"
 
+    @patch("hummingbot.connector.exchange.binance.binance_time.BinanceTime.start")
     @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
-    def setUp(self, mocked_get) -> None:
+    def setUp(self, mocked_get, mocked_binance_time_start) -> None:
         super().setUp()
         self.ev_loop = asyncio.get_event_loop()
 
@@ -37,9 +38,6 @@ class BinancePerpetualDerivativeUnitTest(unittest.TestCase):
             binance_perpetual_api_secret="testSecret",
             trading_pairs=[self.trading_pair],
         )
-
-        self._set_mock_response(mock_api=mocked_get, status=200, json_data={"serverTime": self.start_timestamp})
-        self.ev_loop.run_until_complete(self._await_all_api_responses_delivered())
 
     async def _get_next_api_response(self):
         message = await self.api_responses.get()

--- a/test/hummingbot/connector/derivative/test_binance_perpetual_market.py
+++ b/test/hummingbot/connector/derivative/test_binance_perpetual_market.py
@@ -21,8 +21,7 @@ class BinancePerpetualDerivativeUnitTest(unittest.TestCase):
         cls.symbol = f"{cls.base_asset}{cls.quote_asset}"
 
     @patch("hummingbot.connector.exchange.binance.binance_time.BinanceTime.start")
-    @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
-    def setUp(self, mocked_get, mocked_binance_time_start) -> None:
+    def setUp(self, mocked_binance_time_start) -> None:
         super().setUp()
         self.ev_loop = asyncio.get_event_loop()
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Changed setUp in BinancePerpetualDerivativeUnitTest to avoid delays due to the startup of the BinanceTime component. Reduces the required execution time from 6 minutes for 7 tests to 99 ms for 7 tests.


**Tests performed by the developer**:
All unit tests in the testing class pass in green


**Tips for QA testing**:
No QA testing required

