### PR TITLE
feat/adapt data streams connection to all perpetual bybit markets

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -264,7 +264,7 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 self.logger().network(
                     f"Unexpected error with WebSocket connection on {url} ({ex})",
                     exc_info=True,
-                    app_warning_msg="Unexpected error with WebSocket connection on. Retrying in 30 seconds. "
+                    app_warning_msg="Unexpected error with WebSocket connectionß. Retrying in 30 seconds. "
                                     "Check network connection."
                 )
                 if ws_adaptor:

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_auth.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_auth.py
@@ -42,7 +42,6 @@ class BybitPerpetualAuth():
     def extend_params_with_authentication_info(self, params: Dict[str, Any]):
         params["timestamp"] = self.get_expiration_timestamp()
         params["api_key"] = self._api_key
-        params["recv_window"] = 10000
         key_value_elements = []
         for key, value in sorted(params.items()):
             converted_value = float(value) if type(value) is Decimal else value

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
@@ -24,7 +24,10 @@ QUERY_SYMBOL_ENDPOINT = {
 ORDER_BOOK_ENDPOINT = {
     "linear": f"{REST_API_VERSION}/public/orderBook/L2",
     "non_linear": f"{REST_API_VERSION}/public/orderBook/L2"}
-
+SERVER_TIME_PATH_URL = {
+    "linear": f"{REST_API_VERSION}/public/time",
+    "non_linear": f"{REST_API_VERSION}/public/time"
+}
 # REST API Private Endpoints
 SET_LEVERAGE_PATH_URL = {
     "linear": "private/linear/position/set-leverage",

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
@@ -4,8 +4,13 @@ EXCHANGE_NAME = "bybit_perpetual"
 
 REST_URLS = {"bybit_perpetual_main": "https://api.bybit.com/",
              "bybit_perpetual_testnet": "https://api-testnet.bybit.com/"}
-WSS_URLS = {"bybit_perpetual_main": "wss://stream.bybit.com/realtime",
-            "bybit_perpetual_testnet": "wss://stream-testnet.bybit.com/realtime"}
+WSS_NON_LINEAR_PUBLIC_URLS = {"bybit_perpetual_main": "wss://stream.bybit.com/realtime",
+                              "bybit_perpetual_testnet": "wss://stream-testnet.bybit.com/realtime"}
+WSS_NON_LINEAR_PRIVATE_URLS = WSS_NON_LINEAR_PUBLIC_URLS
+WSS_LINEAR_PUBLIC_URLS = {"bybit_perpetual_main": "wss://stream.bybit.com/realtime_public",
+                          "bybit_perpetual_testnet": "wss://stream-testnet.bybit.com/realtime_public"}
+WSS_LINEAR_PRIVATE_URLS = {"bybit_perpetual_main": "wss://stream.bybit.com/realtime_private",
+                           "bybit_perpetual_testnet": "wss://stream-testnet.bybit.com/realtime_private"}
 
 REST_API_VERSION = "v2"
 

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_order_book.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_order_book.py
@@ -56,11 +56,12 @@ class BybitPerpetualOrderBook(OrderBook):
         if metadata:
             msg.update(metadata)
 
-        bids, asks = cls._bids_and_asks_from_entries(msg["data"])
+        entries = msg["data"]["order_book"] if "order_book" in msg["data"] else msg["data"]
+        bids, asks = cls._bids_and_asks_from_entries(entries)
 
         msg.update({"asks": asks,
                     "bids": bids,
-                    "update_id": msg["timestamp_e6"]})
+                    "update_id": int(msg["timestamp_e6"])})
 
         return OrderBookMessage(
             message_type=OrderBookMessageType.SNAPSHOT,
@@ -112,7 +113,7 @@ class BybitPerpetualOrderBook(OrderBook):
 
         msg.update({"asks": asks,
                     "bids": bids,
-                    "update_id": msg["timestamp_e6"]})
+                    "update_id": int(msg["timestamp_e6"])})
 
         return OrderBookMessage(
             message_type=OrderBookMessageType.DIFF,

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_order_book_tracker.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_order_book_tracker.py
@@ -40,6 +40,9 @@ class BybitPerpetualOrderBookTracker(OrderBookTracker):
             raise ValueError(f"The symbol representing trading pair {trading_pair} could not be found")
         return symbol
 
+    def is_funding_info_initialized(self) -> bool:
+        return self._data_source.is_funding_info_initialized()
+
     def start(self):
         super().start()
         self._order_book_event_listener_task = safe_ensure_future(self._data_source.listen_for_subscriptions())

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_order_book_tracker.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_order_book_tracker.py
@@ -6,7 +6,6 @@ from typing import List, Optional
 import aiohttp
 
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_api_order_book_data_source import BybitPerpetualAPIOrderBookDataSource
-from hummingbot.core.data_type.order_book import OrderBook
 
 from hummingbot.core.data_type.order_book_tracker import OrderBookTracker
 from hummingbot.core.utils.async_utils import safe_ensure_future
@@ -55,6 +54,3 @@ class BybitPerpetualOrderBookTracker(OrderBookTracker):
             self._order_book_instruments_info_listener_task.cancel()
             self._order_book_instruments_info_listener_task = None
         super().stop()
-
-    async def _initial_order_book_for_trading_pair(self, trading_pair: str) -> OrderBook:
-        return self._data_source.order_book_create_function()

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -50,9 +50,25 @@ def rest_api_url_for_endpoint(endpoint: str, domain: Optional[str] = None) -> st
     return CONSTANTS.REST_URLS.get(variant) + endpoint
 
 
-def wss_url(connector_variant_label: Optional[str]) -> str:
+def _wss_url(endpoint: Dict[str, str], connector_variant_label: Optional[str]) -> str:
     variant = connector_variant_label if connector_variant_label else "bybit_perpetual_main"
-    return CONSTANTS.WSS_URLS.get(variant)
+    return endpoint.get(variant)
+
+
+def wss_linear_public_url(connector_variant_label: Optional[str]) -> str:
+    return _wss_url(CONSTANTS.WSS_LINEAR_PUBLIC_URLS, connector_variant_label)
+
+
+def wss_linear_private_url(connector_variant_label: Optional[str]) -> str:
+    return _wss_url(CONSTANTS.WSS_LINEAR_PRIVATE_URLS, connector_variant_label)
+
+
+def wss_non_linear_public_url(connector_variant_label: Optional[str]) -> str:
+    return _wss_url(CONSTANTS.WSS_NON_LINEAR_PUBLIC_URLS, connector_variant_label)
+
+
+def wss_non_linear_private_url(connector_variant_label: Optional[str]) -> str:
+    return _wss_url(CONSTANTS.WSS_NON_LINEAR_PRIVATE_URLS, connector_variant_label)
 
 
 def get_next_funding_timestamp(current_timestamp: float) -> float:

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
@@ -462,7 +462,7 @@ class BybitPerpetualAPIOrderBookDataSourceTests(TestCase):
                                            'side': 'Sell',
                                            'size': 89041}],
                                       'cross_seq': 8945092523,
-                                      'timestamp_e6': 1628703196211205})
+                                      'timestamp_e6': "1628703196211205"})
 
         # Lock the test to let the async task run
         order_book_message = asyncio.get_event_loop().run_until_complete(order_book_messages.get())

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
@@ -345,7 +345,9 @@ class BybitPerpetualAPIOrderBookDataSourceTests(TestCase):
             # The exception will happen when cancelling the task
             pass
 
-        self.assertTrue(self._is_logged("NETWORK", "Unexpected error with WebSocket connection ()"))
+        self.assertTrue(
+            self._is_logged("NETWORK",
+                            "Unexpected error with WebSocket connection on wss://stream.bybit.com/realtime_public ()"))
 
     def test_listen_for_trades(self, ):
         BybitPerpetualAPIOrderBookDataSource._trading_pair_symbol_map = {None: {"BTCUSDT": "BTC-USDT"}}

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_auth.py
@@ -37,15 +37,14 @@ class BybitPerpetualAuthTests(TestCase):
             get_expiration_timestamp_mock.return_value = expires
             headers = auth.extend_params_with_authentication_info(headers)
 
-        raw_signature = "api_key=" + self.api_key + "&recv_window=10000" + "&timestamp=" + expires
+        raw_signature = "api_key=" + self.api_key + "&timestamp=" + expires
         expected_signature = hmac.new(self.secret_key.encode('utf-8'),
                                       raw_signature.encode('utf-8'),
                                       hashlib.sha256).hexdigest()
 
-        self.assertEqual(4, len(headers))
+        self.assertEqual(3, len(headers))
         self.assertEqual(expires, headers.get('timestamp'))
         self.assertEqual(self.api_key, headers.get('api_key'))
-        self.assertEqual(10000, headers.get("recv_window"))
         self.assertEqual(expected_signature, headers.get('sign'))
 
     def test_ws_auth_payload(self):

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -16,6 +16,7 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.event.event_logger import EventLogger
 
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_in_flight_order import BybitPerpetualInFlightOrder
+from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_order_book import BybitPerpetualOrderBook
 from hummingbot.core.event.events import OrderType, PositionAction, PositionSide, TradeType, MarketEvent, FundingInfo, \
     PositionMode
 from hummingbot.core.network_iterator import NetworkStatus
@@ -861,7 +862,7 @@ class BybitPerpetualDerivativeTests(TestCase):
         self.connector._order_book_tracker._order_books_initialized.set()
         self.connector._user_stream_tracker.data_source._last_recv_time = 1
         self.connector._account_balances["USDT"] = Decimal(10000)
-        self.connector._funding_info[self.trading_pair] = FundingInfo(
+        self.connector._order_book_tracker._data_source._funding_info[self.trading_pair] = FundingInfo(
             trading_pair=self.trading_pair,
             index_price=Decimal(1),
             mark_price=Decimal(1),
@@ -879,7 +880,7 @@ class BybitPerpetualDerivativeTests(TestCase):
         self.assertFalse(local_connector.ready)
 
         local_connector._order_book_tracker._order_books_initialized.set()
-        local_connector._funding_info[self.trading_pair] = FundingInfo(
+        local_connector._order_book_tracker._data_source._funding_info[self.trading_pair] = FundingInfo(
             trading_pair=self.trading_pair,
             index_price=Decimal(1),
             mark_price=Decimal(1),
@@ -1632,6 +1633,17 @@ class BybitPerpetualDerivativeTests(TestCase):
 
         self.assertEqual(NetworkStatus.NOT_CONNECTED, result)
 
+    def test_get_order_book_for_valid_trading_pair(self):
+        dummy_order_book = BybitPerpetualOrderBook()
+        self.connector._order_book_tracker.order_books["BTC-USDT"] = dummy_order_book
+        self.assertEqual(dummy_order_book, self.connector.get_order_book("BTC-USDT"))
+
+    def test_get_order_book_for_invalid_trading_pair_raises_error(self):
+        self.assertRaisesRegex(ValueError,
+                               "No order book exists for 'BTC-USDT'",
+                               self.connector.get_order_book,
+                               "BTC-USDT")
+
     def test_supported_position_modes(self):
         expected_result = [PositionMode.ONEWAY, PositionMode.HEDGE]
         self.assertEqual(expected_result, self.connector.supported_position_modes())
@@ -1789,49 +1801,34 @@ class BybitPerpetualDerivativeTests(TestCase):
             "ext_info": "",
             "result": [
                 {
-                    "is_valid": True,
-                    "data": {
-                        "id": 0,
-                        "position_idx": 0,
-                        "mode": 0,
-                        "user_id": 118921,
-                        "risk_id": 1,
-                        "symbol": self.ex_trading_pair,
-                        "side": "Buy",
-                        "size": 10,
-                        "position_value": "0.00076448",
-                        "entry_price": "13080.78694014",
-                        "is_isolated": False,
-                        "auto_add_margin": 1,
-                        "leverage": "100",
-                        "effective_leverage": "0.01",
-                        "position_margin": "0.40111704",
-                        "liq_price": "25",
-                        "bust_price": "25",
-                        "occ_closing_fee": "0.0003",
-                        "occ_funding_fee": "0",
-                        "take_profit": "0",
-                        "stop_loss": "0",
-                        "trailing_stop": "0",
-                        "position_status": "Normal",
-                        "deleverage_indicator": 1,
-                        "oc_calc_data": "{\"blq\":0,\"slq\":0,\"bmp\":0,\"smp\":0,\"fq\":-10,\"bv2c\":0.0115075,\"sv2c\":0.0114925}",
-                        "order_margin": "0",
-                        "wallet_balance": "0.40141704",
-                        "realised_pnl": "-0.00000008",
-                        "unrealised_pnl": 0.00003797,
-                        "cum_realised_pnl": "-0.090626",
-                        "cross_seq": 764786721,
-                        "position_seq": 581513847,
-                        "created_at": "2020-08-10T07:04:32Z",
-                        "updated_at": "2020-11-02T00:00:11.943371457Z",
-                        "tp_sl_mode": "Partial"
-                    }
-                },
+                    "user_id": 100004,
+                    "symbol": self.ex_trading_pair,
+                    "side": "Buy",
+                    "size": 10,
+                    "position_value": "0.00076448",
+                    "entry_price": "13080.78694014",
+                    "liq_price": "25",
+                    "bust_price": "25",
+                    "leverage": 100,
+                    "is_isolated": False,
+                    "auto_add_margin": 1,
+                    "position_margin": "0.40111704",
+                    "occ_closing_fee": "0.0003",
+                    "realised_pnl": 0,
+                    "cum_realised_pnl": 0,
+                    "free_qty": 30,
+                    "tp_sl_mode": "Full",
+                    "unrealised_pnl": 0.00003797,
+                    "deleverage_indicator": 0,
+                    "risk_id": 1,
+                    "stop_loss": 0,
+                    "take_profit": 0,
+                    "trailing_stop": 0
+                }
             ],
-            "time_now": "1604302124.031104",
-            "rate_limit_status": 118,
-            "rate_limit_reset_ms": 1604302124020,
+            "time_now": "1577480599.097287",
+            "rate_limit_status": 119,
+            "rate_limit_reset_ms": 1580885703683,
             "rate_limit": 120
         })
 
@@ -1848,49 +1845,34 @@ class BybitPerpetualDerivativeTests(TestCase):
             "ext_info": "",
             "result": [
                 {
-                    "is_valid": True,
-                    "data": {
-                        "id": 0,
-                        "position_idx": 0,
-                        "mode": 0,
-                        "user_id": 118921,
-                        "risk_id": 1,
-                        "symbol": self.ex_trading_pair,
-                        "side": "Buy",
-                        "size": 0,
-                        "position_value": "0.00076448",
-                        "entry_price": "13080.78694014",
-                        "is_isolated": False,
-                        "auto_add_margin": 1,
-                        "leverage": "100",
-                        "effective_leverage": "0.01",
-                        "position_margin": "0.40111704",
-                        "liq_price": "25",
-                        "bust_price": "25",
-                        "occ_closing_fee": "0.0003",
-                        "occ_funding_fee": "0",
-                        "take_profit": "0",
-                        "stop_loss": "0",
-                        "trailing_stop": "0",
-                        "position_status": "Normal",
-                        "deleverage_indicator": 1,
-                        "oc_calc_data": "{\"blq\":0,\"slq\":0,\"bmp\":0,\"smp\":0,\"fq\":-10,\"bv2c\":0.0115075,\"sv2c\":0.0114925}",
-                        "order_margin": "0",
-                        "wallet_balance": "0.40141704",
-                        "realised_pnl": "-0.00000008",
-                        "unrealised_pnl": 0.00003797,
-                        "cum_realised_pnl": "-0.090626",
-                        "cross_seq": 764786721,
-                        "position_seq": 581513847,
-                        "created_at": "2020-08-10T07:04:32Z",
-                        "updated_at": "2020-11-02T00:00:11.943371457Z",
-                        "tp_sl_mode": "Partial"
-                    }
-                },
+                    "user_id": 100004,
+                    "symbol": self.ex_trading_pair,
+                    "side": "Buy",
+                    "size": 0,
+                    "position_value": "0.00076448",
+                    "entry_price": "13080.78694014",
+                    "liq_price": "25",
+                    "bust_price": "25",
+                    "leverage": 100,
+                    "is_isolated": False,
+                    "auto_add_margin": 1,
+                    "position_margin": "0.40111704",
+                    "occ_closing_fee": "0.0003",
+                    "realised_pnl": 0,
+                    "cum_realised_pnl": 0,
+                    "free_qty": 30,
+                    "tp_sl_mode": "Full",
+                    "unrealised_pnl": 0.00003797,
+                    "deleverage_indicator": 0,
+                    "risk_id": 1,
+                    "stop_loss": 0,
+                    "take_profit": 0,
+                    "trailing_stop": 0
+                }
             ],
-            "time_now": "1604302130",
-            "rate_limit_status": 118,
-            "rate_limit_reset_ms": 1604302124030,
+            "time_now": "1577480599.097287",
+            "rate_limit_status": 119,
+            "rate_limit_reset_ms": 1580885703683,
             "rate_limit": 120
         })
 

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_order_book_tracker.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_order_book_tracker.py
@@ -32,8 +32,6 @@ class BybitPerpetualOrderBookTrackerTests(TestCase):
         self.assertIsNone(self.tracker._order_book_event_listener_task)
         self.assertIsNone(self.tracker._order_book_instruments_info_listener_task)
 
-        self.assertTrue(self.mock_data_source.order_book_create_function.called)
-
     def test_trading_pair_symbol(self):
         BybitPerpetualAPIOrderBookDataSource._trading_pair_symbol_map = {None: {"BTCUSDT": "BTC-USDT"}}
 

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_utils.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_utils.py
@@ -43,15 +43,45 @@ class BybitPerpetualUtilsTests(TestCase):
         url = utils.rest_api_url_for_endpoint(endpoint=endpoint, domain="bybit_perpetual_testnet")
         self.assertEqual(CONSTANTS.REST_URLS.get("bybit_perpetual_testnet") + "/testEndpoint", url)
 
-    def test_wss_url(self):
-        url = utils.wss_url(None)
-        self.assertEqual(CONSTANTS.WSS_URLS.get("bybit_perpetual_main"), url)
+    def test_wss_linear_public_url(self):
+        url = utils.wss_linear_public_url(None)
+        self.assertEqual(CONSTANTS.WSS_LINEAR_PUBLIC_URLS.get("bybit_perpetual_main"), url)
 
-        url = utils.wss_url("bybit_perpetual_main")
-        self.assertEqual(CONSTANTS.WSS_URLS.get("bybit_perpetual_main"), url)
+        url = utils.wss_linear_public_url("bybit_perpetual_main")
+        self.assertEqual(CONSTANTS.WSS_LINEAR_PUBLIC_URLS.get("bybit_perpetual_main"), url)
 
-        url = utils.wss_url("bybit_perpetual_testnet")
-        self.assertEqual(CONSTANTS.WSS_URLS.get("bybit_perpetual_testnet"), url)
+        url = utils.wss_linear_public_url("bybit_perpetual_testnet")
+        self.assertEqual(CONSTANTS.WSS_LINEAR_PUBLIC_URLS.get("bybit_perpetual_testnet"), url)
+
+    def test_wss_linear_private_url(self):
+        url = utils.wss_linear_private_url(None)
+        self.assertEqual(CONSTANTS.WSS_LINEAR_PRIVATE_URLS.get("bybit_perpetual_main"), url)
+
+        url = utils.wss_linear_private_url("bybit_perpetual_main")
+        self.assertEqual(CONSTANTS.WSS_LINEAR_PRIVATE_URLS.get("bybit_perpetual_main"), url)
+
+        url = utils.wss_linear_private_url("bybit_perpetual_testnet")
+        self.assertEqual(CONSTANTS.WSS_LINEAR_PRIVATE_URLS.get("bybit_perpetual_testnet"), url)
+
+    def test_wss_non_linear_public_url(self):
+        url = utils.wss_non_linear_public_url(None)
+        self.assertEqual(CONSTANTS.WSS_NON_LINEAR_PUBLIC_URLS.get("bybit_perpetual_main"), url)
+
+        url = utils.wss_non_linear_public_url("bybit_perpetual_main")
+        self.assertEqual(CONSTANTS.WSS_NON_LINEAR_PUBLIC_URLS.get("bybit_perpetual_main"), url)
+
+        url = utils.wss_non_linear_public_url("bybit_perpetual_testnet")
+        self.assertEqual(CONSTANTS.WSS_NON_LINEAR_PUBLIC_URLS.get("bybit_perpetual_testnet"), url)
+
+    def test_wss_non_linear_private_url(self):
+        url = utils.wss_non_linear_private_url(None)
+        self.assertEqual(CONSTANTS.WSS_NON_LINEAR_PRIVATE_URLS.get("bybit_perpetual_main"), url)
+
+        url = utils.wss_non_linear_private_url("bybit_perpetual_main")
+        self.assertEqual(CONSTANTS.WSS_NON_LINEAR_PRIVATE_URLS.get("bybit_perpetual_main"), url)
+
+        url = utils.wss_non_linear_private_url("bybit_perpetual_testnet")
+        self.assertEqual(CONSTANTS.WSS_NON_LINEAR_PRIVATE_URLS.get("bybit_perpetual_testnet"), url)
 
     def test_get_next_funding_timestamp(self):
         # Simulate 01:00 UTC


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Added logic in order book data stream and user data stream to connect to both the inverse perpetual and the usdt perpetual markets when registering to events.


**Tests performed by the developer**:
Unit tests


**Tips for QA testing**:
This PR does not require testing from QA. The testing will be done in the epic PR.

