### PR TITLE
feat/ filter non-linear markets in Bybit Perpetual connector

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -88,7 +88,8 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         instrument["name"]: f"{instrument['base_currency']}-{instrument['quote_currency']}"
                         for instrument in resp_json["result"]
                         if (instrument["status"] == "Trading"
-                            and instrument["name"] == f"{instrument['base_currency']}{instrument['quote_currency']}")
+                            and instrument["name"] == f"{instrument['base_currency']}{instrument['quote_currency']}"
+                            and bybit_perpetual_utils.is_linear_perpetual(f"{instrument['base_currency']}-{instrument['quote_currency']}"))
                     }
 
     @classmethod

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
@@ -112,6 +112,31 @@ class BybitPerpetualAPIOrderBookDataSourceTests(TestCase):
                     }
                 },
                 {
+                    "name": "BTCUSD",
+                    "alias": "BTCUSD",
+                    "status": "Trading",
+                    "base_currency": "BTC",
+                    "quote_currency": "USD",
+                    "price_scale": 2,
+                    "taker_fee": "0.00075",
+                    "maker_fee": "-0.00025",
+                    "leverage_filter": {
+                        "min_leverage": 1,
+                        "max_leverage": 100,
+                        "leverage_step": "0.01"
+                    },
+                    "price_filter": {
+                        "min_price": "0.5",
+                        "max_price": "999999.5",
+                        "tick_size": "0.5"
+                    },
+                    "lot_size_filter": {
+                        "max_trading_qty": 1000000,
+                        "min_trading_qty": 1,
+                        "qty_step": 1
+                    }
+                },
+                {
                     "name": "BTCUSDT",
                     "alias": "BTCUSDT",
                     "status": "Trading",
@@ -205,7 +230,32 @@ class BybitPerpetualAPIOrderBookDataSourceTests(TestCase):
                         "min_trading_qty": 0.001,
                         "qty_step": 0.001
                     }
-                }
+                },
+                {
+                    "name": "BTCUSD",
+                    "alias": "BTCUSD",
+                    "status": "Trading",
+                    "base_currency": "BTC",
+                    "quote_currency": "USD",
+                    "price_scale": 2,
+                    "taker_fee": "0.00075",
+                    "maker_fee": "-0.00025",
+                    "leverage_filter": {
+                        "min_leverage": 1,
+                        "max_leverage": 100,
+                        "leverage_step": "0.01"
+                    },
+                    "price_filter": {
+                        "min_price": "0.5",
+                        "max_price": "999999.5",
+                        "tick_size": "0.5"
+                    },
+                    "lot_size_filter": {
+                        "max_trading_qty": 1000000,
+                        "min_trading_qty": 1,
+                        "qty_step": 1
+                    }
+                },
             ],
             "time_now": "1615801223.589808"
         }


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
As per discussed, until the Perpetual strategies are reviewed and modified to handle inverse perpetual markets, we will ensure that users will not be able to trade on any inverse markets.
With this PR, trading pairs on the Bybit Inverse Perpetual market will not be supported.


**Tests performed by the developer**:
Added an additional condition when fetching supported trading pairs.
Modified relevant unit tests.

**Tips for QA testing**:
None needed at this point in time.

