### PR TITLE
Feat/hanging orders tracker for pure mm

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -26,7 +26,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         object _inventory_target_base_pct
         object _inventory_range_multiplier
         bint _hanging_orders_enabled
-        object _hanging_orders_cancel_pct
+        object _hanging_orders_tracker
         bint _order_optimization_enabled
         object _ask_order_optimization_depth
         object _bid_order_optimization_depth
@@ -48,12 +48,10 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         bint _all_markets_ready
         int _filled_buys_balance
         int _filled_sells_balance
-        list _hanging_order_ids
         double _last_timestamp
         double _status_report_interval
         int64_t _logging_options
         object _last_own_trade_price
-        list _hanging_orders_to_recreate
 
     cdef object c_get_mid_price(self)
     cdef object c_create_base_proposal(self)
@@ -71,10 +69,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
     cdef c_apply_add_transaction_costs(self, object proposal)
     cdef bint c_is_within_tolerance(self, list current_prices, list proposal_prices)
     cdef c_cancel_active_orders(self, object proposal)
-    cdef c_cancel_hanging_orders(self)
     cdef c_cancel_orders_below_min_spread(self)
     cdef c_cancel_active_orders_on_max_age_limit(self)
     cdef bint c_to_create_orders(self, object proposal)
     cdef c_execute_orders_proposal(self, object proposal)
     cdef set_timers(self)
-    cdef c_recreate_hanging_order(self, object order)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -32,6 +32,10 @@ from .data_types import (
 )
 from .pure_market_making_order_tracker import PureMarketMakingOrderTracker
 
+from hummingbot.strategy.hanging_orders_tracker import (
+    CreatedPairOfOrders,
+    HangingOrdersTracker)
+
 from hummingbot.strategy.asset_price_delegate cimport AssetPriceDelegate
 from hummingbot.strategy.asset_price_delegate import AssetPriceDelegate
 from .inventory_skew_calculator cimport c_calculate_bid_ask_ratios_from_base_asset_ratio
@@ -117,7 +121,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         self._inventory_target_base_pct = inventory_target_base_pct
         self._inventory_range_multiplier = inventory_range_multiplier
         self._hanging_orders_enabled = hanging_orders_enabled
-        self._hanging_orders_cancel_pct = hanging_orders_cancel_pct
+        self._hanging_orders_tracker = HangingOrdersTracker(self, hanging_orders_cancel_pct)
         self._order_optimization_enabled = order_optimization_enabled
         self._ask_order_optimization_depth = ask_order_optimization_depth
         self._bid_order_optimization_depth = bid_order_optimization_depth
@@ -135,14 +139,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
         self._cancel_timestamp = 0
         self._create_timestamp = 0
-        self._hanging_orders_to_recreate = []
         self._limit_order_type = self._market_info.market.get_maker_order_type()
         if take_if_crossed:
             self._limit_order_type = OrderType.LIMIT
         self._all_markets_ready = False
         self._filled_buys_balance = 0
         self._filled_sells_balance = 0
-        self._hanging_order_ids = []
         self._logging_options = logging_options
         self._last_timestamp = 0
         self._status_report_interval = status_report_interval
@@ -273,11 +275,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
     @property
     def hanging_orders_cancel_pct(self) -> Decimal:
-        return self._hanging_orders_cancel_pct
+        return self._hanging_orders_tracker._hanging_orders_cancel_pct
 
     @hanging_orders_cancel_pct.setter
     def hanging_orders_cancel_pct(self, value: Decimal):
-        self._hanging_orders_cancel_pct = value
+        self._hanging_orders_tracker._hanging_orders_cancel_pct = value
 
     @property
     def bid_spread(self) -> Decimal:
@@ -400,7 +402,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
     @property
     def hanging_order_ids(self) -> List[str]:
-        return self._hanging_order_ids
+        return [o.order_id for o in self._hanging_orders_tracker.strategy_current_hanging_orders]
 
     @property
     def market_info_to_active_orders(self) -> Dict[MarketTradingPairTuple, List[LimitOrder]]:
@@ -422,7 +424,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
     @property
     def active_non_hanging_orders(self) -> List[LimitOrder]:
-        orders = [o for o in self.active_orders if o.client_order_id not in self._hanging_order_ids]
+        orders = [o for o in self.active_orders if not self._hanging_orders_tracker.is_order_id_in_hanging_orders(o.client_order_id)]
         return orders
 
     @property
@@ -432,6 +434,10 @@ cdef class PureMarketMakingStrategy(StrategyBase):
     @logging_options.setter
     def logging_options(self, int64_t logging_options):
         self._logging_options = logging_options
+
+    @property
+    def hanging_orders_tracker(self):
+        return self._hanging_orders_tracker
 
     @property
     def asset_price_delegate(self) -> AssetPriceDelegate:
@@ -529,17 +535,19 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         return df
 
     def active_orders_df(self) -> pd.DataFrame:
+        market, trading_pair, base_asset, quote_asset = self._market_info
         price = self.get_price()
         active_orders = self.active_orders
-        no_sells = len([o for o in active_orders if not o.is_buy and o.client_order_id not in self._hanging_order_ids])
+        no_sells = len([o for o in active_orders if not o.is_buy and o.client_order_id and
+                        not self._hanging_orders_tracker.is_order_id_in_hanging_orders(o.client_order_id)])
         active_orders.sort(key=lambda x: x.price, reverse=True)
         columns = ["Level", "Type", "Price", "Spread", "Amount (Orig)", "Amount (Adj)", "Age"]
         data = []
         lvl_buy, lvl_sell = 0, 0
         for idx in range(0, len(active_orders)):
             order = active_orders[idx]
-            level = None
-            if order.client_order_id not in self._hanging_order_ids:
+            is_hanging_order = self._hanging_orders_tracker.is_order_id_in_hanging_orders(order.client_order_id)
+            if not is_hanging_order:
                 if order.is_buy:
                     level = lvl_buy + 1
                     lvl_buy += 1
@@ -552,9 +560,14 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             if "//" not in order.client_order_id:
                 age = pd.Timestamp(int(time.time()) - int(order.client_order_id[-16:])/1e6,
                                    unit='s').strftime('%H:%M:%S')
-            amount_orig = "" if level is None else self._order_amount + ((level - 1) * self._order_level_amount)
+
+            if is_hanging_order:
+                amount_orig = self._order_amount + ((level - 1) * self._order_level_amount)
+                level = "hang"
+            else:
+                amount_orig = ""
             data.append([
-                "hang" if order.client_order_id in self._hanging_order_ids else level,
+                level,
                 "buy" if order.is_buy else "sell",
                 float(order.price),
                 f"{spread:.2%}",
@@ -649,14 +662,24 @@ cdef class PureMarketMakingStrategy(StrategyBase):
     cdef c_start(self, Clock clock, double timestamp):
         StrategyBase.c_start(self, clock, timestamp)
         self._last_timestamp = timestamp
+
+        self._hanging_orders_tracker.register_events(self.active_markets)
+
         # start tracking any restored limit order
         restored_order_ids = self.c_track_restored_orders(self.market_info)
         # make restored order hanging orders
         for order_id in restored_order_ids:
-            self._hanging_order_ids.append(order_id)
+            order = next(o for o in self.market_info.market.limit_orders if o.client_order_id == order_id)
+            if order:
+                self._hanging_orders_tracker.add_order(order)
+
+    cdef c_stop(self, Clock clock):
+        self._hanging_orders_tracker.unregister_events(self.active_markets)
+        StrategyBase.c_stop(self, clock)
 
     cdef c_tick(self, double timestamp):
         StrategyBase.c_tick(self, timestamp)
+
         cdef:
             int64_t current_tick = <int64_t>(timestamp // self._status_report_interval)
             int64_t last_tick = <int64_t>(self._last_timestamp // self._status_report_interval)
@@ -696,9 +719,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
                 if not self._take_if_crossed:
                     self.c_filter_out_takers(proposal)
+
+            self._hanging_orders_tracker.process_tick()
+
             self.c_cancel_active_orders_on_max_age_limit()
             self.c_cancel_active_orders(proposal)
-            self.c_cancel_hanging_orders()
             self.c_cancel_orders_below_min_spread()
             if self.c_to_create_orders(proposal):
                 self.c_execute_orders_proposal(proposal)
@@ -1003,7 +1028,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
         if self._hanging_orders_enabled:
             # If the filled order is a hanging order, do nothing
-            if order_id in self._hanging_order_ids:
+            if order_id in self.hanging_order_ids:
                 self.log_with_clock(
                     logging.INFO,
                     f"({self.trading_pair}) Hanging maker buy order {order_id} "
@@ -1019,10 +1044,6 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         # delay order creation by filled_order_dalay (in seconds)
         self._create_timestamp = self._current_timestamp + self._filled_order_delay
         self._cancel_timestamp = min(self._cancel_timestamp, self._create_timestamp)
-
-        if self._hanging_orders_enabled:
-            for other_order_id in active_sell_ids:
-                self._hanging_order_ids.append(other_order_id)
 
         self._filled_buys_balance += 1
         self._last_own_trade_price = limit_order_record.price
@@ -1047,7 +1068,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         active_buy_ids = [x.client_order_id for x in self.active_orders if x.is_buy]
         if self._hanging_orders_enabled:
             # If the filled order is a hanging order, do nothing
-            if order_id in self._hanging_order_ids:
+            if order_id in self.hanging_order_ids:
                 self.log_with_clock(
                     logging.INFO,
                     f"({self.trading_pair}) Hanging maker sell order {order_id} "
@@ -1063,10 +1084,6 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         # delay order creation by filled_order_dalay (in seconds)
         self._create_timestamp = self._current_timestamp + self._filled_order_delay
         self._cancel_timestamp = min(self._cancel_timestamp, self._create_timestamp)
-
-        if self._hanging_orders_enabled:
-            for other_order_id in active_buy_ids:
-                self._hanging_order_ids.append(other_order_id)
 
         self._filled_sells_balance += 1
         self._last_own_trade_price = limit_order_record.price
@@ -1099,6 +1116,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         """
         cdef:
             list active_orders = self.active_non_hanging_orders
+
         if active_orders and any(order_age(o) > self._max_order_age for o in active_orders):
             for order in active_orders:
                 self.c_cancel_order(self._market_info, order.client_order_id)
@@ -1121,82 +1139,26 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             bint to_defer_canceling = False
         if len(active_orders) == 0:
             return
-        if proposal is not None and self._order_refresh_tolerance_pct >= 0:
+        if proposal is not None and \
+                self._order_refresh_tolerance_pct >= 0:
 
             active_buy_prices = [Decimal(str(o.price)) for o in active_orders if o.is_buy]
             active_sell_prices = [Decimal(str(o.price)) for o in active_orders if not o.is_buy]
             proposal_buys = [buy.price for buy in proposal.buys]
             proposal_sells = [sell.price for sell in proposal.sells]
+
             if self.c_is_within_tolerance(active_buy_prices, proposal_buys) and \
                     self.c_is_within_tolerance(active_sell_prices, proposal_sells):
                 to_defer_canceling = True
 
         if not to_defer_canceling:
-            for order in active_orders:
-                self.c_cancel_order(self._market_info, order.client_order_id)
+            self._hanging_orders_tracker.update_strategy_orders_with_equivalent_orders()
+            for order in self.active_non_hanging_orders:
+                # If is about to be added to hanging_orders then don't cancel
+                if not self._hanging_orders_tracker.is_potential_hanging_order(order):
+                    self.c_cancel_order(self._market_info, order.client_order_id)
         # else:
         #     self.set_timers()
-
-    cdef c_cancel_hanging_orders(self):
-        if not global_config_map.get("0x_active_cancels").value:
-            if ((self._market_info.market.name in self.RADAR_RELAY_TYPE_EXCHANGES) or
-                    (self._market_info.market.name == "bamboo_relay" and not self._market_info.market.use_coordinator)):
-                return
-
-        cdef:
-            object price = self.get_price()
-            list active_orders = self.active_orders
-            list orders
-            LimitOrder order
-        for h_order_id in self._hanging_order_ids:
-            orders = [o for o in active_orders if o.client_order_id == h_order_id]
-            if orders and price > 0:
-                order = orders[0]
-                if abs(order.price - price)/price >= self._hanging_orders_cancel_pct:
-                    self.c_cancel_order(self._market_info, order.client_order_id)
-                # hanging orders older than max age are canceled and marked to be recreated.
-                elif order_age(order) > self._max_order_age:
-                    self.c_cancel_order(self._market_info, order.client_order_id)
-                    self._hanging_order_ids.remove(order.client_order_id)
-                    self._hanging_orders_to_recreate.append(order)
-
-    cdef c_did_cancel_order(self, object cancelled_event):
-        cdef:
-            list orders = [o for o in self._hanging_orders_to_recreate if o.client_order_id == cancelled_event.order_id]
-        if orders:
-            self.c_recreate_hanging_order(orders[0])
-
-    @property
-    def hanging_orders_to_recreate(self) -> List[LimitOrder]:
-        return self._hanging_orders_to_recreate
-
-    cdef c_recreate_hanging_order(self, object order):
-        """
-        To recreate hanging orders which are older than max order age limit
-        :param order: The hanging order to be recreated.
-        """
-        cdef:
-            str order_id
-            LimitOrder hanging_order = order
-        if self._logging_options:
-            self.logger().info(f"Recreating hanging order: {hanging_order.client_order_id} ")
-        if order.is_buy:
-            order_id = self.c_buy_with_specific_market(
-                self._market_info,
-                hanging_order.quantity,
-                order_type=self._limit_order_type,
-                price=hanging_order.price
-            )
-        else:
-            order_id = self.c_sell_with_specific_market(
-                self._market_info,
-                hanging_order.quantity,
-                order_type=self._limit_order_type,
-                price=hanging_order.price
-            )
-        self.logger().info(f"New hanging order: {order_id} ")
-        self._hanging_orders_to_recreate.remove(order)
-        self._hanging_order_ids.append(order_id)
 
     # Cancel Non-Hanging, Active Orders if Spreads are below minimum_spread
     cdef c_cancel_orders_below_min_spread(self):
@@ -1204,7 +1166,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             list active_orders = self.market_info_to_active_orders.get(self._market_info, [])
             object price = self.get_price()
         active_orders = [order for order in active_orders
-                         if order.client_order_id not in self._hanging_order_ids]
+                         if order.client_order_id not in self.hanging_order_ids]
         for order in active_orders:
             negation = -1 if order.is_buy else 1
             if (negation * (order.price - price) / price) < self._minimum_spread:
@@ -1214,9 +1176,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                 self.c_cancel_order(self._market_info, order.client_order_id)
 
     cdef bint c_to_create_orders(self, object proposal):
+        non_hanging_orders_non_cancelled = [o for o in self.active_non_hanging_orders if not
+                                            self._hanging_orders_tracker.is_potential_hanging_order(o)]
         return self._create_timestamp < self._current_timestamp and \
             proposal is not None and \
-            len(self.active_non_hanging_orders) == 0
+            len(non_hanging_orders_non_cancelled) == 0
 
     cdef c_execute_orders_proposal(self, object proposal):
         cdef:
@@ -1227,6 +1191,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                                          else NaN)
             str bid_order_id, ask_order_id
             bint orders_created = False
+        # Number of pair of orders to track for hanging orders
+        number_of_pairs = min((len(proposal.buys), len(proposal.sells))) if self._hanging_orders_enabled else 0
 
         if len(proposal.buys) > 0:
             if self._logging_options & self.OPTION_LOG_CREATE_ORDER:
@@ -1237,7 +1203,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                     f"({self.trading_pair}) Creating {len(proposal.buys)} bid orders "
                     f"at (Size, Price): {price_quote_str}"
                 )
-            for buy in proposal.buys:
+            for idx, buy in enumerate(proposal.buys):
                 bid_order_id = self.c_buy_with_specific_market(
                     self._market_info,
                     buy.size,
@@ -1246,6 +1212,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                     expiration_seconds=expiration_seconds
                 )
                 orders_created = True
+                if idx < number_of_pairs:
+                    order = next((o for o in self.active_orders if o.client_order_id == bid_order_id))
+                    if order:
+                        self._hanging_orders_tracker.add_current_pairs_of_proposal_orders_executed_by_strategy(
+                            CreatedPairOfOrders(order, None))
         if len(proposal.sells) > 0:
             if self._logging_options & self.OPTION_LOG_CREATE_ORDER:
                 price_quote_str = [f"{sell.size.normalize()} {self.base_asset}, "
@@ -1255,7 +1226,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                     f"({self.trading_pair}) Creating {len(proposal.sells)} ask "
                     f"orders at (Size, Price): {price_quote_str}"
                 )
-            for sell in proposal.sells:
+            for idx, sell in enumerate(proposal.sells):
                 ask_order_id = self.c_sell_with_specific_market(
                     self._market_info,
                     sell.size,
@@ -1264,6 +1235,10 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                     expiration_seconds=expiration_seconds
                 )
                 orders_created = True
+                if idx < number_of_pairs:
+                    order = next((o for o in self.active_orders if o.client_order_id == ask_order_id))
+                    if order:
+                        self._hanging_orders_tracker.current_created_pairs_of_orders[idx].sell_order = order
         if orders_created:
             self.set_timers()
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -561,11 +561,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                 age = pd.Timestamp(int(time.time()) - int(order.client_order_id[-16:])/1e6,
                                    unit='s').strftime('%H:%M:%S')
 
-            if is_hanging_order:
+            if not is_hanging_order:
                 amount_orig = self._order_amount + ((level - 1) * self._order_level_amount)
-                level = "hang"
+                level = ""
             else:
                 amount_orig = ""
+                level = "hang"
             data.append([
                 level,
                 "buy" if order.is_buy else "sell",

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -614,7 +614,7 @@ class PMMUnitTest(unittest.TestCase):
 
         # Bid is filled and due to delay is not replenished immediately
         # Ask order is now hanging but is active
-        self.clock.backtest_til(self.start_timestamp + 2)
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
         self.assertEqual(1, len(self.order_fill_logger.event_log))
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
@@ -623,12 +623,12 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(hanging_sell.client_order_id, strategy.hanging_order_ids[0])
 
         # At order_refresh_time, hanging order remains.
-        self.clock.backtest_til(self.start_timestamp + 5)
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 1)
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
-        self.clock.backtest_til(self.start_timestamp + 10)
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 2)
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(2, len(strategy.active_sells))
 
@@ -649,14 +649,15 @@ class PMMUnitTest(unittest.TestCase):
         # be calculated. We manually add the order to to_recreate_hanging_orders and trigger order cancel event here to
         # simulate the recreate.
         strategy = self.one_level_strategy
+        strategy.hanging_orders_enabled = True
+
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
 
-        strategy.hanging_orders_enabled = True
         self.simulate_maker_market_trade(False, 100, 98.9)
-        self.clock.backtest_til(self.start_timestamp + 6)
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
         self.assertEqual(1, len(self.order_fill_logger.event_log))
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
@@ -664,13 +665,12 @@ class PMMUnitTest(unittest.TestCase):
         hanging_sell: LimitOrder = strategy.active_sells[0]
         self.assertEqual(hanging_sell.client_order_id, strategy.hanging_order_ids[0])
 
-        strategy.hanging_orders_to_recreate.append(hanging_sell)
         self.market.trigger_event(MarketEvent.OrderCancelled, OrderCancelledEvent(
             self.market.current_timestamp,
             hanging_sell.client_order_id
         ))
-        self.clock.backtest_til(self.start_timestamp + 7)
-        self.assertEqual(2, len(strategy.active_sells))
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 1)
+        self.assertEqual(1, len(strategy.active_sells))
         new_hang: LimitOrder = [o for o in strategy.active_sells if o.price == hanging_sell.price
                                 and o.quantity == hanging_sell.quantity]
 
@@ -690,22 +690,25 @@ class PMMUnitTest(unittest.TestCase):
         self.simulate_maker_market_trade(False, 100, 98.9)
 
         # Bid is filled and due to delay is not replenished immediately
-        # Ask order is now hanging but is active
-        self.clock.backtest_til(self.start_timestamp + 2)
+        # Ask order is active
+        # Hanging orders are not yet created
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time / 2)
         self.assertEqual(1, len(self.order_fill_logger.event_log))
         self.assertEqual(2, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
-        self.assertEqual(3, len(strategy.hanging_order_ids))
+        self.assertEqual(0, len(strategy.hanging_order_ids))
 
-        # At order_refresh_time, hanging order remains.
-        self.clock.backtest_til(self.start_timestamp + 5)
+        # At order_refresh_time, hanging orders are created, active orders are cancelled
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
+
         self.assertEqual(0, len(strategy.active_buys))
-        self.assertEqual(3, len(strategy.active_sells))
+        self.assertEqual(1, len(strategy.active_sells))
+        self.assertEqual(1, len(strategy.hanging_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
-        self.clock.backtest_til(self.start_timestamp + 10)
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
         self.assertEqual(3, len(strategy.active_buys))
-        self.assertEqual(6, len(strategy.active_sells))
+        self.assertEqual(4, len(strategy.active_sells))
 
         self.assertTrue(all(id in (order.client_order_id for order in strategy.active_sells)
                             for id in strategy.hanging_order_ids))
@@ -713,7 +716,7 @@ class PMMUnitTest(unittest.TestCase):
         simulate_order_book_widening(self.book_data.order_book, 80, 100)
         # As book bids moving lower, the ask hanging order price spread is now more than the hanging_orders_cancel_pct
         # Hanging order is canceled and removed from the active list
-        self.clock.backtest_til(self.start_timestamp + 11 * self.clock_tick_size)
+        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + strategy.filled_order_delay + 1)
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
         self.assertFalse(any(o.client_order_id in strategy.hanging_order_ids for o in strategy.active_sells))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Replacement of an old hanging orders tracker and integration of a new hanging orders tracker as in the Avellaneda-Stoikov strategy

**Tests performed by the developer**:

Already existing unit tests were modified to account for a different functioning of the new hanging orders tracker, and verified.

**Tips for QA testing**:

Run the unit tests. Unlike before, hanging orders are created on refresh, not immediately.
