### PR TITLE
fix/ BybitPerpetual not tracking order and positions correctly

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -108,6 +108,10 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
             domain=domain)
         self._user_stream_tracker = BybitPerpetualUserStreamTracker(self._auth, domain=domain)
 
+        # Set Position Mode depending on the Perpetual Market
+        if not self._domain:
+            self.set_position_mode(PositionMode.HEDGE)
+
         # Tasks
         self._funding_fee_polling_task = None
         self._user_funding_fee_polling_task = None
@@ -894,7 +898,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
         """
         ex_trading_pair = position_msg.get("symbol")
         hb_trading_pair = symbol_trading_pair_map.get(ex_trading_pair)
-        position_side = PositionSide.LONG if position_msg.get("side") == "buy" else PositionSide.SHORT
+        position_side = PositionSide.LONG if position_msg.get("side") == "Buy" else PositionSide.SHORT
         position_value = Decimal(str(position_msg.get("position_value")))
         entry_price = Decimal(str(position_msg.get("entry_price")))
         amount = Decimal(str(position_msg.get("size")))
@@ -1100,7 +1104,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
             data = position
             ex_trading_pair = data.get("symbol")
             hb_trading_pair = symbol_trading_pair_map.get(ex_trading_pair)
-            position_side = PositionSide.LONG if data.get("side") == "buy" else PositionSide.SHORT
+            position_side = PositionSide.LONG if data.get("side") == "Buy" else PositionSide.SHORT
             unrealized_pnl = Decimal(str(data.get("unrealised_pnl")))
             entry_price = Decimal(str(data.get("entry_price")))
             amount = Decimal(str(data.get("size")))
@@ -1154,26 +1158,6 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
 
     def set_leverage(self, trading_pair: str, leverage: int):
         safe_ensure_future(self._set_leverage(trading_pair=trading_pair, leverage=leverage))
-
-    # async def _get_position_mode(self):
-    #     if self._position_mode is None:
-    #         if all(bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
-    #             # Currently Linear Perpetual defaults to HEDGE mode
-    #             mode = PositionMode.HEDGE
-    #         else:
-    #             mode = PositionMode.ONEWAY
-    #         self._position_mode = mode
-    #     return self._position_mode
-
-    # async def _set_position_mode(self, position_mode: PositionMode):
-    #     initial_mode = await self._get_position_mode()
-    #     if position_mode != initial_mode:
-    #         params = {
-    #         }
-    #         self._position_mode =
-
-    # def set_position_mode(self, position_mode: PositionMode):
-    #     safe_ensure_future(self._set_position_mode(position_mode))
 
     def get_funding_info(self, trading_pair: str) -> Optional[FundingInfo]:
         return asyncio.get_event_loop().run_until_complete(

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -197,23 +197,16 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
         return self._shared_client
 
     def supported_position_modes(self) -> List[PositionMode]:
-        if self._domain and self._domain == "bybit_perpetual_testnet":
-            if all(bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
-                return [PositionMode.HEDGE]
-            elif all(not bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
-                # Support for both ONE-WAY and HEDGE positions modes is only available in Testnet Inverse Perps Markets.
-                return [PositionMode.ONEWAY, PositionMode.HEDGE]
-            else:
-                return []
-        else:  # Mainnet
-            if all(bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
-                return [PositionMode.HEDGE]
-            elif all(not bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
-                return [PositionMode.ONEWAY]
-            else:
-                self.logger().warning("Currently there is no support for both linear and non-linear markets concurrently. "
-                                      "Please start another Hummingbot instance.")
-                return []
+        # Linear Perpetuals ONLY supports Hedge mode and Non-linear perpetuals ONLY supports One-way
+        if all(bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
+            return [PositionMode.HEDGE]
+        elif all(not bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
+            # As of ByBit API v2, we only support ONEWAy mode for non-linear perpetuals
+            return [PositionMode.ONEWAY]
+        else:
+            self.logger().warning("Currently there is no support for both linear and non-linear markets concurrently. "
+                                  "Please start another Hummingbot instance.")
+            return []
 
     async def start_network(self):
         self._order_book_tracker.start()

--- a/hummingbot/connector/perpetual_trading.py
+++ b/hummingbot/connector/perpetual_trading.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from decimal import Decimal
 from typing import Dict, List, Optional
 from hummingbot.core.event.events import PositionMode, FundingInfo, PositionSide
@@ -17,7 +18,7 @@ class PerpetualTrading:
     def __init__(self):
         self._account_positions: Dict[str, Position] = {}
         self._position_mode: PositionMode = PositionMode.ONEWAY
-        self._leverage: Dict[str, int] = {}
+        self._leverage: Dict[str, int] = defaultdict(lambda: 1)
         self._funding_info: Dict[str, FundingInfo] = {}
         self._funding_payment_span: List[int] = [0, 0]
 

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -1712,28 +1712,14 @@ class BybitPerpetualDerivativeTests(TestCase):
                                                                 bybit_perpetual_secret_key='testSecretKey',
                                                                 trading_pairs=["BTC-USD"],
                                                                 domain="bybit_perpetual_testnet")
-        mainnet_non_linear_connector = BybitPerpetualDerivative(bybit_perpetual_api_key='testApiKey',
-                                                                bybit_perpetual_secret_key='testSecretKey',
-                                                                trading_pairs=["BTC-USD"])
-        mainnet_linear_connector = BybitPerpetualDerivative(bybit_perpetual_api_key='testApiKey',
-                                                            bybit_perpetual_secret_key='testSecretKey',
-                                                            trading_pairs=[self.trading_pair])
 
-        # Case 1: TESTNET Linear Perpetual
+        # Case 1: Linear Perpetual
         expected_result = [PositionMode.HEDGE]
         self.assertEqual(expected_result, self.connector.supported_position_modes())
 
-        # Case 2: TESTNET Non-Linear Perpetual
-        expected_result = [PositionMode.ONEWAY, PositionMode.HEDGE]
-        self.assertEqual(expected_result, testnet_non_linear_connector.supported_position_modes())
-
-        # Case 3: MAINNET Linear Perpetual
-        expected_result = [PositionMode.HEDGE]
-        self.assertEqual(expected_result, mainnet_linear_connector.supported_position_modes())
-
-        # Case 4: MAINNET Non-linear Perpetual
+        # Case 2: Non-Linear Perpetual
         expected_result = [PositionMode.ONEWAY]
-        self.assertEqual(expected_result, mainnet_non_linear_connector.supported_position_modes())
+        self.assertEqual(expected_result, testnet_non_linear_connector.supported_position_modes())
 
     @patch("hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_next_funding_timestamp")
     def test_tick_funding_fee_poll_notifier_set(self, mock_time):

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -1708,8 +1708,32 @@ class BybitPerpetualDerivativeTests(TestCase):
                                "BTC-USDT")
 
     def test_supported_position_modes(self):
-        expected_result = [PositionMode.ONEWAY, PositionMode.HEDGE]
+        testnet_non_linear_connector = BybitPerpetualDerivative(bybit_perpetual_api_key='testApiKey',
+                                                                bybit_perpetual_secret_key='testSecretKey',
+                                                                trading_pairs=["BTC-USD"],
+                                                                domain="bybit_perpetual_testnet")
+        mainnet_non_linear_connector = BybitPerpetualDerivative(bybit_perpetual_api_key='testApiKey',
+                                                                bybit_perpetual_secret_key='testSecretKey',
+                                                                trading_pairs=["BTC-USD"])
+        mainnet_linear_connector = BybitPerpetualDerivative(bybit_perpetual_api_key='testApiKey',
+                                                            bybit_perpetual_secret_key='testSecretKey',
+                                                            trading_pairs=[self.trading_pair])
+
+        # Case 1: TESTNET Linear Perpetual
+        expected_result = [PositionMode.HEDGE]
         self.assertEqual(expected_result, self.connector.supported_position_modes())
+
+        # Case 2: TESTNET Non-Linear Perpetual
+        expected_result = [PositionMode.ONEWAY, PositionMode.HEDGE]
+        self.assertEqual(expected_result, testnet_non_linear_connector.supported_position_modes())
+
+        # Case 3: MAINNET Linear Perpetual
+        expected_result = [PositionMode.HEDGE]
+        self.assertEqual(expected_result, mainnet_linear_connector.supported_position_modes())
+
+        # Case 4: MAINNET Non-linear Perpetual
+        expected_result = [PositionMode.ONEWAY]
+        self.assertEqual(expected_result, mainnet_non_linear_connector.supported_position_modes())
 
     @patch("hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_next_funding_timestamp")
     def test_tick_funding_fee_poll_notifier_set(self, mock_time):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes issue reported by @rxlxrxsx and @RC-13 regarding positions not being tracked correctly. 
Additionally, include a default leverage of `1` when first initialising the connector.

Supported Position Mode is as follows:
1. Linear Perpetuals: Only Hedge mode
2. Non-linear Perpetuals: Only One-way mode

**Tests performed by the developer**:
Update `_process_account_position_event()` and `_update_positions()` to use the correct comparison to determine the side of the order/position.
Updated `supported_position_modes()` to reflect actual mainnet and testnet environments.
Update the relevant unit tests.

**Tips for QA testing**:
None needed in this PR. All testing to be performed in `epic/bybit_connector` PR.

