### PR TITLE
fix / ndax default fees

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_utils.py
+++ b/hummingbot/connector/exchange/ndax/ndax_utils.py
@@ -11,7 +11,7 @@ EXAMPLE_PAIR = "BTC-CAD"
 
 # NDAX fees: https://ndax.io/fees
 # Fees have to be expressed as percent value
-DEFAULT_FEES = [2, 2]
+DEFAULT_FEES = [0.2, 0.2]
 
 
 # USE_ETHEREUM_WALLET not required because default value is false

--- a/hummingbot/connector/exchange/ndax/ndax_utils.py
+++ b/hummingbot/connector/exchange/ndax/ndax_utils.py
@@ -68,7 +68,7 @@ KEYS = {
 OTHER_DOMAINS = ["ndax_testnet"]
 OTHER_DOMAINS_PARAMETER = {"ndax_testnet": "ndax_testnet"}
 OTHER_DOMAINS_EXAMPLE_PAIR = {"ndax_testnet": "BTC-CAD"}
-OTHER_DOMAINS_DEFAULT_FEES = {"ndax_testnet": [2, 2]}
+OTHER_DOMAINS_DEFAULT_FEES = {"ndax_testnet": [0.2, 0.2]}
 OTHER_DOMAINS_KEYS = {
     "ndax_testnet": {
         "ndax_testnet_uid":

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -378,7 +378,7 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(inflight_order.order_type, fill_event.order_type)
         self.assertEqual(Decimal(35000), fill_event.price)
         self.assertEqual(Decimal(1), fill_event.amount)
-        self.assertEqual(Decimal("0.02"), fill_event.trade_fee.percent)
+        self.assertEqual(Decimal("0.002"), fill_event.trade_fee.percent)
         self.assertEqual(0, len(fill_event.trade_fee.flat_fees))
         self.assertEqual("213", fill_event.exchange_trade_id)
         buy_event = self.exchange.event_logs[1]
@@ -451,7 +451,7 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(inflight_order.order_type, fill_event.order_type)
         self.assertEqual(Decimal(35000), fill_event.price)
         self.assertEqual(Decimal(1), fill_event.amount)
-        self.assertEqual(Decimal("0.02"), fill_event.trade_fee.percent)
+        self.assertEqual(Decimal("0.002"), fill_event.trade_fee.percent)
         self.assertEqual(0, len(fill_event.trade_fee.flat_fees))
         self.assertEqual("213", fill_event.exchange_trade_id)
         buy_event = self.exchange.event_logs[1]

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -363,7 +363,7 @@ class NdaxExchangeTests(TestCase):
         self.assertIn(payload["TradeId"], inflight_order.trade_id_set)
         self.assertEqual(Decimal(1), inflight_order.executed_amount_base)
         self.assertEqual(Decimal(35000), inflight_order.executed_amount_quote)
-        self.assertEqual(inflight_order.executed_amount_base * Decimal("0.02"), inflight_order.fee_paid)
+        self.assertEqual(inflight_order.executed_amount_base * Decimal("0.002"), inflight_order.fee_paid)
 
         self.assertFalse(inflight_order.client_order_id in self.exchange.in_flight_orders)
         self.assertTrue(self._is_logged("INFO", f"The {inflight_order.trade_type.name} order "
@@ -435,7 +435,7 @@ class NdaxExchangeTests(TestCase):
         self.assertIn(payload["TradeId"], inflight_order.trade_id_set)
         self.assertEqual(Decimal(1), inflight_order.executed_amount_base)
         self.assertEqual(Decimal(35000), inflight_order.executed_amount_quote)
-        self.assertEqual(inflight_order.executed_amount_base * inflight_order.executed_amount_quote * Decimal("0.02"),
+        self.assertEqual(inflight_order.executed_amount_base * inflight_order.executed_amount_quote * Decimal("0.002"),
                          inflight_order.fee_paid)
 
         self.assertFalse(inflight_order.client_order_id in self.exchange.in_flight_orders)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Updated hardcoded default fees value to fix issue reported in https://github.com/CoinAlpha/hummingbot/issues/4118

**Tests performed by the developer**:

Ran NDAX connector unit tests `nosetests -v test_ndax_exchange.py`

**Tips for QA testing**:

1. Execute at least a single trade
2. Run `history` command
3. "Fees Paid" value should be equivalent to 0.2% denominated in quote asset
4. Perform steps 1-3 for both maker and taker trades