### PR TITLE
fix/update eth hash version requirement

### DIFF
--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -108,12 +108,12 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.4
-    - eth-hash==0.3.2
+    - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2
     - eth-typing==2.2.1
-    - eth-utils==1.8.4
+    - eth-utils>=1.8.4,<=1.10.0
     - ethsnarks-loopring==0.1.5
     - filelock==3.0.12
     - flake8==3.7.9

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -44,7 +44,7 @@ dependencies:
   - openblas=0.3.4=h9ac9557_1000
   - openssl=1.1.1k=h7f98852_0
   - pandas=1.2.1=py38h51da96c_0
-  - pip=21.1.2=pyhd8ed1ab_0
+  - pip
   - prompt_toolkit=3.0.3=py_0
   - pygments=2.5.2=py_0
   - pytables=3.6.1=py38h9f153d1_1
@@ -61,7 +61,7 @@ dependencies:
   - tzlocal=2.0.0=py38_0
   - ujson=1.35=py38h7b6447c_0
   - wcwidth=0.1.8=py_0
-  - wheel=0.34.2=py_1
+  - wheel
   - xz=5.2.4=h14c3975_1001
   - zlib=1.2.11=h516909a_1006
   - zstd=1.3.7=h0b5b093_0

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -108,7 +108,7 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.4
-    - eth-hash>=0.2.0,<=0.3.2
+    - eth-hash==0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -107,7 +107,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom>=1.0.3,<=1.0.4
+    - eth-bloom==1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -108,7 +108,7 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.3
-    - eth-hash==0.2.0
+    - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -107,7 +107,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom==1.0.3
+    - eth-bloom>=1.0.3,<=1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -94,12 +94,12 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.4
-    - eth-hash==0.3.2
+    - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2
     - eth-typing==2.2.1
-    - eth-utils==1.8.4
+    - eth-utils>=1.8.4,<=1.10.0
     - ethsnarks-loopring==0.1.5
     - filelock==3.0.12
     - flake8==3.7.9

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -93,7 +93,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom==1.0.3
+    - eth-bloom>=1.0.3,<=1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -93,7 +93,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom>=1.0.3,<=1.0.4
+    - eth-bloom==1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -29,7 +29,7 @@ dependencies:
   - numpy-base=1.18.5=py38hc3f5095_0
   - openssl=1.1.1k=h8ffe710_0
   - pandas=1.2.1=py38h4c96930_0
-  - pip=21.1.2=pyhd8ed1ab_0
+  - pip
   - prompt_toolkit=3.0.3=py_0
   - pygments=2.5.2=py_0
   - pytables=3.6.1=py38h26f9782_1
@@ -47,7 +47,7 @@ dependencies:
   - vc=14.2=hb210afc_5
   - vs2015_runtime=14.29.30037=h902a5da_5
   - wcwidth=0.1.8=pyh9f0ad1d_1
-  - wheel=0.34.2=py_1
+  - wheel
   - wincertstore=0.2=py38haa244fe_1006
   - xz=5.2.4=h2fa13f4_1002
   - zlib=1.2.11=h62dcd97_1010

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -94,7 +94,7 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.4
-    - eth-hash>=0.2.0,<=0.3.2
+    - eth-hash==0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -94,7 +94,7 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.3
-    - eth-hash==0.2.0
+    - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - openblas=0.3.4=hdc02c5d_1000
   - openssl=1.1.1k=h0d85af4_0
   - pandas=1.2.1=py38he9f00de_0
-  - pip=21.1.2=pyhd8ed1ab_0
+  - pip
   - prompt_toolkit=3.0.3=py_0
   - pygments=2.5.2=py_0
   - pytables=3.6.1=py38h6f8395a_1
@@ -49,7 +49,7 @@ dependencies:
   - tzlocal=2.0.0=py38_0
   - ujson=1.35=py38h1de35cc_0
   - wcwidth=0.1.8=py_0
-  - wheel=0.34.2=py_1
+  - wheel
   - xz=5.2.4=h1de35cc_1001
   - zlib=1.2.11=h0b31af3_1006
   - zstd=1.3.7=h5bba6e5_0
@@ -93,7 +93,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom
+    - eth-bloom==1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -93,13 +93,13 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom==1.0.4
-    - eth-hash==0.3.2
+    - eth-bloom
+    - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2
     - eth-typing==2.2.1
-    - eth-utils==1.8.4
+    - eth-utils>=1.8.4,<=1.10.0
     - ethsnarks-loopring==0.1.5
     - filelock==3.0.12
     - flake8==3.7.9

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -93,7 +93,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom==1.0.3
+    - eth-bloom>=1.0.3,<=1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -93,7 +93,7 @@ dependencies:
     - entrypoints==0.3
     - eth-abi==2.1.1
     - eth-account==0.4.0
-    - eth-bloom>=1.0.3,<=1.0.4
+    - eth-bloom==1.0.4
     - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -94,7 +94,7 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.4
-    - eth-hash>=0.2.0,<=0.3.2
+    - eth-hash==0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -94,7 +94,7 @@ dependencies:
     - eth-abi==2.1.1
     - eth-account==0.4.0
     - eth-bloom==1.0.3
-    - eth-hash==0.2.0
+    - eth-hash>=0.2.0,<=0.3.2
     - eth-keyfile==0.5.1
     - eth-keys==0.2.4
     - eth-rlp==0.1.2

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -14,7 +14,7 @@ web3==5.12.0
 prompt-toolkit==3.0.5
 0x-order-utils==4.0.0
 0x-contract-wrappers==2.0.0
-eth-bloom==1.0.3
+eth-bloom>=1.0.3,<=1.0.4
 pyperclip==1.8.0
 telegram==0.0.1
 pyjwt==1.7.1

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -14,7 +14,7 @@ web3==5.12.0
 prompt-toolkit==3.0.5
 0x-order-utils==4.0.0
 0x-contract-wrappers==2.0.0
-eth-bloom>=1.0.3,<=1.0.4
+eth-bloom==1.0.4
 pyperclip==1.8.0
 telegram==0.0.1
 pyjwt==1.7.1


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Update in declaration of version requirement for eth-hash library, to solve issue during installation in linux environment with eth-hash[pycryptodome] (`eth-hash[pycryptodome] 0.3.2 depends on eth-hash 0.3.2`)


**Tests performed by the developer**:



**Tips for QA testing**:


