### PR TITLE
fix/enable mkdocs material linux library

### DIFF
--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -142,7 +142,7 @@ dependencies:
     - matplotlib-inline==0.1.2
     - mccabe==0.6.1
     - mkdocs==1.0.4
-#    - mkdocs-material==4.6
+    - mkdocs-material==4.3.1
     - more-itertools==8.8.0
     - mpmath==1.0.0
     - multiaddr==0.0.9

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -61,6 +61,7 @@ dependencies:
     - aioconsole==0.1.15
     - aiohttp==3.6.2
     - aiokafka==0.5.2
+    - aioresponses==0.7.2
     - altgraph==0.17
     - appdirs==1.4.3
     - asn1crypto==1.3.0
@@ -117,8 +118,11 @@ dependencies:
     - jsonschema==3.2.0
     - kafka-python==1.4.6
     - lru-dict==1.1.6
+    - markdown==3.0.1
     - markupsafe==2.0.1
     - mccabe==0.6.1
+    - mkdocs==1.0.4
+    - mkdocs-material==4.6
     - more-itertools==8.8.0
     - mpmath==1.0.0
     - multiaddr==0.0.9
@@ -145,6 +149,7 @@ dependencies:
     - pyhamcrest==2.0.2
     - pyinstaller==3.6
     - pyjwt==1.7.1
+    - pymdown-extensions==6.2
     - pyopenssl==19.1.0
     - pyparsing==2.4.7
     - pyperclip==1.7.0
@@ -153,6 +158,7 @@ dependencies:
     - pysha3==1.0.2
     - pytest==4.6.11
     - python-binance==0.7.5
+    - python-markdown-math==0.6
     - python-telegram-bot==12.4.2
     - pywin32==227
     - pywin32-ctypes==0.2.0
@@ -184,12 +190,6 @@ dependencies:
     - yarl==1.4.2
     - zipp==3.5.0
     - zope-interface==4.7.1
-    - markdown==3.0.1
-    - mkdocs==1.0.4
-    - mkdocs-material==4.6
-    - pymdown-extensions==6.2
-    - python-markdown-math==0.6
     - git+https://github.com/CoinAlpha/python-signalr-client.git
     - https://hummingbot-python.s3.us-west-2.amazonaws.com/hummingsim-20210607-cp38-cp38-win_amd64.whl
-    - aioresponses==0.7.2
 prefix: C:\Users\marti\Anaconda3\envs\hummingbot

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -62,6 +62,7 @@ dependencies:
     - aioconsole==0.1.15
     - aiohttp==3.6.2
     - aiokafka==0.5.2
+    - aioresponses==0.7.2
     - altgraph==0.17
     - appdirs==1.4.3
     - asn1crypto==1.3.0
@@ -116,7 +117,10 @@ dependencies:
     - kafka-python==1.4.6
     - lru-dict==1.1.6
     - macholib==1.14
+    - markdown==3.0.1
     - mccabe==0.6.1
+    - mkdocs==1.0.4
+    - mkdocs-material==4.6
     - more-itertools==8.8.0
     - mpmath==1.0.0
     - multiaddr==0.0.9
@@ -142,6 +146,7 @@ dependencies:
     - pyhamcrest==2.0.2
     - pyinstaller==3.6
     - pyjwt==1.7.1
+    - pymdown-extensions==6.2
     - pyopenssl==19.1.0
     - pyparsing==2.4.7
     - pyperclip==1.7.0
@@ -149,6 +154,7 @@ dependencies:
     - pysha3==1.0.2
     - pytest==4.6.11
     - python-binance==0.7.5
+    - python-markdown-math==0.6
     - python-telegram-bot==12.4.2
     - pyyaml==5.3
     - regex==2020.2.20
@@ -179,12 +185,6 @@ dependencies:
     - yarl==1.4.2
     - zipp==3.4.1
     - zope-interface==4.7.1
-    - markdown==3.0.1
-    - mkdocs==1.0.4
-    - mkdocs-material==4.6
-    - pymdown-extensions==6.2
-    - python-markdown-math==0.6
     - git+https://github.com/CoinAlpha/python-signalr-client.git
     - https://hummingbot-python.s3-us-west-2.amazonaws.com/hummingsim-20210806-cp38-cp38-macosx_10_9_x86_64.whl
-    - aioresponses==0.7.2
 prefix: /usr/local/Caskroom/miniconda/base/envs/hummingbot


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I have added back the mkdocs-material library in the dependencies list for linux, now with a version that does not break dependencies.


**Tests performed by the developer**:



**Tips for QA testing**:


