### PR TITLE
fix / data frames value printout

### DIFF
--- a/hummingbot/client/__init__.py
+++ b/hummingbot/client/__init__.py
@@ -3,6 +3,8 @@ import logging
 import pandas as pd
 import decimal
 
+FLOAT_PRINTOUT_PRECISION = 7
+
 
 def format_decimal(n):
     """
@@ -10,11 +12,10 @@ def format_decimal(n):
     """
     try:
         with decimal.localcontext() as ctx:
-            ctx.prec = 7
             if isinstance(n, float):
-                d = ctx.create_decimal(repr(n))
-                return format(d.normalize(), 'f')
-            elif isinstance(n, decimal.Decimal):
+                n = ctx.create_decimal(n)
+            if isinstance(n, decimal.Decimal):
+                n = round(n, FLOAT_PRINTOUT_PRECISION)
                 return format(n.normalize(), 'f')
             else:
                 return str(n)

--- a/hummingbot/client/__init__.py
+++ b/hummingbot/client/__init__.py
@@ -3,7 +3,7 @@ import logging
 import pandas as pd
 import decimal
 
-FLOAT_PRINTOUT_PRECISION = 7
+FLOAT_PRINTOUT_PRECISION = 8
 
 
 def format_decimal(n):

--- a/test/hummingbot/client/test_formatter.py
+++ b/test/hummingbot/client/test_formatter.py
@@ -6,12 +6,12 @@ from hummingbot.client import format_decimal, FLOAT_PRINTOUT_PRECISION
 
 class FormatterTest(unittest.TestCase):
     def test_precision_assumption(self):
-        self.assertEqual(7, FLOAT_PRINTOUT_PRECISION)  # test cases must be adapted on precision change
+        self.assertEqual(8, FLOAT_PRINTOUT_PRECISION)  # test cases must be adapted on precision change
 
     def test_format_float_decimal_places_rounded(self):
-        n = 0.87654321
+        n = 0.987654321
         s = format_decimal(n)
-        self.assertEqual("0.8765432", s)
+        self.assertEqual("0.98765432", s)
 
     def test_format_float_places_no_rounding(self):
         n = 0.21
@@ -19,14 +19,14 @@ class FormatterTest(unittest.TestCase):
         self.assertEqual("0.21", s)
 
     def test_format_large_float(self):
-        n = 87654321.0
+        n = 987654321.0
         s = format_decimal(n)
-        self.assertEqual("87654321", s)
+        self.assertEqual("987654321", s)
 
     def test_format_decimal_obj_decimal_places_rounded(self):
-        n = Decimal("0.87654321")
+        n = Decimal("0.987654321")
         s = format_decimal(n)
-        self.assertEqual("0.8765432", s)
+        self.assertEqual("0.98765432", s)
 
     def test_format_decimal_obj_places_no_rounding(self):
         n = Decimal("0.21")
@@ -34,6 +34,6 @@ class FormatterTest(unittest.TestCase):
         self.assertEqual("0.21", s)
 
     def test_format_large_decimal_obj(self):
-        n = Decimal("87654321.0")
+        n = Decimal("987654321.0")
         s = format_decimal(n)
-        self.assertEqual("87654321", s)
+        self.assertEqual("987654321", s)

--- a/test/hummingbot/client/test_formatter.py
+++ b/test/hummingbot/client/test_formatter.py
@@ -1,0 +1,39 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.client import format_decimal, FLOAT_PRINTOUT_PRECISION
+
+
+class FormatterTest(unittest.TestCase):
+    def test_precision_assumption(self):
+        self.assertEqual(7, FLOAT_PRINTOUT_PRECISION)  # if failed, remaining test case must be adapted
+
+    def test_format_float_decimal_places_rounded(self):
+        n = 0.12345678
+        s = format_decimal(n)
+        self.assertEqual("0.1234568", s)
+
+    def test_format_float_places_no_rounding(self):
+        n = 0.12
+        s = format_decimal(n)
+        self.assertEqual("0.12", s)
+
+    def test_format_large_float(self):
+        n = 12345678.0
+        s = format_decimal(n)
+        self.assertEqual("12345678", s)
+
+    def test_format_decimal_obj_decimal_places_rounded(self):
+        n = Decimal("0.12345678")
+        s = format_decimal(n)
+        self.assertEqual("0.1234568", s)
+
+    def test_format_decimal_obj_places_no_rounding(self):
+        n = Decimal("0.12")
+        s = format_decimal(n)
+        self.assertEqual("0.12", s)
+
+    def test_format_large_decimal_obj(self):
+        n = Decimal("12345678.0")
+        s = format_decimal(n)
+        self.assertEqual("12345678", s)

--- a/test/hummingbot/client/test_formatter.py
+++ b/test/hummingbot/client/test_formatter.py
@@ -6,34 +6,34 @@ from hummingbot.client import format_decimal, FLOAT_PRINTOUT_PRECISION
 
 class FormatterTest(unittest.TestCase):
     def test_precision_assumption(self):
-        self.assertEqual(7, FLOAT_PRINTOUT_PRECISION)  # if failed, remaining test case must be adapted
+        self.assertEqual(7, FLOAT_PRINTOUT_PRECISION)  # test cases must be adapted on precision change
 
     def test_format_float_decimal_places_rounded(self):
-        n = 0.12345678
+        n = 0.87654321
         s = format_decimal(n)
-        self.assertEqual("0.1234568", s)
+        self.assertEqual("0.8765432", s)
 
     def test_format_float_places_no_rounding(self):
-        n = 0.12
+        n = 0.21
         s = format_decimal(n)
-        self.assertEqual("0.12", s)
+        self.assertEqual("0.21", s)
 
     def test_format_large_float(self):
-        n = 12345678.0
+        n = 87654321.0
         s = format_decimal(n)
-        self.assertEqual("12345678", s)
+        self.assertEqual("87654321", s)
 
     def test_format_decimal_obj_decimal_places_rounded(self):
-        n = Decimal("0.12345678")
+        n = Decimal("0.87654321")
         s = format_decimal(n)
-        self.assertEqual("0.1234568", s)
+        self.assertEqual("0.8765432", s)
 
     def test_format_decimal_obj_places_no_rounding(self):
-        n = Decimal("0.12")
+        n = Decimal("0.21")
         s = format_decimal(n)
-        self.assertEqual("0.12", s)
+        self.assertEqual("0.21", s)
 
     def test_format_large_decimal_obj(self):
-        n = Decimal("12345678.0")
+        n = Decimal("87654321.0")
         s = format_decimal(n)
-        self.assertEqual("12345678", s)
+        self.assertEqual("87654321", s)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes an issue where `pd.DataFrame` values larger than 1,000,000 get backwards truncated on printout (i.e. 123,456,789 becomes 123,456,700).


**Tests performed by the developer**:
- Test cases added for the affected part of the code.


**Tips for QA testing**:
- Verify that values are printing properly on the client's interface


