### PR TITLE
fix/ resolve websocket authentication error in Bybit Perpetual

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_auth.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_auth.py
@@ -18,12 +18,15 @@ class BybitPerpetualAuth():
     def get_timestamp(self):
         return str(int(time.time() * 1e3))
 
+    def get_expiration_timestamp(self):
+        return str(int(time.time() + 1 * 1e3))
+
     def get_ws_auth_payload(self) -> Dict[str, Any]:
         """
         Generates a dictionary with all required information for the authentication process
         :return: a dictionary of authentication info including the request signature
         """
-        expires = self.get_timestamp()
+        expires = self.get_expiration_timestamp()
         raw_signature = 'GET/realtime' + expires
         signature = hmac.new(self._secret_key.encode('utf-8'), raw_signature.encode('utf-8'), hashlib.sha256).hexdigest()
         auth_info = [self._api_key, expires, signature]

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_auth.py
@@ -21,6 +21,9 @@ class BybitPerpetualAuthTests(TestCase):
     def _get_timestamp(self):
         return str(int(time.time() * 1e3))
 
+    def _get_expiration_timestamp(self):
+        return str(int(time.time() + 1 * 1e3))
+
     def test_no_authentication_headers(self):
         auth = BybitPerpetualAuth(api_key=self.api_key, secret_key=self.secret_key)
         headers = auth.get_headers()
@@ -51,18 +54,18 @@ class BybitPerpetualAuthTests(TestCase):
     def test_ws_auth_payload(self):
         auth = BybitPerpetualAuth(api_key=self.api_key, secret_key=self.secret_key)
 
-        timestamp = self._get_timestamp()
+        expires = self._get_expiration_timestamp()
 
-        with patch.object(auth, 'get_timestamp') as get_timestamp_mock:
-            get_timestamp_mock.return_value = timestamp
+        with patch.object(auth, 'get_expiration_timestamp') as get_expires_ts_mock:
+            get_expires_ts_mock.return_value = expires
             payload = auth.get_ws_auth_payload()
 
-        raw_signature = 'GET/realtime' + timestamp
+        raw_signature = 'GET/realtime' + expires
         expected_signature = hmac.new(self.secret_key.encode('utf-8'),
                                       raw_signature.encode('utf-8'),
                                       hashlib.sha256).hexdigest()
 
         self.assertEqual(3, len(payload))
         self.assertEqual(self.api_key, payload[0])
-        self.assertEqual(timestamp, payload[1])
+        self.assertEqual(expires, payload[1])
         self.assertEqual(expected_signature, payload[2])


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
My mistake on assuming that the timestamps used for both REST API signature and WS Auth payloads refer to the same thing.

Just for record, the timestamp used in REST API signature generation should be the time in which the request is made, whereas the timestamp for WebSocket Auth payload refers to the expiration timestamp of the payload.


**Tests performed by the developer**:
Include a `get_expiration_timestamp()` function back into `BybitPerpetualAuth` class
Update the relevant unit tests


**Tips for QA testing**:
All testing to be performed in the epic branch #3930 

