### PR TITLE
Feat/allow avellaneda wait cancel confirmation

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -55,6 +55,9 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _latest_parameter_calculation_vol
         str _debug_csv_path
         object _avg_vol
+        bint _should_wait_order_cancel_confirmation
+        double _previous_orders_execution_timestamp
+        object _previous_orders_execution_task
 
     cdef object c_get_mid_price(self)
     cdef _create_proposal_based_on_order_override(self)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -276,4 +276,12 @@ avellaneda_market_making_config_map = {
                   type_str="decimal",
                   default=Decimal("10"),
                   validator=lambda v: validate_decimal(v, 0, 100, inclusive=False)),
+    "should_wait_order_cancel_confirmation":
+        ConfigVar(key="should_wait_order_cancel_confirmation",
+                  prompt="Should the strategy wait to receive a confirmation for orders cancellation "
+                         "before creating a new set of orders? "
+                         "(Not waiting requires enough available balance) (Yes/No) >>> ",
+                  type_str="bool",
+                  default=True,
+                  validator=validate_bool),
 }

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -59,6 +59,7 @@ def start(self):
             order_amount_shape_factor = c_map.get("order_amount_shape_factor").value
         closing_time = c_map.get("closing_time").value * Decimal(3600 * 24 * 1e3)
         volatility_buffer_size = c_map.get("volatility_buffer_size").value
+        should_wait_order_cancel_confirmation = c_map.get("should_wait_order_cancel_confirmation")
         debug_csv_path = os.path.join(data_path(),
                                       HummingbotApplication.main_application().strategy_file_name.rsplit('.', 1)[0] +
                                       f"_{pd.Timestamp.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv")
@@ -92,6 +93,7 @@ def start(self):
             closing_time=closing_time,
             debug_csv_path=debug_csv_path,
             volatility_buffer_size=volatility_buffer_size,
+            should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
             is_debug=False
         )
     except Exception as e:

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -348,12 +348,8 @@ class HangingOrdersTracker:
         self.current_created_pairs_of_orders.append(pair)
 
     def _add_hanging_orders_based_on_partially_executed_pairs(self):
-        for pair in self.current_created_pairs_of_orders:
-            if pair.partially_filled():
-                unfilled_order = pair.get_unfilled_order()
-                # Check if the unfilled order is in active_orders because it might have failed before being created
-                if unfilled_order in self.strategy.active_orders:
-                    self.add_order(unfilled_order)
+        for unfilled_order in self.candidate_hanging_orders_from_pairs():
+            self.add_order(unfilled_order)
         self.current_created_pairs_of_orders.clear()
 
     def _get_hanging_order_from_limit_order(self, order: LimitOrder):
@@ -362,3 +358,13 @@ class HangingOrdersTracker:
     def _limit_order_age(self, order: LimitOrder):
         calculated_age = order_age(order)
         return calculated_age if calculated_age >= 0 else 0
+
+    def candidate_hanging_orders_from_pairs(self):
+        candidate_orders = []
+        for pair in self.current_created_pairs_of_orders:
+            if pair.partially_filled():
+                unfilled_order = pair.get_unfilled_order()
+                # Check if the unfilled order is in active_orders because it might have failed before being created
+                if unfilled_order in self.strategy.active_orders:
+                    candidate_orders.append(unfilled_order)
+        return candidate_orders

--- a/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Avellaneda market making strategy config    ###
 ########################################################
 
-template_version: 5
+template_version: 6
 strategy: null
 
 # Exchange and token parameters.
@@ -73,3 +73,6 @@ closing_time: null
 
 # Buffer size used to store historic samples and calculate volatility
 volatility_buffer_size: 60
+
+# If the strategy should wait to receive cancelations confirmation before creating new orders during refresh time
+should_wait_order_cancel_confirmation: True

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+import asyncio
 import unittest
 import pandas as pd
 import math
@@ -1251,6 +1251,8 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
 
+        asyncio.get_event_loop().run_until_complete(self.strategy._last_orders_execution_task())
+
         buy_order = self.strategy.active_buys[0]
         sell_order = self.strategy.active_sells[0]
 
@@ -1314,6 +1316,8 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
 
+        asyncio.get_event_loop().run_until_complete(self.strategy._last_orders_execution_task())
+
         buy_order = self.strategy.active_buys[0]
         sell_order = self.strategy.active_sells[0]
 
@@ -1340,6 +1344,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.clock.backtest_til(orders_creation_timestamp + 10 + filled_extension_time - 1)
         self.assertEqual(0, len(self.strategy.active_non_hanging_orders))
         self.clock.backtest_til(orders_creation_timestamp + 10 + filled_extension_time + 1)
+        asyncio.get_event_loop().run_until_complete(self.strategy._last_orders_execution_task())
         self.assertEqual(2, len(self.strategy.active_non_hanging_orders))
         # The hanging order should still be present
         self.assertEqual(1, len(self.strategy.hanging_orders_tracker.strategy_current_hanging_orders))

--- a/test/hummingbot/strategy/test_hanging_orders_tracker.py
+++ b/test/hummingbot/strategy/test_hanging_orders_tracker.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from mock import MagicMock, PropertyMock
 
 from hummingbot.core.event.events import MarketEvent, OrderCancelledEvent, BuyOrderCompletedEvent
-from hummingbot.strategy.hanging_orders_tracker import HangingOrdersTracker
+from hummingbot.strategy.hanging_orders_tracker import HangingOrdersTracker, CreatedPairOfOrders
 from hummingbot.strategy.data_types import OrderType
 from hummingbot.core.data_type.limit_order import LimitOrder
 
@@ -396,3 +396,77 @@ class TestHangingOrdersTracker(unittest.TestCase):
         self.assertFalse(self.tracker.is_potential_hanging_order(buy_order_2))
         self.assertIn(hanging_order_1, self.tracker.strategy_current_hanging_orders)
         self.assertTrue(self.tracker.is_potential_hanging_order(buy_order_1))
+
+    def test_add_orders_from_partially_executed_pairs(self):
+        active_orders = []
+        type(self.strategy).active_orders = PropertyMock(return_value=active_orders)
+
+        buy_order_1 = LimitOrder("Order-1234569960000000",
+                                 "BTC-USDT",
+                                 True,
+                                 "BTC",
+                                 "USDT",
+                                 Decimal(101),
+                                 Decimal(1))
+        buy_order_2 = LimitOrder("Order-1234569961000000",
+                                 "BTC-USDT",
+                                 True,
+                                 "BTC",
+                                 "USDT",
+                                 Decimal(102),
+                                 Decimal(2))
+        buy_order_3 = LimitOrder("Order-1234569962000000",
+                                 "BTC-USDT",
+                                 True,
+                                 "BTC",
+                                 "USDT",
+                                 Decimal(103),
+                                 Decimal(3))
+        sell_order_1 = LimitOrder("Order-1234569980000000",
+                                  "BTC-USDT",
+                                  False,
+                                  "BTC",
+                                  "USDT",
+                                  Decimal(120),
+                                  Decimal(1))
+        sell_order_2 = LimitOrder("Order-1234569981000000",
+                                  "BTC-USDT",
+                                  False,
+                                  "BTC",
+                                  "USDT",
+                                  Decimal(122),
+                                  Decimal(2))
+        sell_order_3 = LimitOrder("Order-1234569982000000",
+                                  "BTC-USDT",
+                                  False,
+                                  "BTC",
+                                  "USDT",
+                                  Decimal(123),
+                                  Decimal(3))
+
+        non_executed_pair = CreatedPairOfOrders(buy_order_1, sell_order_1)
+        partially_executed_pair = CreatedPairOfOrders(buy_order_2, sell_order_2)
+        partially_executed_pair.filled_buy = True
+        executed_pair = CreatedPairOfOrders(buy_order_3, sell_order_3)
+        executed_pair.filled_buy = True
+        executed_pair.filled_sell = True
+
+        active_orders.append(buy_order_1)
+        active_orders.append(buy_order_2)
+        active_orders.append(buy_order_3)
+        active_orders.append(sell_order_1)
+        active_orders.append(sell_order_2)
+        active_orders.append(sell_order_3)
+
+        self.tracker.add_current_pairs_of_proposal_orders_executed_by_strategy(non_executed_pair)
+        self.tracker.add_current_pairs_of_proposal_orders_executed_by_strategy(partially_executed_pair)
+        self.tracker.add_current_pairs_of_proposal_orders_executed_by_strategy(executed_pair)
+
+        self.tracker._add_hanging_orders_based_on_partially_executed_pairs()
+
+        self.assertNotIn(buy_order_1, self.tracker.original_orders)
+        self.assertNotIn(buy_order_2, self.tracker.original_orders)
+        self.assertNotIn(buy_order_3, self.tracker.original_orders)
+        self.assertNotIn(sell_order_1, self.tracker.original_orders)
+        self.assertIn(sell_order_2, self.tracker.original_orders)
+        self.assertNotIn(sell_order_3, self.tracker.original_orders)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Added functionality in Avellaneda strategy to wait for orders cancellation confirmation before creating the new set of orders during the refresh time. The new functionality is configurable with a new parameter (configuration) in the strategy called `should_wait_order_cancel_confirmation` for the user to decide if they want to use it or not. By default the value of the configuration is `True` and makes the strategy wait for cancellation confirmation.


**Tests performed by the developer**:
New unit tests.
Tested running the bot connected to Gateio exchange, and using 3 order levels (causing the strategy to consume all available balance in each cycle).


**Tips for QA testing**:
To check if the strategy is working correctly with the changes I suggest running it connected to a exchange that does not provide constant balance updates (like Gateio).
I also suggest to check the strategy with and without using hanging orders.

Fix #4209 (for Avellaneda)