### PR TITLE
fix/ fix Bybit Perpetual error fetching funding info in Spot-Perp Arbitrage 

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -58,7 +58,8 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
         return copy.deepcopy(self._funding_info)
 
     def is_funding_info_initialized(self) -> bool:
-        return all(trading_pair in self._funding_info for trading_pair in self._trading_pairs)
+        return all(trading_pair in self._funding_info
+                   for trading_pair in self._trading_pairs)
 
     async def _sleep(self, delay):
         """
@@ -256,8 +257,7 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
         Returns the FundingInfo of the specified trading pair. If it does not exist, it will query the REST API.
         """
         if trading_pair not in self._funding_info:
-            async with self._funding_info_async_lock:
-                self._funding_info[trading_pair] = await self._get_funding_info_from_exchange(trading_pair)
+            self._funding_info[trading_pair] = await self._get_funding_info_from_exchange(trading_pair)
         return self._funding_info[trading_pair]
 
     async def _listen_for_subscriptions_on_url(self, url: str, trading_pairs: List[str]):

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -235,20 +235,20 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
         session = await self._get_session()
         async with session as client:
             async with self._throttler.execute_task(limit_id):
-                async with client.get(url=url, params=params) as response:
-                    if response.status == 200:
-                        resp_json = await response.json()
+                response = await client.get(url=url, params=params)
+                if response.status == 200:
+                    resp_json = await response.json()
 
-                        symbol_info: Dict[str, Any] = (
-                            resp_json["result"][0]  # Endpoint returns a List even though 1 entry is returned
-                        )
-                        funding_info = FundingInfo(
-                            trading_pair=trading_pair,
-                            index_price=Decimal(str(symbol_info["index_price"])),
-                            mark_price=Decimal(str(symbol_info["mark_price"])),
-                            next_funding_utc_timestamp=int(pd.Timestamp(symbol_info["next_funding_time"]).timestamp()),
-                            rate=Decimal(str(symbol_info["predicted_funding_rate"])),  # Note: no _e6 suffix from resp
-                        )
+                    symbol_info: Dict[str, Any] = (
+                        resp_json["result"][0]  # Endpoint returns a List even though 1 entry is returned
+                    )
+                    funding_info = FundingInfo(
+                        trading_pair=trading_pair,
+                        index_price=Decimal(str(symbol_info["index_price"])),
+                        mark_price=Decimal(str(symbol_info["mark_price"])),
+                        next_funding_utc_timestamp=int(pd.Timestamp(symbol_info["next_funding_time"]).timestamp()),
+                        rate=Decimal(str(symbol_info["predicted_funding_rate"])),  # Note: no _e6 suffix from resp
+                    )
         return funding_info
 
     async def get_funding_info(self, trading_pair: str) -> FundingInfo:

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -58,7 +58,7 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
         return copy.deepcopy(self._funding_info)
 
     def is_funding_info_initialized(self) -> bool:
-        return len(self._funding_info) > 0
+        return all(trading_pair in self._funding_info for trading_pair in self._trading_pairs)
 
     async def _sleep(self, delay):
         """
@@ -256,7 +256,8 @@ class BybitPerpetualAPIOrderBookDataSource(OrderBookTrackerDataSource):
         Returns the FundingInfo of the specified trading pair. If it does not exist, it will query the REST API.
         """
         if trading_pair not in self._funding_info:
-            self._funding_info[trading_pair] = await self._get_funding_info_from_exchange(trading_pair)
+            async with self._funding_info_async_lock:
+                self._funding_info[trading_pair] = await self._get_funding_info_from_exchange(trading_pair)
         return self._funding_info[trading_pair]
 
     async def _listen_for_subscriptions_on_url(self, url: str, trading_pairs: List[str]):

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -1159,9 +1159,15 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
         safe_ensure_future(self._set_leverage(trading_pair=trading_pair, leverage=leverage))
 
     def get_funding_info(self, trading_pair: str) -> Optional[FundingInfo]:
+        """
+        Retrieves the Funding Info for the specified trading pair.
+        Note: This function should NOT be called when the connector is not yet ready.
+        :param: trading_pair: The specified trading pair.
+        """
         if trading_pair in self._order_book_tracker.data_source.funding_info:
             return self._order_book_tracker.data_source.funding_info[trading_pair]
         else:
+            self.logger().error(f"Funding Info for {trading_pair} not found. Proceeding to fetch using REST API.")
             safe_ensure_future(self._order_book_tracker.data_source.get_funding_info(trading_pair))
             return None
 

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -1,5 +1,4 @@
 import copy
-from hummingbot.core.data_type.funding_info import FundingInfo
 
 import aiohttp
 import asyncio
@@ -33,6 +32,7 @@ from hummingbot.connector.derivative.position import Position
 from hummingbot.connector.exchange_base import CancellationResult, ExchangeBase
 from hummingbot.connector.perpetual_trading import PerpetualTrading
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
@@ -1159,9 +1159,11 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
         safe_ensure_future(self._set_leverage(trading_pair=trading_pair, leverage=leverage))
 
     def get_funding_info(self, trading_pair: str) -> Optional[FundingInfo]:
-        return asyncio.get_event_loop().run_until_complete(
-            self._order_book_tracker.data_source.get_funding_info(trading_pair)
-        )
+        if trading_pair in self._order_book_tracker.data_source.funding_info:
+            return self._order_book_tracker.data_source.funding_info[trading_pair]
+        else:
+            safe_ensure_future(self._order_book_tracker.data_source.get_funding_info(trading_pair))
+            return None
 
     def _get_throttler_instance(self) -> AsyncThrottler:
         if self._trading_pairs is not None:

--- a/hummingbot/strategy/spot_perpetual_arbitrage/arb_proposal.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/arb_proposal.py
@@ -67,7 +67,7 @@ class ArbProposal:
         self.spot_buy_sell_prices = [prices[0], prices[1]]
         self.deriv_buy_sell_prices = [prices[2], prices[3]]
 
-    def is_funding_payment_time(self):
+    def is_funding_payment_time(self) -> bool:
         """
         Check if it's time for funding payment.
         Return True if it's time for funding payment else False.
@@ -76,11 +76,10 @@ class ArbProposal:
         f_info: FundingInfo = perp_trading.get_funding_info(
             self.derivative_market_info.trading_pair)
         payment_span = perp_trading.funding_payment_span
-        if (f_info.next_funding_utc_timestamp - payment_span[0]) < self.timestamp < \
+        if f_info and (f_info.next_funding_utc_timestamp - payment_span[0]) < self.timestamp < \
                 (f_info.next_funding_utc_timestamp + payment_span[1]):
             return True
-        else:
-            return False
+        return False
 
     async def proposed_spot_deriv_arb(self):
         """

--- a/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
@@ -239,7 +239,7 @@ class SpotPerpetualArbitrageStrategy(StrategyPyBase):
         """
         funding_info: FundingInfo = self._derivative_market_info.market.get_funding_info(
             self._derivative_market_info.trading_pair)
-        if (active_position[0].amount > 0 > funding_info.rate) or (active_position[0].amount < 0 < funding_info.rate):
+        if funding_info and (active_position[0].amount > 0 > funding_info.rate) or (active_position[0].amount < 0 < funding_info.rate):
             return True
         return False
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Simple fix to resolve error when fetching funding info in Spot-Perp Arbitrage strategy


**Tests performed by the developer**:
Made modifications to `get_funding_info()` in `BybitPerpetualDerivative` class. If the `FundingInfo` for a trading pair is not found, it will create a task to retrieve the funding info. However, it will not wait for the task to return.
Include additional conditions in the Spot-Perp Arbitrage strategy to check the `FundingInfo` returned by Perp connectors.
Include new unit test.


**Tips for QA testing**:
The fix will prevent the error from occurring repeatedly. There is still a possibility that it will arise, but it should only appear once.

