### PR TITLE
feat/allow pmm and avellaneda wait cancel confirmation

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -55,6 +55,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _latest_parameter_calculation_vol
         str _debug_csv_path
         object _avg_vol
+        bint _should_wait_order_cancel_confirmation
 
     cdef object c_get_mid_price(self)
     cdef _create_proposal_based_on_order_override(self)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -92,6 +92,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                     closing_time: Decimal = Decimal("1"),
                     debug_csv_path: str = '',
                     volatility_buffer_size: int = 30,
+                    should_wait_order_cancel_confirmation = True,
                     is_debug: bool = False,
                     ):
         self._sb_order_tracker = OrderTracker()
@@ -142,6 +143,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._optimal_spread = s_decimal_zero
         self._optimal_ask = s_decimal_zero
         self._optimal_bid = s_decimal_zero
+        self._should_wait_order_cancel_confirmation = should_wait_order_cancel_confirmation
         self._debug_csv_path = debug_csv_path
         self._is_debug = is_debug
         try:
@@ -604,15 +606,14 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                     self.c_apply_order_amount_eta_transformation(proposal)
                     # 3. Apply functions that modify orders price
                     self.c_apply_order_price_modifiers(proposal)
+                    # 4. Apply budget constraint, i.e. can't buy/sell more than what you have.
+                    self.c_apply_budget_constraint(proposal)
 
                 self._hanging_orders_tracker.process_tick()
                 self.c_cancel_active_orders_on_max_age_limit()
                 self.c_cancel_active_orders(proposal)
 
                 if self.c_to_create_orders(proposal):
-                    # 4. Apply budget constraint (after hanging orders were created), i.e. can't buy/sell
-                    # more than what you have.
-                    self.c_apply_budget_constraint(proposal)
                     self.c_execute_orders_proposal(proposal)
 
                 if self._is_debug:
@@ -921,7 +922,12 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         return self.c_apply_budget_constraint(proposal)
 
     def adjusted_available_balance_for_orders_budget_constrain(self):
-        return self.c_get_adjusted_available_balance(self.active_non_hanging_orders)
+        candidate_hanging_orders = self.hanging_orders_tracker.candidate_hanging_orders_from_pairs()
+        all_limit_orders = []
+        if self.market_info in self._sb_order_tracker.get_limit_orders():
+            all_limit_orders = self._sb_order_tracker.get_limit_orders()[self.market_info].values()
+        all_non_hanging_orders = list(set(all_limit_orders) - set(candidate_hanging_orders))
+        return self.c_get_adjusted_available_balance(all_non_hanging_orders)
 
     cdef c_apply_budget_constraint(self, object proposal):
         cdef:
@@ -1194,8 +1200,11 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         non_hanging_orders_non_cancelled = [o for o in self.active_non_hanging_orders if not
                                             self._hanging_orders_tracker.is_potential_hanging_order(o)]
 
-        return self._create_timestamp < self._current_timestamp and \
-            proposal is not None and len(non_hanging_orders_non_cancelled) == 0
+        return (self._create_timestamp < self._current_timestamp
+                and (not self._should_wait_order_cancel_confirmation or
+                     len(self._sb_order_tracker.in_flight_cancels) == 0)
+                and proposal is not None
+                and len(non_hanging_orders_non_cancelled) == 0)
 
     def to_create_orders(self, proposal: Proposal) -> bool:
         return self.c_to_create_orders(proposal)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -276,4 +276,12 @@ avellaneda_market_making_config_map = {
                   type_str="decimal",
                   default=Decimal("10"),
                   validator=lambda v: validate_decimal(v, 0, 100, inclusive=False)),
+    "should_wait_order_cancel_confirmation":
+        ConfigVar(key="should_wait_order_cancel_confirmation",
+                  prompt="Should the strategy wait to receive a confirmation for orders cancellation "
+                         "before creating a new set of orders? "
+                         "(Not waiting requires enough available balance) (Yes/No) >>> ",
+                  type_str="bool",
+                  default=True,
+                  validator=validate_bool),
 }

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -59,6 +59,7 @@ def start(self):
             order_amount_shape_factor = c_map.get("order_amount_shape_factor").value
         closing_time = c_map.get("closing_time").value * Decimal(3600 * 24 * 1e3)
         volatility_buffer_size = c_map.get("volatility_buffer_size").value
+        should_wait_order_cancel_confirmation = c_map.get("should_wait_order_cancel_confirmation")
         debug_csv_path = os.path.join(data_path(),
                                       HummingbotApplication.main_application().strategy_file_name.rsplit('.', 1)[0] +
                                       f"_{pd.Timestamp.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv")
@@ -92,6 +93,7 @@ def start(self):
             closing_time=closing_time,
             debug_csv_path=debug_csv_path,
             volatility_buffer_size=volatility_buffer_size,
+            should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
             is_debug=False
         )
     except Exception as e:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -52,6 +52,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         double _status_report_interval
         int64_t _logging_options
         object _last_own_trade_price
+        bint _should_wait_order_cancel_confirmation
 
     cdef object c_get_mid_price(self)
     cdef object c_create_base_proposal(self)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -99,6 +99,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                     minimum_spread: Decimal = Decimal(0),
                     hb_app_notification: bool = False,
                     order_override: Dict[str, List[str]] = {},
+                    should_wait_order_cancel_confirmation = True,
                     ):
         if price_ceiling != s_decimal_neg_one and price_ceiling < price_floor:
             raise ValueError("Parameter price_ceiling cannot be lower than price_floor.")
@@ -149,6 +150,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         self._last_timestamp = 0
         self._status_report_interval = status_report_interval
         self._last_own_trade_price = Decimal('nan')
+        self._should_wait_order_cancel_confirmation = should_wait_order_cancel_confirmation
 
         self.c_add_markets([market_info.market])
 
@@ -872,6 +874,14 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             size = market.c_quantize_order_amount(self.trading_pair, size, sell.price)
             sell.size = size
 
+    def adjusted_available_balance_for_orders_budget_constrain(self):
+        candidate_hanging_orders = self.hanging_orders_tracker.candidate_hanging_orders_from_pairs()
+        all_limit_orders = []
+        if self.market_info in self._sb_order_tracker.get_limit_orders():
+            all_limit_orders = self._sb_order_tracker.get_limit_orders()[self.market_info].values()
+        all_non_hanging_orders = list(set(all_limit_orders) - set(candidate_hanging_orders))
+        return self.c_get_adjusted_available_balance(all_non_hanging_orders)
+
     cdef c_apply_budget_constraint(self, object proposal):
         cdef:
             ExchangeBase market = self._market_info.market
@@ -879,7 +889,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             object base_size
             object adjusted_amount
 
-        base_balance, quote_balance = self.c_get_adjusted_available_balance(self.active_non_hanging_orders)
+        base_balance, quote_balance = self.adjusted_available_balance_for_orders_budget_constrain()
 
         for buy in proposal.buys:
             buy_fee = market.c_get_fee(self.base_asset, self.quote_asset, OrderType.LIMIT, TradeType.BUY,
@@ -1177,9 +1187,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
     cdef bint c_to_create_orders(self, object proposal):
         non_hanging_orders_non_cancelled = [o for o in self.active_non_hanging_orders if not
                                             self._hanging_orders_tracker.is_potential_hanging_order(o)]
-        return self._create_timestamp < self._current_timestamp and \
-            proposal is not None and \
-            len(non_hanging_orders_non_cancelled) == 0
+        return (self._create_timestamp < self._current_timestamp
+                and (not self._should_wait_order_cancel_confirmation or
+                     len(self._sb_order_tracker.in_flight_cancels) == 0)
+                and proposal is not None
+                and len(non_hanging_orders_non_cancelled) == 0)
 
     cdef c_execute_orders_proposal(self, object proposal):
         cdef:

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -372,4 +372,12 @@ pure_market_making_config_map = {
                   required_if=lambda: False,
                   default=None,
                   type_str="json"),
+    "should_wait_order_cancel_confirmation":
+        ConfigVar(key="should_wait_order_cancel_confirmation",
+                  prompt="Should the strategy wait to receive a confirmation for orders cancellation "
+                         "before creating a new set of orders? "
+                         "(Not waiting requires enough available balance) (Yes/No) >>> ",
+                  type_str="bool",
+                  default=True,
+                  validator=validate_bool),
 }

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -77,6 +77,8 @@ def start(self):
             inventory_cost_price_delegate = InventoryCostPriceDelegate(db, trading_pair)
         take_if_crossed = c_map.get("take_if_crossed").value
 
+        should_wait_order_cancel_confirmation = c_map.get("should_wait_order_cancel_confirmation")
+
         strategy_logging_options = PureMarketMakingStrategy.OPTION_LOG_ALL
         self.strategy = PureMarketMakingStrategy()
         self.strategy.init_params(
@@ -111,6 +113,7 @@ def start(self):
             minimum_spread=minimum_spread,
             hb_app_notification=True,
             order_override={} if order_override is None else order_override,
+            should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
         )
     except Exception as e:
         self._notify(str(e))

--- a/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Avellaneda market making strategy config    ###
 ########################################################
 
-template_version: 5
+template_version: 6
 strategy: null
 
 # Exchange and token parameters.
@@ -73,3 +73,6 @@ closing_time: null
 
 # Buffer size used to store historic samples and calculate volatility
 volatility_buffer_size: 60
+
+# If the strategy should wait to receive cancellations confirmation before creating new orders during refresh time
+should_wait_order_cancel_confirmation: True

--- a/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Pure market making strategy config         ###
 ########################################################
 
-template_version: 21
+template_version: 22
 strategy: null
 
 # Exchange and token parameters.
@@ -124,6 +124,9 @@ take_if_crossed: null
 #   order_3: [sell, 0.1, 500]
 # Please make sure there is a space between : and [
 order_override: null
+
+# If the strategy should wait to receive cancellations confirmation before creating new orders during refresh time
+should_wait_order_cancel_confirmation: True
 
 # For more detailed information, see:
 # https://docs.hummingbot.io/strategies/pure-market-making/#configuration-parameters

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -1345,3 +1345,66 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.assertEqual(1, len(self.strategy.hanging_orders_tracker.strategy_current_hanging_orders))
         self.assertEqual(buy_order.client_order_id,
                          list(self.strategy.hanging_orders_tracker.strategy_current_hanging_orders)[0].order_id)
+
+    def test_no_new_orders_created_until_previous_orders_cancellation_confirmed(self):
+
+        refresh_time = self.strategy.order_refresh_time
+
+        self.strategy.avg_vol = self.avg_vol_indicator
+
+        # Simulate low volatility
+        self.simulate_low_volatility(self.strategy)
+        # Prepare market variables and parameters for calculation
+        self.strategy.recalculate_parameters()
+        self.strategy.calculate_reserved_price_and_optimal_spread()
+
+        self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
+
+        self.assertEqual(1, len(self.strategy.active_buys))
+        self.assertEqual(1, len(self.strategy.active_sells))
+
+        orders_creation_timestamp = self.strategy.current_timestamp
+
+        # Add a fake in flight cancellation to simulate a confirmation has not arrived
+        self.strategy._sb_order_tracker.in_flight_cancels["OID-99"] = self.strategy.current_timestamp
+
+        # After refresh time the two real orders should be cancelled, but no new order should be created
+        self.clock.backtest_til(orders_creation_timestamp + refresh_time)
+        self.assertEqual(0, len(self.strategy.active_buys))
+        self.assertEqual(0, len(self.strategy.active_sells))
+
+        # After a second refresh time no new order should be created
+        self.clock.backtest_til(orders_creation_timestamp + (2 * refresh_time))
+        self.assertEqual(0, len(self.strategy.active_buys))
+        self.assertEqual(0, len(self.strategy.active_sells))
+
+        del self.strategy._sb_order_tracker.in_flight_cancels["OID-99"]
+
+        # After removing the pending cancel, in the next tick the new orders should be created
+        self.clock.backtest_til(self.strategy.current_timestamp + 1)
+        self.assertEqual(1, len(self.strategy.active_buys))
+        self.assertEqual(1, len(self.strategy.active_sells))
+
+    def test_adjusted_available_balance_considers_in_flight_cancel_orders(self):
+        base_balance = self.market.get_available_balance(self.base_asset)
+        quote_balance = self.market.get_available_balance(self.quote_asset)
+
+        self.strategy._sb_order_tracker.start_tracking_limit_order(
+            market_pair=self.market_info,
+            order_id="OID-1",
+            is_buy=True,
+            price=Decimal(1000),
+            quantity=Decimal(1))
+        self.strategy._sb_order_tracker.start_tracking_limit_order(
+            market_pair=self.market_info,
+            order_id="OID-2",
+            is_buy=False,
+            price=Decimal(2000),
+            quantity=Decimal(2))
+
+        self.strategy._sb_order_tracker.in_flight_cancels["OID-1"] = self.strategy.current_timestamp
+
+        available_base_balance, available_quote_balance = self.strategy.adjusted_available_balance_for_orders_budget_constrain()
+
+        self.assertEqual(available_base_balance, base_balance + Decimal(2))
+        self.assertEqual(available_quote_balance, quote_balance + (Decimal(1) * Decimal(1000)))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Added functionality in Avellaneda strategy to wait for orders cancellation confirmation before creating the new set of orders during the refresh time. The new functionality is configurable with a new parameter (configuration) in the strategy called should_wait_order_cancel_confirmation for the user to decide if they want to use it or not. By default the value of the configuration is True and makes the strategy wait for cancellation confirmation.


**Tests performed by the developer**:
New unit tests.
Tested running the bot connected to Gateio exchange, and using 3 order levels (causing the strategy to consume all available balance in each cycle).


**Tips for QA testing**:
To check if the strategy is working correctly with the changes I suggest running it connected to a exchange that does not provide constant balance updates (like Gateio).
I also suggest to check the strategy with and without using hanging orders.

Fix #3686
Fix #4087  
Fix #4209


