### PR TITLE
Fix / Add throttler parameter for connector settings to fix paper trade on several connectors.

### DIFF
--- a/hummingbot/connector/exchange/coinzoom/coinzoom_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/coinzoom/coinzoom_api_order_book_data_source.py
@@ -33,9 +33,10 @@ class CoinzoomAPIOrderBookDataSource(OrderBookTrackerDataSource):
             cls._logger = logging.getLogger(__name__)
         return cls._logger
 
-    def __init__(self, throttler: AsyncThrottler, trading_pairs: List[str] = None):
+    def __init__(self, throttler: Optional[AsyncThrottler] = None, trading_pairs: List[str] = None):
         super().__init__(trading_pairs)
         self._throttler: AsyncThrottler = throttler
+        self._throttler = throttler or self._get_throttler_instance()
         self._trading_pairs: List[str] = trading_pairs
         self._snapshot_msg: Dict[str, any] = {}
 

--- a/hummingbot/connector/exchange/coinzoom/coinzoom_order_book_tracker.py
+++ b/hummingbot/connector/exchange/coinzoom/coinzoom_order_book_tracker.py
@@ -27,7 +27,7 @@ class CoinzoomOrderBookTracker(OrderBookTracker):
             cls._logger = logging.getLogger(__name__)
         return cls._logger
 
-    def __init__(self, throttler: AsyncThrottler, trading_pairs: Optional[List[str]] = None):
+    def __init__(self, throttler: Optional[AsyncThrottler] = None, trading_pairs: Optional[List[str]] = None):
         super().__init__(
             CoinzoomAPIOrderBookDataSource(throttler=throttler, trading_pairs=trading_pairs),
             trading_pairs)

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
@@ -32,9 +32,9 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
             cls._logger = logging.getLogger(__name__)
         return cls._logger
 
-    def __init__(self, throttler: AsyncThrottler, trading_pairs: List[str] = None):
+    def __init__(self, throttler: Optional[AsyncThrottler] = None, trading_pairs: List[str] = None):
         super().__init__(trading_pairs)
-        self._throttler = throttler
+        self._throttler = throttler or self._get_throttler_instance()
         self._trading_pairs: List[str] = trading_pairs
         self._snapshot_msg: Dict[str, any] = {}
 

--- a/hummingbot/connector/exchange/gate_io/gate_io_order_book_tracker.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_order_book_tracker.py
@@ -27,7 +27,7 @@ class GateIoOrderBookTracker(OrderBookTracker):
             cls._logger = logging.getLogger(__name__)
         return cls._logger
 
-    def __init__(self, throttler: AsyncThrottler, trading_pairs: Optional[List[str]] = None,):
+    def __init__(self, throttler: Optional[AsyncThrottler] = None, trading_pairs: Optional[List[str]] = None,):
         super().__init__(GateIoAPIOrderBookDataSource(throttler, trading_pairs), trading_pairs)
 
         self._ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()

--- a/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
@@ -43,10 +43,10 @@ class KrakenAPIOrderBookDataSource(OrderBookTrackerDataSource):
             cls._kraobds_logger = logging.getLogger(__name__)
         return cls._kraobds_logger
 
-    def __init__(self, throttler: AsyncThrottler, trading_pairs: List[str] = None):
+    def __init__(self, throttler: Optional[AsyncThrottler] = None, trading_pairs: List[str] = None):
         super().__init__(trading_pairs)
         self._order_book_create_function = lambda: OrderBook()
-        self._throttler = throttler
+        self._throttler = throttler or self._get_throttler_instance()
 
     @classmethod
     def _get_throttler_instance(cls) -> AsyncThrottler:

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.pyx
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.pyx
@@ -112,7 +112,7 @@ cdef class KrakenExchange(ExchangeBase):
         super().__init__()
         self._trading_required = trading_required
         self._throttler = self._build_async_throttler()
-        self._order_book_tracker = KrakenOrderBookTracker(self._throttler, trading_pairs)
+        self._order_book_tracker = KrakenOrderBookTracker(trading_pairs=trading_pairs, throttler=self._throttler)
         self._kraken_auth = KrakenAuth(kraken_api_key, kraken_secret_key)
         self._user_stream_tracker = KrakenUserStreamTracker(self._throttler, self._kraken_auth)
         self._ev_loop = asyncio.get_event_loop()

--- a/hummingbot/connector/exchange/kraken/kraken_order_book_tracker.py
+++ b/hummingbot/connector/exchange/kraken/kraken_order_book_tracker.py
@@ -32,7 +32,10 @@ class KrakenOrderBookTracker(OrderBookTracker):
             cls._krobt_logger = logging.getLogger(__name__)
         return cls._krobt_logger
 
-    def __init__(self, throttler: AsyncThrottler, trading_pairs: List[str]):
+    def __init__(self,
+                 trading_pairs: List[str],
+                 throttler: Optional[AsyncThrottler] = None,
+                 ):
         super().__init__(KrakenAPIOrderBookDataSource(throttler, trading_pairs), trading_pairs)
         self._order_book_diff_stream: asyncio.Queue = asyncio.Queue()
         self._order_book_snapshot_stream: asyncio.Queue = asyncio.Queue()

--- a/hummingbot/connector/exchange/kucoin/kucoin_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_api_order_book_data_source.py
@@ -313,12 +313,12 @@ class KucoinAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     def __init__(
         self,
-        throttler: AsyncThrottler,
+        throttler: Optional[AsyncThrottler] = None,
         trading_pairs: Optional[List[str]] = None,
         auth: Optional[KucoinAuth] = None,
     ):
         super().__init__(trading_pairs)
-        self._throttler = throttler
+        self._throttler = throttler or self._get_throttler_instance()
         self._auth = auth
         self._order_book_create_function = lambda: OrderBook()
         self._tasks: DefaultDict[StreamType, Dict[int, KucoinAPIOrderBookDataSource.TaskEntry]] = defaultdict(dict)

--- a/hummingbot/connector/exchange/kucoin/kucoin_order_book_tracker.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_order_book_tracker.py
@@ -33,7 +33,7 @@ class KucoinOrderBookTracker(OrderBookTracker):
         return cls._kobt_logger
 
     def __init__(self,
-                 throttler: AsyncThrottler,
+                 throttler: Optional[AsyncThrottler] = None,
                  trading_pairs: Optional[List[str]] = None,
                  auth: Optional[KucoinAuth] = None):
         super().__init__(KucoinAPIOrderBookDataSource(throttler, trading_pairs, auth), trading_pairs)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix for Paper trade failing to start on the following exchanges since the asyncio throttler refactor:
gate.io, binance, kucoin, ascend_ex, crypto.com, ndax, kraken

Fixes #4300
