### PR TITLE
Fix/hanging orders in gateio

### DIFF
--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -779,7 +779,8 @@ class GateIoExchange(ExchangeBase):
             "price": "10000.00000000",
             "fee": "0.00200000000000",
             "point_fee": "0",
-            "gt_fee": "0"
+            "gt_fee": "0",
+            "text": "user_defined_text",
         }
         """
         exchange_order_id = str(trade_msg["order_id"])

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -119,7 +119,7 @@ class HangingOrdersTracker:
     def _did_complete_order(self,
                             event: Union[BuyOrderCompletedEvent, SellOrderCompletedEvent],
                             is_buy: bool):
-
+        self.logger().info(f"*** The order with id {event.order_id} has been completed.")
         hanging_order = next((hanging_order for hanging_order in self.strategy_current_hanging_orders
                               if hanging_order.order_id == event.order_id), None)
 
@@ -263,6 +263,15 @@ class HangingOrdersTracker:
         equivalent_orders = self.equivalent_orders
         orders_to_create = equivalent_orders.difference(self.strategy_current_hanging_orders)
         orders_to_cancel = self.strategy_current_hanging_orders.difference(equivalent_orders)
+
+        equivalent_orders_str = ""
+        current_ho_str = ""
+        for order in self.equivalent_orders:
+            equivalent_orders_str = equivalent_orders_str + f"\n\t{order}"
+        for order in self.strategy_current_hanging_orders:
+            current_ho_str = current_ho_str + f"\n\t{order}"
+        self.logger().info(
+            f"### Updating hanging orders:\nEquivalent orders{equivalent_orders_str}\nCurrent hanging orders{current_ho_str}")
 
         self._cancel_multiple_orders_in_strategy([o.order_id for o in orders_to_cancel])
 

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -359,7 +359,7 @@ class HangingOrdersTracker:
     def _add_hanging_orders_based_on_partially_executed_pairs(self):
         for unfilled_order in self.candidate_hanging_orders_from_pairs():
             self.add_order(unfilled_order)
-        self.current_created_pairs_of_orders = list()
+        self.current_created_pairs_of_orders.clear()
 
     def _get_hanging_order_from_limit_order(self, order: LimitOrder):
         return HangingOrder(order.client_order_id, order.trading_pair, order.is_buy, order.price, order.quantity)

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -350,6 +350,7 @@ class HangingOrdersTracker:
     def _add_hanging_orders_based_on_partially_executed_pairs(self):
         for unfilled_order in self.candidate_hanging_orders_from_pairs():
             self.add_order(unfilled_order)
+        self.current_created_pairs_of_orders = list()
 
     def _get_hanging_order_from_limit_order(self, order: LimitOrder):
         return HangingOrder(order.client_order_id, order.trading_pair, order.is_buy, order.price, order.quantity)

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -119,7 +119,6 @@ class HangingOrdersTracker:
     def _did_complete_order(self,
                             event: Union[BuyOrderCompletedEvent, SellOrderCompletedEvent],
                             is_buy: bool):
-        self.logger().info(f"*** The order with id {event.order_id} has been completed.")
         hanging_order = next((hanging_order for hanging_order in self.strategy_current_hanging_orders
                               if hanging_order.order_id == event.order_id), None)
 
@@ -263,15 +262,6 @@ class HangingOrdersTracker:
         equivalent_orders = self.equivalent_orders
         orders_to_create = equivalent_orders.difference(self.strategy_current_hanging_orders)
         orders_to_cancel = self.strategy_current_hanging_orders.difference(equivalent_orders)
-
-        equivalent_orders_str = ""
-        current_ho_str = ""
-        for order in self.equivalent_orders:
-            equivalent_orders_str = equivalent_orders_str + f"\n\t{order}"
-        for order in self.strategy_current_hanging_orders:
-            current_ho_str = current_ho_str + f"\n\t{order}"
-        self.logger().info(
-            f"### Updating hanging orders:\nEquivalent orders{equivalent_orders_str}\nCurrent hanging orders{current_ho_str}")
 
         self._cancel_multiple_orders_in_strategy([o.order_id for o in orders_to_cancel])
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -563,12 +563,13 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                 age = pd.Timestamp(int(time.time()) - int(order.client_order_id[-16:])/1e6,
                                    unit='s').strftime('%H:%M:%S')
 
-            if not is_hanging_order:
-                amount_orig = self._order_amount + ((level - 1) * self._order_level_amount)
-                level = ""
+            if is_hanging_order:
+                level_for_calculation = lvl_buy if order.is_buy else lvl_sell
+                amount_orig = self._order_amount + ((level_for_calculation - 1) * self._order_level_amount)
+                level = "hang"
             else:
                 amount_orig = ""
-                level = "hang"
+
             data.append([
                 level,
                 "buy" if order.is_buy else "sell",
@@ -668,13 +669,15 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
         self._hanging_orders_tracker.register_events(self.active_markets)
 
-        # start tracking any restored limit order
-        restored_order_ids = self.c_track_restored_orders(self.market_info)
-        # make restored order hanging orders
-        for order_id in restored_order_ids:
-            order = next(o for o in self.market_info.market.limit_orders if o.client_order_id == order_id)
-            if order:
-                self._hanging_orders_tracker.add_order(order)
+        if self._hanging_orders_enabled:
+            # start tracking any restored limit order
+            restored_order_ids = self.c_track_restored_orders(self.market_info)
+            # make restored order hanging orders
+            for order_id in restored_order_ids:
+                order = next(o for o in self.market_info.market.limit_orders if o.client_order_id == order_id)
+                if order:
+                    self._hanging_orders_tracker.add_order(order)
+                    self._hanging_orders_tracker.update_strategy_orders_with_equivalent_orders()
 
     cdef c_stop(self, Clock clock):
         self._hanging_orders_tracker.unregister_events(self.active_markets)
@@ -876,10 +879,12 @@ cdef class PureMarketMakingStrategy(StrategyBase):
 
     def adjusted_available_balance_for_orders_budget_constrain(self):
         candidate_hanging_orders = self.hanging_orders_tracker.candidate_hanging_orders_from_pairs()
-        all_limit_orders = []
+        non_hanging = []
         if self.market_info in self._sb_order_tracker.get_limit_orders():
-            all_limit_orders = self._sb_order_tracker.get_limit_orders()[self.market_info].values()
-        all_non_hanging_orders = list(set(all_limit_orders) - set(candidate_hanging_orders))
+            all_orders = self._sb_order_tracker.get_limit_orders()[self.market_info].values()
+            non_hanging = [order for order in all_orders
+                           if not self._hanging_orders_tracker.is_order_id_in_hanging_orders(order.client_order_id)]
+        all_non_hanging_orders = list(set(non_hanging) - set(candidate_hanging_orders))
         return self.c_get_adjusted_available_balance(all_non_hanging_orders)
 
     cdef c_apply_budget_constraint(self, object proposal):

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -1272,6 +1272,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
                                        for order in self.strategy.active_non_hanging_orders
                                        if order.is_buy])
                                   + self.market.get_available_balance(self.market_info.quote_asset))
+
         self.assertEqual(expected_base_balance, current_base_balance)
         self.assertEqual(expected_quote_balance, current_quote_balance)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix in Gateio connector for:
- Scenario when an order is filled while it is being created by the exchange.
- Finding the in flight order a trade update message is received for.
- Cleaning unnecessary order pairs information in hanging orders tracker once the order cycle period finishes

I have added some extra log lines to continue the investigation of the issue (they will be removed for the final PR version).

**Tests performed by the developer**:
I tested this by running Avellaneda strategy and PMM strategy with Gateio connector, using a configuration with very low spread percentages.


**Tips for QA testing**:
Test Avellaneda and PMM strategies.

Resolves #4284 
