### PR TITLE
fix/ Bybit Perpetual not recording FundingPaymentCompletedEvent

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -72,7 +72,6 @@ def get_rest_api_limit_id_for_endpoint(endpoint: Dict[str, str],
 def _wss_url(endpoint: Dict[str, str], connector_variant_label: Optional[str]) -> str:
     variant = connector_variant_label if connector_variant_label else "bybit_perpetual_main"
     return endpoint.get(variant)
-    return endpoint.get(variant)
 
 
 def wss_linear_public_url(connector_variant_label: Optional[str]) -> str:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Resolves issue #4290


**Tests performed by the developer**:
Added additional checks on Funding Payment response and filtering based on non-linear and linear perpetual markets.
Modified unit tests accordingly

**Tips for QA testing**:
Ensure that `FundingPaymentCompletedEvent` is now being recorded.

