### PR TITLE
feat/ allow Kraken users to specify Account Tier

### DIFF
--- a/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
@@ -26,7 +26,9 @@ from hummingbot.logger import HummingbotLogger
 from hummingbot.connector.exchange.kraken.kraken_order_book import KrakenOrderBook
 from hummingbot.connector.exchange.kraken.kraken_utils import (
     convert_from_exchange_trading_pair,
-    convert_to_exchange_trading_pair)
+    convert_to_exchange_trading_pair,
+    build_rate_limits_by_tier,
+)
 from hummingbot.connector.exchange.kraken import kraken_constants as CONSTANTS
 
 
@@ -50,7 +52,7 @@ class KrakenAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     @classmethod
     def _get_throttler_instance(cls) -> AsyncThrottler:
-        throttler = AsyncThrottler(CONSTANTS.RATE_LIMITS)
+        throttler = AsyncThrottler(build_rate_limits_by_tier())
         return throttler
 
     @classmethod

--- a/hummingbot/connector/exchange/kraken/kraken_constants.py
+++ b/hummingbot/connector/exchange/kraken/kraken_constants.py
@@ -1,4 +1,36 @@
+from enum import Enum
+from typing import (
+    Dict,
+    Tuple,
+)
 from hummingbot.core.api_throttler.data_types import RateLimit, LinkedLimitWeightPair
+
+
+class KrakenAPITier(Enum):
+    """
+    Kraken's Private Endpoint Rate Limit Tiers, based on the Account Verification level.
+    """
+    STARTER = "STARTER"
+    INTERMEDIATE = "INTERMEDIATE"
+    PRO = "PRO"
+
+
+# Values are calculated by adding the Maxiumum Counter value and the expected count decay(in a minute) of a given tier.
+# Reference:
+# - API Rate Limits: https://support.kraken.com/hc/en-us/articles/206548367-What-are-the-API-rate-limits
+# - Matching Engine Limits: https://support.kraken.com/hc/en-us/articles/360045239571
+STARTER_PRIVATE_ENDPOINT_LIMIT = 15 + 20
+STARTER_MATCHING_ENGINE_LIMIT = 60 + 60
+INTERMEDIATE_PRIVATE_ENDPOINT_LIMIT = 20 + 30
+INTERMEDIATE_MATCHING_ENGINE_LIMIT = 125 + 140
+PRO_PRIVATE_ENDPOINT_LIMIT = 20 + 60
+PRO_MATCHING_ENGINE_LIMIT = 180 + 225
+
+KRAKEN_TIER_LIMITS: Dict[KrakenAPITier, Tuple[int, int]] = {
+    KrakenAPITier.STARTER: (STARTER_PRIVATE_ENDPOINT_LIMIT, STARTER_MATCHING_ENGINE_LIMIT),
+    KrakenAPITier.INTERMEDIATE: (INTERMEDIATE_PRIVATE_ENDPOINT_LIMIT, INTERMEDIATE_MATCHING_ENGINE_LIMIT),
+    KrakenAPITier.PRO: (PRO_PRIVATE_ENDPOINT_LIMIT, PRO_MATCHING_ENGINE_LIMIT),
+}
 
 KRAKEN_TO_HB_MAP = {
     "XBT": "BTC",
@@ -24,30 +56,19 @@ PUBLIC_ENDPOINT_LIMIT_ID = "PublicEndpointLimitID"
 PUBLIC_ENDPOINT_LIMIT = 1
 PUBLIC_ENDPOINT_LIMIT_INTERVAL = 1
 PRIVATE_ENDPOINT_LIMIT_ID = "PrivateEndpointLimitID"
-PRIVATE_ENDPOINT_LIMIT = 15 + 20  # relaxed for limit-decay; one extra call every 3s; issue #4178 for details
 PRIVATE_ENDPOINT_LIMIT_INTERVAL = 60
 MATCHING_ENGINE_LIMIT_ID = "MatchingEngineLimitID"
-MATCHING_ENGINE_LIMIT = 60 + 60    # relaxed for limit-decay; one extra call every 1s; issue #4178 for details
 MATCHING_ENGINE_LIMIT_INTERVAL = 60
 WS_CONNECTION_LIMIT_ID = "WSConnectionLimitID"
 
-RATE_LIMITS = [
+PUBLIC_API_LIMITS = [
+    # Public API Pool
     RateLimit(
         limit_id=PUBLIC_ENDPOINT_LIMIT_ID,
         limit=PUBLIC_ENDPOINT_LIMIT,
         time_interval=PUBLIC_ENDPOINT_LIMIT_INTERVAL,
     ),
-    RateLimit(
-        limit_id=PRIVATE_ENDPOINT_LIMIT_ID,
-        limit=PRIVATE_ENDPOINT_LIMIT,
-        time_interval=PRIVATE_ENDPOINT_LIMIT_INTERVAL,
-    ),
-    RateLimit(
-        limit_id=MATCHING_ENGINE_LIMIT_ID,
-        limit=MATCHING_ENGINE_LIMIT,
-        time_interval=MATCHING_ENGINE_LIMIT_INTERVAL,
-    ),
-    # public endpoints
+    # Public Endpoints
     RateLimit(
         limit_id=SNAPSHOT_PATH_URL,
         limit=PUBLIC_ENDPOINT_LIMIT,
@@ -72,47 +93,8 @@ RATE_LIMITS = [
         time_interval=PUBLIC_ENDPOINT_LIMIT_INTERVAL,
         linked_limits=[LinkedLimitWeightPair(PUBLIC_ENDPOINT_LIMIT_ID)],
     ),
-    # private endpoints
-    RateLimit(
-        limit_id=GET_TOKEN_PATH_URL,
-        limit=PRIVATE_ENDPOINT_LIMIT,
-        time_interval=PRIVATE_ENDPOINT_LIMIT_INTERVAL,
-        linked_limits=[LinkedLimitWeightPair(PRIVATE_ENDPOINT_LIMIT_ID)],
-    ),
-    RateLimit(
-        limit_id=BALANCE_PATH_URL,
-        limit=PRIVATE_ENDPOINT_LIMIT,
-        time_interval=PRIVATE_ENDPOINT_LIMIT_INTERVAL,
-        weight=2,
-        linked_limits=[LinkedLimitWeightPair(PRIVATE_ENDPOINT_LIMIT_ID)],
-    ),
-    RateLimit(
-        limit_id=OPEN_ORDERS_PATH_URL,
-        limit=PRIVATE_ENDPOINT_LIMIT,
-        time_interval=PRIVATE_ENDPOINT_LIMIT_INTERVAL,
-        weight=2,
-        linked_limits=[LinkedLimitWeightPair(PRIVATE_ENDPOINT_LIMIT_ID)],
-    ),
-    RateLimit(
-        limit_id=QUERY_ORDERS_PATH_URL,
-        limit=PRIVATE_ENDPOINT_LIMIT,
-        time_interval=PRIVATE_ENDPOINT_LIMIT_INTERVAL,
-        weight=2,
-        linked_limits=[LinkedLimitWeightPair(PRIVATE_ENDPOINT_LIMIT_ID)],
-    ),
-    # matching engine endpoints
-    RateLimit(
-        limit_id=ADD_ORDER_PATH_URL,
-        limit=MATCHING_ENGINE_LIMIT,
-        time_interval=MATCHING_ENGINE_LIMIT_INTERVAL,
-        linked_limits=[LinkedLimitWeightPair(MATCHING_ENGINE_LIMIT_ID)],
-    ),
-    RateLimit(
-        limit_id=CANCEL_ORDER_PATH_URL,
-        limit=MATCHING_ENGINE_LIMIT,
-        time_interval=MATCHING_ENGINE_LIMIT_INTERVAL,
-        linked_limits=[LinkedLimitWeightPair(MATCHING_ENGINE_LIMIT_ID)],
-    ),
-    # ws connections limit
-    RateLimit(limit_id=WS_CONNECTION_LIMIT_ID, limit=150, time_interval=60 * 10),
+    # WebSocket Connection Limit
+    RateLimit(limit_id=WS_CONNECTION_LIMIT_ID,
+              limit=150,
+              time_interval=60 * 10),
 ]

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.pxd
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.pxd
@@ -28,6 +28,7 @@ cdef class KrakenExchange(ExchangeBase):
         dict _asset_pairs
         int32_t _last_userref
         object _throttler
+        object _kraken_api_tier
 
     cdef c_did_timeout_tx(self, str tracking_id)
     cdef c_start_tracking_order(self,

--- a/hummingbot/connector/exchange/kraken/kraken_in_flight_order.pyx
+++ b/hummingbot/connector/exchange/kraken/kraken_in_flight_order.pyx
@@ -98,25 +98,6 @@ cdef class KrakenInFlightOrder(InFlightOrderBase):
         super().update_exchange_order_id(exchange_id)
         self.last_state = "new"
 
-    def update_with_execution_report(self, execution_report: Dict[str, Any]):
-        trade_id = execution_report["t"]
-        if trade_id in self.trade_id_set:
-            # trade already recorded
-            return
-        self.trade_id_set.add(trade_id)
-        last_executed_quantity = Decimal(execution_report["l"])
-        last_commission_amount = Decimal(execution_report["n"])
-        last_commission_asset = execution_report["N"]
-        last_order_state = execution_report["X"]
-        last_executed_price = Decimal(execution_report["L"])
-        executed_amount_quote = last_executed_price * last_executed_quantity
-        self.executed_amount_base += last_executed_quantity
-        self.executed_amount_quote += executed_amount_quote
-        if last_commission_asset is not None:
-            self.fee_asset = last_commission_asset
-        self.fee_paid += last_commission_amount
-        self.last_state = last_order_state
-
     def update_with_trade_update(self, trade_update: Dict[str, Any]):
         trade_id = trade_update["trade_id"]
         if str(trade_update["ordertxid"]) != self.exchange_order_id or trade_id in self.trade_id_set:

--- a/hummingbot/connector/exchange/kraken/kraken_order_book_tracker.py
+++ b/hummingbot/connector/exchange/kraken/kraken_order_book_tracker.py
@@ -16,10 +16,11 @@ from hummingbot.logger import HummingbotLogger
 from hummingbot.core.data_type.order_book_tracker import (
     OrderBookTracker
 )
-from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.connector.exchange.kraken.kraken_api_order_book_data_source import KrakenAPIOrderBookDataSource
-from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from hummingbot.connector.exchange.kraken.kraken_constants import KrakenAPITier
 from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.utils.async_utils import wait_til
 
 
@@ -35,6 +36,7 @@ class KrakenOrderBookTracker(OrderBookTracker):
     def __init__(self,
                  trading_pairs: List[str],
                  throttler: Optional[AsyncThrottler] = None,
+                 kraken_api_tier: KrakenAPITier = KrakenAPITier.STARTER,
                  ):
         super().__init__(KrakenAPIOrderBookDataSource(throttler, trading_pairs), trading_pairs)
         self._order_book_diff_stream: asyncio.Queue = asyncio.Queue()

--- a/hummingbot/connector/exchange/kraken/kraken_order_book_tracker.py
+++ b/hummingbot/connector/exchange/kraken/kraken_order_book_tracker.py
@@ -17,7 +17,6 @@ from hummingbot.core.data_type.order_book_tracker import (
     OrderBookTracker
 )
 from hummingbot.connector.exchange.kraken.kraken_api_order_book_data_source import KrakenAPIOrderBookDataSource
-from hummingbot.connector.exchange.kraken.kraken_constants import KrakenAPITier
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
@@ -36,7 +35,6 @@ class KrakenOrderBookTracker(OrderBookTracker):
     def __init__(self,
                  trading_pairs: List[str],
                  throttler: Optional[AsyncThrottler] = None,
-                 kraken_api_tier: KrakenAPITier = KrakenAPITier.STARTER,
                  ):
         super().__init__(KrakenAPIOrderBookDataSource(throttler, trading_pairs), trading_pairs)
         self._order_book_diff_stream: asyncio.Queue = asyncio.Queue()

--- a/hummingbot/connector/exchange/kraken/kraken_utils.py
+++ b/hummingbot/connector/exchange/kraken/kraken_utils.py
@@ -196,9 +196,9 @@ KEYS = {
                   is_connect_key=True),
     "kraken_api_tier":
         ConfigVar(key="kraken_api_tier",
-                  prompt="Enter your Kraken API Tier(i.e Starter/Intermediate/Pro) >>> ",
+                  prompt="Enter your Kraken API Tier (Starter/Intermediate/Pro) >>> ",
                   required_if=using_exchange("kraken"),
-                  default="starter",
+                  default="Starter",
                   is_secure=False,
                   is_connect_key=True,
                   validator=lambda v: _api_tier_validator(v),

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -3,7 +3,7 @@
 #################################
 
 # For more detailed information: https://docs.hummingbot.io
-template_version: 24
+template_version: 25
 
 # Exchange configs
 bamboo_relay_use_coordinator: false

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -69,6 +69,7 @@ kucoin_passphrase: null
 
 kraken_api_key: null
 kraken_secret_key: null
+kraken_api_tier: null
 
 bitmart_api_key: null
 bitmart_secret_key: null

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_api_order_book_data_source.py
@@ -9,8 +9,10 @@ from unittest.mock import patch, AsyncMock
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.kraken.kraken_api_order_book_data_source import KrakenAPIOrderBookDataSource
-from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.connector.exchange.kraken import kraken_constants as CONSTANTS
+from hummingbot.connector.exchange.kraken.kraken_constants import KrakenAPITier
+from hummingbot.connector.exchange.kraken.kraken_utils import build_rate_limits_by_tier
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book import OrderBook, OrderBookMessage
 from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
@@ -23,11 +25,12 @@ class KrakenAPIOrderBookDataSourceTest(unittest.TestCase):
         cls.base_asset = "COINALPHA"
         cls.quote_asset = "HBOT"
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.api_tier = KrakenAPITier.STARTER
 
     def setUp(self) -> None:
         super().setUp()
         self.mocking_assistant = NetworkMockingAssistant()
-        self.throttler = AsyncThrottler(CONSTANTS.RATE_LIMITS)
+        self.throttler = AsyncThrottler(build_rate_limits_by_tier(self.api_tier))
         self.data_source = KrakenAPIOrderBookDataSource(self.throttler, trading_pairs=[self.trading_pair])
 
     def async_run_with_timeout(self, coroutine: Awaitable, timeout: int = 1):

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_api_user_stream_data_source.py
@@ -9,8 +9,10 @@ from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.kraken.kraken_api_user_stream_data_source import KrakenAPIUserStreamDataSource
 from hummingbot.connector.exchange.kraken.kraken_auth import KrakenAuth
-from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.connector.exchange.kraken import kraken_constants as CONSTANTS
+from hummingbot.connector.exchange.kraken.kraken_constants import KrakenAPITier
+from hummingbot.connector.exchange.kraken.kraken_utils import build_rate_limits_by_tier
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
@@ -22,11 +24,12 @@ class KrakenAPIUserStreamDataSourceTest(unittest.TestCase):
         cls.base_asset = "COINALPHA"
         cls.quote_asset = "HBOT"
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.api_tier = KrakenAPITier.STARTER
 
     def setUp(self) -> None:
         super().setUp()
         self.mocking_assistant = NetworkMockingAssistant()
-        self.throttler = AsyncThrottler(CONSTANTS.RATE_LIMITS)
+        self.throttler = AsyncThrottler(build_rate_limits_by_tier(self.api_tier))
         not_a_real_secret = "kQH5HW/8p1uGOVjbgWA7FunAmGO8lsSUXNsu3eow76sz84Q18fWxnyRzBHCd3pd5nE9qa99HAZtuZuj6F1huXg=="
         kraken_auth = KrakenAuth(api_key="someKey", secret_key=not_a_real_secret)
         self.data_source = KrakenAPIUserStreamDataSource(self.throttler, kraken_auth)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This allows the user to effectively change the Rate Limit according to their Account Tiers.

To find your account tier click [here](https://www.kraken.com/u/verify).

For more info on the Rate Limits for the respective account tiers, refer to the links below:
REST API Rate Limits: https://support.kraken.com/hc/en-us/articles/206548367-What-are-the-API-rate-limits
Trading Engine Limits: https://support.kraken.com/hc/en-us/articles/360045239571

For existing users, please execute the `connect` command and re-insert your API credentials and specify your Account Tier

**Tests performed by the developer**:
Added new `ConfigVar` for in `kraken_utils`
Added necessary function(s) to parse and dynamically initialise Rate Limits
Added Unit Test [WIP]

**Tips for QA testing**:
Ensure that Kraken is working as intended.
Ensure that the API throttler is performing as it should given the different tiers.

