### PR TITLE
Add: Slippage buffer to cross exchange market making strategy

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pxd
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pxd
@@ -34,6 +34,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
         bint _use_oracle_conversion_rate
         object _taker_to_maker_base_conversion_rate
         object _taker_to_maker_quote_conversion_rate
+        object _slippage_buffer
         bint _hb_app_notification
         list _maker_order_ids
         double _last_conv_rates_logged

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -79,6 +79,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                     use_oracle_conversion_rate: bool = False,
                     taker_to_maker_base_conversion_rate: Decimal = Decimal("1"),
                     taker_to_maker_quote_conversion_rate: Decimal = Decimal("1"),
+                    slippage_buffer: Decimal = Decimal("0.05"),
                     hb_app_notification: bool = False
                     ):
         """
@@ -138,6 +139,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
         self._use_oracle_conversion_rate = use_oracle_conversion_rate
         self._taker_to_maker_base_conversion_rate = taker_to_maker_base_conversion_rate
         self._taker_to_maker_quote_conversion_rate = taker_to_maker_quote_conversion_rate
+        self._slippage_buffer = slippage_buffer
         self._last_conv_rates_logged = 0
         self._hb_app_notification = hb_app_notification
 
@@ -681,7 +683,11 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                               sum([r.amount for _, r in buy_fill_records]))
             order_price = taker_market.get_price_for_volume(taker_trading_pair, False,
                                                             quantized_hedge_amount).result_price
-
+            self.log_with_clock(logging.INFO, f"Calculated by HB order_price: {order_price}")
+            order_price *= Decimal("1") - self._slippage_buffer
+            order_price = taker_market.quantize_order_price(taker_trading_pair, order_price)
+            self.log_with_clock(logging.INFO, f"Slippage buffer adjusted order_price: {order_price}")
+            
             if quantized_hedge_amount > s_decimal_zero:
                 self.c_place_order(market_pair, False, False, quantized_hedge_amount, order_price)
 
@@ -714,7 +720,12 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                               sum([r.amount for _, r in sell_fill_records]))
             order_price = taker_market.get_price_for_volume(taker_trading_pair, True,
                                                             quantized_hedge_amount).result_price
-
+            
+            self.log_with_clock(logging.INFO, f"Calculated by HB order_price: {order_price}")
+            order_price *= Decimal("1") + self._slippage_buffer
+            order_price = taker_market.quantize_order_price(taker_trading_pair, order_price)
+            self.log_with_clock(logging.INFO, f"Slippage buffer adjusted order_price: {order_price}")
+            
             if quantized_hedge_amount > s_decimal_zero:
                 self.c_place_order(market_pair, True, False, quantized_hedge_amount, order_price)
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
@@ -242,4 +242,13 @@ cross_exchange_market_making_config_map = {
         validator=lambda v: validate_decimal(v, Decimal(0), inclusive=False),
         type_str="decimal"
     ),
+    "slippage_buffer": ConfigVar(
+        key="slippage_buffer",
+        prompt="How much buffer do you want to add to the price to account for slippage for taker orders "
+               "Enter 1 to indicate 1% >>> ",
+        prompt_on_new=True,
+        default=Decimal("5"),
+        type_str="decimal",
+        validator=lambda v: validate_decimal(v, Decimal(0), Decimal(100), inclusive=True)
+    )
 }

--- a/hummingbot/strategy/cross_exchange_market_making/start.py
+++ b/hummingbot/strategy/cross_exchange_market_making/start.py
@@ -31,6 +31,7 @@ def start(self):
     use_oracle_conversion_rate = xemm_map.get("use_oracle_conversion_rate").value
     taker_to_maker_base_conversion_rate = xemm_map.get("taker_to_maker_base_conversion_rate").value
     taker_to_maker_quote_conversion_rate = xemm_map.get("taker_to_maker_quote_conversion_rate").value
+    slippage_buffer = xemm_map.get("slippage_buffer").value / Decimal("100")
 
     # check if top depth tolerance is a list or if trade size override exists
     if isinstance(top_depth_tolerance, list) or "trade_size_override" in xemm_map:
@@ -88,5 +89,6 @@ def start(self):
         use_oracle_conversion_rate=use_oracle_conversion_rate,
         taker_to_maker_base_conversion_rate=taker_to_maker_base_conversion_rate,
         taker_to_maker_quote_conversion_rate=taker_to_maker_quote_conversion_rate,
+        slippage_buffer=slippage_buffer,
         hb_app_notification=True,
     )

--- a/hummingbot/templates/conf_cross_exchange_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_cross_exchange_market_making_strategy_TEMPLATE.yml
@@ -74,5 +74,11 @@ taker_to_maker_base_conversion_rate: null
 # the conversion rate is 0.8 (1 / 1.25)
 taker_to_maker_quote_conversion_rate: null
 
+# A buffer for which to adjust order price for higher chance of the order getting filled.
+# Since we hedge on marktes a slippage is acceptable rather having the transaction get rejected.
+# The submitted order price will be adjust higher (by percentage value) for buy order
+# and lower for sell order. (Enter 1 for 1%)
+slippage_buffer: null
+
 # For more detailed information, see:
 # https://docs.hummingbot.io/strategies/cross-exchange-market-making/#configuration-parameters


### PR DESCRIPTION
This is a request to add a slippage buffer parameter to the cross-exchange market making strategy. I have received this code from Vik and tested it. Vik gave me permission to push this parameter through so it can be used by all users. Thanks Vik for creating this parameter.

This strategy limits the chance of an unfilled taker order by placing the taker order x% higher or lower than the min profit target level taker price. Setting this parameter to a high percentage will result in a "market order" type order.

Two important adjustments still need to be done to the code in order for this parameter to work properly.

* for maker order size calculation, take into account the slippage size. Only applicable for maker sell orders.
* add average maker fill price and taker fill price to terminals log for easy profit checking as hedging orders can now be executed unprofitably.

IMPORTANT: Hedging on relatively low liquidity exchanges/pairs could lead to decent slippage and trading unprofitably. 

**A description of the changes proposed in the pull request**:
See above. Again one important thing needs to be added to the strategy in order to work properly. This is related to the maker order price calculation, see description of the problem below:

Let's say you only have 100$ on the taker exchange. Token X = 1$. The bot places limit sell orders on the maker exchange. The amount is limited to the 100$ that is on the taker exchange. In this case, 100 token's X, even though the maker exchange has 300 token X available.

The maker sell amount is limited to the dollar balance (quote asset) on the taker exchange because the volume needs to hedge. Let's say there is a min profit setting of 1% and a slippage buffer of 5%. Let's say the 100 token sell order gets filled. It wants to buy on the taker exchange 100 tokens of 0.99$ each, but because of the 5% slippage buffer, it wants to place an order of 0.99 * 100 * 1,05 = 103,95. This is not possible, as there is only 100$ on the account. It does not take into account the slippage buffer when deciding the maker volume.

This is only at maker market sell orders and taker buy orders, not for the other way around.

**Tests performed by the developer**:
Have been tested on multiple exchanges. Slippage buffer set to 5% and manually calculate the taker's order price to see if the strategy works correctly.



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1mmck59) by [Unito](https://www.unito.io)
