### PR TITLE
refactor/migrate NetworkStatus to network_iterator

### DIFF
--- a/hummingbot/core/network_base.py
+++ b/hummingbot/core/network_base.py
@@ -1,18 +1,12 @@
 import asyncio
-from enum import Enum
 import logging
 from typing import Optional
 from hummingbot.logger import HummingbotLogger
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.network_iterator import NetworkStatus
 
 NaN = float("nan")
 nb_logger = None
-
-
-class NetworkStatus(Enum):
-    STOPPED = 0
-    NOT_CONNECTED = 1
-    CONNECTED = 2
 
 
 class NetworkBase:

--- a/hummingbot/core/rate_oracle/rate_oracle.py
+++ b/hummingbot/core/rate_oracle/rate_oracle.py
@@ -9,7 +9,8 @@ from decimal import Decimal
 import aiohttp
 from enum import Enum
 from hummingbot.logger import HummingbotLogger
-from hummingbot.core.network_base import NetworkBase, NetworkStatus
+from hummingbot.core.network_base import NetworkBase
+from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
 import hummingbot.client.settings # noqa
 from hummingbot.connector.exchange.binance.binance_utils import convert_from_exchange_trading_pair as \

--- a/hummingbot/data_feed/custom_api_data_feed.py
+++ b/hummingbot/data_feed/custom_api_data_feed.py
@@ -2,7 +2,8 @@ import asyncio
 import aiohttp
 import logging
 from typing import Optional
-from hummingbot.core.network_base import NetworkBase, NetworkStatus
+from hummingbot.core.network_base import NetworkBase
+from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.logger import HummingbotLogger
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from decimal import Decimal

--- a/hummingbot/data_feed/data_feed_base.py
+++ b/hummingbot/data_feed/data_feed_base.py
@@ -6,7 +6,8 @@ from typing import (
     Dict,
 )
 
-from hummingbot.core.network_base import NetworkBase, NetworkStatus
+from hummingbot.core.network_base import NetworkBase
+from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.logger import HummingbotLogger
 
 

--- a/hummingbot/logger/log_server_client.py
+++ b/hummingbot/logger/log_server_client.py
@@ -7,10 +7,8 @@ from typing import (
 )
 import aiohttp
 
-from hummingbot.core.network_base import (
-    NetworkBase,
-    NetworkStatus
-)
+from hummingbot.core.network_base import NetworkBase
+from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_retry import async_retry
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.logger import HummingbotLogger

--- a/test/hummingbot/core/test_network_base.py
+++ b/test/hummingbot/core/test_network_base.py
@@ -1,5 +1,6 @@
 import asyncio
-from hummingbot.core.network_base import NetworkBase, NetworkStatus
+from hummingbot.core.network_base import NetworkBase
+from hummingbot.core.network_iterator import NetworkStatus
 import unittest
 
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [x] Your code builds clean without any errors or warnings
* [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Removed `NetworkStatus` from `network_base` and moved instances to `network_iterator`
Closes #4526

**Tests performed by the developer**:
Ran from source, Validated both instances of `NetworkStatus` provided exactly the same functionality.



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1t720f1) by [Unito](https://www.unito.io)
