### PR TITLE
feat / gateway v2 config manager [draft]

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -25,6 +25,7 @@
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-sdk": "3.2.1",
     "abi-decoder": "^2.4.0",
+    "ajv": "^8.6.3",
     "app-root-path": "^3.0.0",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",

--- a/gateway/src/services/config-manager-v2.ts
+++ b/gateway/src/services/config-manager-v2.ts
@@ -1,55 +1,148 @@
 import fs from 'fs';
+import path from 'path';
 import yaml from 'js-yaml';
 
 type Configuration = { [key: string]: any };
+type ConfigurationRoot = { [namespaceId: string]: string };
 
 class ConfigurationNamespace {
-  namespaceId: string;
-  filePath: string;
-  configuration: Configuration;
+  readonly #namespaceId: string;
+  readonly #filePath: string;
+  #configuration: Configuration;
 
   constructor(id: string, filePath: string) {
-    this.namespaceId = id;
-    this.filePath = filePath;
-    this.configuration = {};
+    this.#namespaceId = id;
+    this.#filePath = filePath;
+    this.#configuration = {};
+    if (fs.existsSync(filePath)) {
+      this.loadConfig();
+    }
+  }
+
+  get id(): string {
+    return this.#namespaceId;
+  }
+
+  get filePath(): string {
+    return this.#filePath;
   }
 
   loadConfig() {
-    this.configuration = yaml.load(
-      fs.readFileSync(this.filePath, 'utf8')
+    this.#configuration = yaml.load(
+      fs.readFileSync(this.#filePath, 'utf8')
     ) as Configuration;
   }
 
   saveConfig() {
-    fs.writeFileSync(this.filePath, yaml.dump(this.configuration));
+    fs.writeFileSync(this.#filePath, yaml.dump(this.#configuration));
   }
 
-  /*
   get(configPath: string): any {
     const pathComponents: Array<string> = configPath.split('.');
-    let cursor: Configuration | any = this.configuration;
+    let cursor: Configuration | any = this.#configuration;
+
+    pathComponents.forEach((component: string) => {
+      cursor = cursor[component];
+      if (cursor === undefined) {
+        return cursor;
+      }
+    });
+
+    return cursor;
   }
 
   set(configPath: string, value: any): void {
+    const pathComponents: Array<string> = configPath.split('.');
+    let cursor: Configuration | any = this.#configuration;
+    let parent: Configuration = this.#configuration;
+
+    pathComponents.slice(0, -1).forEach((component: string) => {
+      parent = cursor;
+      cursor = cursor[component];
+      if (cursor === undefined) {
+        parent[component] = {};
+        cursor = parent[component];
+      }
+    });
+
+    const lastComponent: string = pathComponents[pathComponents.length - 1];
+    cursor[lastComponent] = value;
+
+    this.saveConfig();
   }
-   */
+}
+
+interface UnpackedConfigNamespace {
+  namespace: ConfigurationNamespace;
+  configPath: string;
 }
 
 export class ConfigManagerV2 {
-  namespaces: { [key: string]: ConfigurationNamespace };
+  readonly #namespaces: { [key: string]: ConfigurationNamespace };
 
-  constructor() {
-    this.namespaces = {};
+  constructor(configRootPath: string) {
+    this.#namespaces = {};
+    this.loadConfigRoot(configRootPath);
   }
 
-  /*
-  get(configPath: string) {
+  getNamespace(id: string): ConfigurationNamespace | undefined {
+    return this.#namespaces[id];
   }
 
-  set(configPath: string, value: any) {
+  addNamespace(id: string, filePath: string): void {
+    this.#namespaces[id] = new ConfigurationNamespace(id, filePath);
   }
 
-  loadConfigRoot() {
+  unpackFullConfigPath(fullConfigPath: string): UnpackedConfigNamespace {
+    const pathComponents: Array<string> = fullConfigPath.split('.');
+    if (pathComponents.length < 2) {
+      throw new Error('Configuration paths must have at least two components.');
+    }
+
+    const namespaceComponent: string = pathComponents[0];
+    const namespace: ConfigurationNamespace | undefined =
+      this.#namespaces[namespaceComponent];
+    if (namespace === undefined) {
+      throw new Error(
+        `The configuration namespace ${namespaceComponent} does not exist.`
+      );
+    }
+
+    const configPath: string = pathComponents.slice(1).join('.');
+    return {
+      namespace,
+      configPath,
+    };
   }
-   */
+
+  get(fullConfigPath: string) {
+    const { namespace, configPath } = this.unpackFullConfigPath(fullConfigPath);
+    return namespace.get(configPath);
+  }
+
+  set(fullConfigPath: string, value: any) {
+    const { namespace, configPath } = this.unpackFullConfigPath(fullConfigPath);
+    namespace.set(configPath, value);
+  }
+
+  loadConfigRoot(configRootPath: string) {
+    // Load the config root file.
+    const configRootFullPath: string = fs.realpathSync(configRootPath);
+    const configRootDir: string = path.dirname(configRootFullPath);
+    const configRoot: ConfigurationRoot = yaml.load(
+      fs.readFileSync(configRootFullPath, 'utf8')
+    ) as ConfigurationRoot;
+
+    // Rebase the file paths in config root if they're relative paths.
+    for (const [namespaceId, filePath] of Object.entries(configRoot)) {
+      if (filePath.charAt(0) !== '/') {
+        configRoot[namespaceId] = path.join(configRootDir, filePath);
+      }
+    }
+
+    // Add the namespaces according to config root.
+    for (const [namespaceId, filePath] of Object.entries(configRoot)) {
+      this.addNamespace(namespaceId, filePath);
+    }
+  }
 }

--- a/gateway/src/services/config-manager-v2.ts
+++ b/gateway/src/services/config-manager-v2.ts
@@ -1,20 +1,82 @@
+import Ajv from 'ajv';
+import { ValidateFunction } from 'ajv';
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 
 type Configuration = { [key: string]: any };
-type ConfigurationRoot = { [namespaceId: string]: string };
+type ConfigurationDefaults = { [namespaceId: string]: Configuration };
+interface _ConfigurationNamespaceDefinition {
+  configurationPath: string;
+  schemaPath: string;
+}
+type ConfigurationNamespaceDefinition = _ConfigurationNamespaceDefinition & {
+  [key: string]: string;
+};
+type ConfigurationRoot = {
+  [namespaceId: string]: ConfigurationNamespaceDefinition;
+};
+const NamespaceTag: string = '$namespace ';
+const ConfigRootSchemaPath: string = path.join(
+  __dirname,
+  'schema/configuration-root-schema.json'
+);
+interface UnpackedConfigNamespace {
+  namespace: ConfigurationNamespace;
+  configPath: string;
+}
 
-class ConfigurationNamespace {
+const ajv: Ajv = new Ajv();
+
+export class ConfigurationNamespace {
+  /**
+   * This class encapsulates a namespace under the configuration tree.
+   * A namespace represents the top-level component of a configuration path.
+   * e.g. if the config path is "ssl.certificatePath", then "ssl" is the
+   * namespace.
+   *
+   * Each namespace contains a JSON schema and a YAML configuration file.
+   *
+   * The JSON schema specifies the properties and data types allowed within the
+   * namespace. e.g. you may specify that the "ssl" namespace has a few
+   * mandatory properties dealing with certificates and private keys. This means
+   * any missing properties or any properties outsides of the JSON schema would
+   * cause a failure to initialize the namespace, and also cannot be set into
+   * the namespace.
+   *
+   * The YAML configuration file is where the actual configuration tree goes
+   * to. It is automatically validated against the JSON schema at namespace
+   * initiation. It is automatically saved to and validated against JSON schema
+   * again at every set() call.
+   *
+   * Note that configuration paths may have multiple levels. What it implies
+   * is those configurations are stored in nested dictionaries - aka. a tree.
+   * e.g. if the config path is "ethereum.networks.kovan.networkID", then,
+   * what it means you're accessing ["networks"]["kovan"]["networkID"] under
+   * the "ethereum" namespace.
+   */
   readonly #namespaceId: string;
-  readonly #filePath: string;
+  readonly #schemaPath: string;
+  readonly #configurationPath: string;
+  readonly #validator: ValidateFunction;
   #configuration: Configuration;
 
-  constructor(id: string, filePath: string) {
+  constructor(id: string, schemaPath: string, configurationPath: string) {
     this.#namespaceId = id;
-    this.#filePath = filePath;
+    this.#schemaPath = schemaPath;
+    this.#configurationPath = configurationPath;
     this.#configuration = {};
-    if (fs.existsSync(filePath)) {
+    if (!fs.existsSync(schemaPath)) {
+      throw new Error(
+        `The JSON schema for namespace ${id} (${schemaPath}) does not exist.`
+      );
+    }
+
+    this.#validator = ajv.compile(
+      JSON.parse(fs.readFileSync(schemaPath).toString())
+    );
+
+    if (fs.existsSync(configurationPath)) {
       this.loadConfig();
     }
   }
@@ -23,18 +85,26 @@ class ConfigurationNamespace {
     return this.#namespaceId;
   }
 
-  get filePath(): string {
-    return this.#filePath;
+  get schemaPath(): string {
+    return this.#schemaPath;
+  }
+
+  get configurationPath(): string {
+    return this.#configurationPath;
   }
 
   loadConfig() {
-    this.#configuration = yaml.load(
-      fs.readFileSync(this.#filePath, 'utf8')
+    const configCandidate: Configuration = yaml.load(
+      fs.readFileSync(this.#configurationPath, 'utf8')
     ) as Configuration;
+    if (!this.#validator(configCandidate)) {
+      throw new Error(`Invalid configuration for namespace ${this.id}.`);
+    }
+    this.#configuration = configCandidate;
   }
 
   saveConfig() {
-    fs.writeFileSync(this.#filePath, yaml.dump(this.#configuration));
+    fs.writeFileSync(this.#configurationPath, yaml.dump(this.#configuration));
   }
 
   get(configPath: string): any {
@@ -53,8 +123,11 @@ class ConfigurationNamespace {
 
   set(configPath: string, value: any): void {
     const pathComponents: Array<string> = configPath.split('.');
-    let cursor: Configuration | any = this.#configuration;
-    let parent: Configuration = this.#configuration;
+    const configClone: Configuration = JSON.parse(
+      JSON.stringify(this.#configuration)
+    );
+    let cursor: Configuration | any = configClone;
+    let parent: Configuration = configClone;
 
     pathComponents.slice(0, -1).forEach((component: string) => {
       parent = cursor;
@@ -68,29 +141,91 @@ class ConfigurationNamespace {
     const lastComponent: string = pathComponents[pathComponents.length - 1];
     cursor[lastComponent] = value;
 
+    if (!this.#validator(configClone)) {
+      throw new Error(
+        `Cannot set ${this.id}.${configPath} to ${value}: ` +
+          'JSON schema violation.'
+      );
+    }
+
+    this.#configuration = configClone;
     this.saveConfig();
   }
 }
 
-interface UnpackedConfigNamespace {
-  namespace: ConfigurationNamespace;
-  configPath: string;
-}
-
 export class ConfigManagerV2 {
+  /**
+   * This class encapsulates the configuration tree and all the contained
+   * namespaces and files for Hummingbot Gateway. It also contains a defaults
+   * mechanism for modules to set default configurations under their namespaces.
+   *
+   * The configuration manager starts by loading the root configuration file,
+   * which defines all the configuration namespaces. The root configuration file
+   * has a fixed JSON schema, that only allows namespaces to be defined there.
+   *
+   * After the namespaces are loaded into the configuration manager during
+   * initiation, the get() and set() functions will map configuration keys and
+   * values to the appropriate namespaces.
+   *
+   * e.g. get('ethereum.networks.kovan.networkID') will be mapped to
+   *      ethereumNamespace.get('networks.kovan.networkID')
+   * e.g. set('ethereum.networks.kovan.networkID', 42) will be mapped to
+   *      ethereumNamespace.set('networks.kovan.networkID', 42)
+   *
+   * File paths in the root configuration file may be defined as absolute paths
+   * or relative paths. Any relative paths would be rebased to the root
+   * configuration file's parent directory.
+   *
+   * The static function `setDefaults()` is expected to be called by gateway
+   * modules, to set default configurations under their own namespaces. Default
+   * configurations are used in the `get()` function if the corresponding config
+   * key is not found in its configuration namespace.
+   */
   readonly #namespaces: { [key: string]: ConfigurationNamespace };
+
+  static defaults: ConfigurationDefaults = {};
 
   constructor(configRootPath: string) {
     this.#namespaces = {};
     this.loadConfigRoot(configRootPath);
   }
 
+  static setDefaults(namespaceId: string, defaultTree: Configuration) {
+    ConfigManagerV2.defaults[namespaceId] = defaultTree;
+  }
+
+  static getFromDefaults(namespaceId: string, configPath: string): any {
+    if (!(namespaceId in ConfigManagerV2.defaults)) {
+      return undefined;
+    }
+
+    const pathComponents: Array<string> = configPath.split('.');
+    const defaultConfig: Configuration = ConfigManagerV2.defaults[namespaceId];
+    let cursor: Configuration | any = defaultConfig;
+    for (const pathComponent of pathComponents) {
+      cursor = cursor[pathComponent];
+      if (cursor === undefined) {
+        return cursor;
+      }
+    }
+
+    return cursor;
+  }
+
   getNamespace(id: string): ConfigurationNamespace | undefined {
     return this.#namespaces[id];
   }
 
-  addNamespace(id: string, filePath: string): void {
-    this.#namespaces[id] = new ConfigurationNamespace(id, filePath);
+  addNamespace(
+    id: string,
+    schemaPath: string,
+    configurationPath: string
+  ): void {
+    this.#namespaces[id] = new ConfigurationNamespace(
+      id,
+      schemaPath,
+      configurationPath
+    );
   }
 
   unpackFullConfigPath(fullConfigPath: string): UnpackedConfigNamespace {
@@ -115,9 +250,13 @@ export class ConfigManagerV2 {
     };
   }
 
-  get(fullConfigPath: string) {
+  get(fullConfigPath: string): any {
     const { namespace, configPath } = this.unpackFullConfigPath(fullConfigPath);
-    return namespace.get(configPath);
+    const configValue: any = namespace.get(configPath);
+    if (configValue === undefined) {
+      return ConfigManagerV2.getFromDefaults(namespace.id, configPath);
+    }
+    return configValue;
   }
 
   set(fullConfigPath: string, value: any) {
@@ -133,16 +272,45 @@ export class ConfigManagerV2 {
       fs.readFileSync(configRootFullPath, 'utf8')
     ) as ConfigurationRoot;
 
+    // Validate the config root file.
+    const validator: ValidateFunction = ajv.compile(
+      JSON.parse(fs.readFileSync(ConfigRootSchemaPath).toString())
+    );
+    if (!validator(configRoot)) {
+      throw new Error('Configuration root file is invalid.');
+    }
+
+    // Enforce the rule that all namespace keys start with "!namespace ".
+    const namespaceMap: ConfigurationRoot = {};
+    for (const namespaceKey of Object.keys(configRoot)) {
+      if (!namespaceKey.startsWith(NamespaceTag)) {
+        throw new Error(
+          `All namespace keys must start with ${NamespaceTag}. ` +
+            `Offending key: '${namespaceKey}'.`
+        );
+      }
+      namespaceMap[namespaceKey.slice(NamespaceTag.length)] =
+        configRoot[namespaceKey];
+    }
+
     // Rebase the file paths in config root if they're relative paths.
-    for (const [namespaceId, filePath] of Object.entries(configRoot)) {
-      if (filePath.charAt(0) !== '/') {
-        configRoot[namespaceId] = path.join(configRootDir, filePath);
+    for (const namespaceDefinition of Object.values(namespaceMap)) {
+      for (const [key, filePath] of Object.entries(namespaceDefinition)) {
+        if (filePath.charAt(0) !== '/') {
+          namespaceDefinition[key] = path.join(configRootDir, filePath);
+        }
       }
     }
 
     // Add the namespaces according to config root.
-    for (const [namespaceId, filePath] of Object.entries(configRoot)) {
-      this.addNamespace(namespaceId, filePath);
+    for (const [namespaceId, namespaceDefinition] of Object.entries(
+      namespaceMap
+    )) {
+      this.addNamespace(
+        namespaceId,
+        namespaceDefinition.schemaPath,
+        namespaceDefinition.configurationPath
+      );
     }
   }
 }

--- a/gateway/src/services/config-manager-v2.ts
+++ b/gateway/src/services/config-manager-v2.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+type Configuration = { [key: string]: any };
+
+class ConfigurationNamespace {
+  namespaceId: string;
+  filePath: string;
+  configuration: Configuration;
+
+  constructor(id: string, filePath: string) {
+    this.namespaceId = id;
+    this.filePath = filePath;
+    this.configuration = {};
+  }
+
+  loadConfig() {
+    this.configuration = yaml.load(
+      fs.readFileSync(this.filePath, 'utf8')
+    ) as Configuration;
+  }
+
+  saveConfig() {
+    fs.writeFileSync(this.filePath, yaml.dump(this.configuration));
+  }
+
+  /*
+  get(configPath: string): any {
+    const pathComponents: Array<string> = configPath.split('.');
+    let cursor: Configuration | any = this.configuration;
+  }
+
+  set(configPath: string, value: any): void {
+  }
+   */
+}
+
+export class ConfigManagerV2 {
+  namespaces: { [key: string]: ConfigurationNamespace };
+
+  constructor() {
+    this.namespaces = {};
+  }
+
+  /*
+  get(configPath: string) {
+  }
+
+  set(configPath: string, value: any) {
+  }
+
+  loadConfigRoot() {
+  }
+   */
+}

--- a/gateway/src/services/schema/configuration-root-schema.json
+++ b/gateway/src/services/schema/configuration-root-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "patternProperties": {
+    "^\\$namespace ": {
+      "type": "object",
+      "properties" : {
+        "configurationPath": {
+          "type": "string"
+        },
+        "schemaPath": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/gateway/test/services/data/config-manager-v2/test1/ethereum.yml
+++ b/gateway/test/services/data/config-manager-v2/test1/ethereum.yml
@@ -1,0 +1,14 @@
+networks:
+  mainnet:
+    chainID: 1
+    nodeURL: http://localhost:8501/
+  ropsten:
+    chainID: 3
+    nodeURL: http://localhost:8503/
+  kovan:
+    chainID: 42
+    nodeURL: http://localhost:8542/
+  bsc:
+    chainID: 97
+    nodeURL: https://bsc-dataseed.binance.org/
+    nativeCurrencySymbol: BNB

--- a/gateway/test/services/data/config-manager-v2/test1/root.yml
+++ b/gateway/test/services/data/config-manager-v2/test1/root.yml
@@ -1,0 +1,6 @@
+$namespace ssl:
+  configurationPath: ssl.yml
+  schemaPath: schema-ssl.json
+$namespace ethereum:
+  configurationPath: ethereum.yml
+  schemaPath: schema-ethereum.json

--- a/gateway/test/services/data/config-manager-v2/test1/schema-ethereum.json
+++ b/gateway/test/services/data/config-manager-v2/test1/schema-ethereum.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "networks": {
+      "type": "object",
+      "patternProperties": {
+        "^\\w+$": {
+          "type": "object",
+          "properties": {
+            "chainID": { "type":  "integer" },
+            "nodeURL": { "type":  "string" },
+            "nativeCurrencySymbol": { "type": "string" }
+          },
+          "required": ["chainID", "nodeURL"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/gateway/test/services/data/config-manager-v2/test1/schema-ssl.json
+++ b/gateway/test/services/data/config-manager-v2/test1/schema-ssl.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "caCertificatePath": { "type":  "string" },
+    "certificatePath": { "type":  "string" },
+    "keyPath": { "type": "string" },
+    "passPhrasePath": { "type": "string" }
+  },
+  "additionalProperties": false,
+  "required": ["caCertificatePath", "certificatePath", "keyPath", "passPhrasePath"]
+}

--- a/gateway/test/services/data/config-manager-v2/test1/ssl.yml
+++ b/gateway/test/services/data/config-manager-v2/test1/ssl.yml
@@ -1,0 +1,4 @@
+caCertificatePath: ca.crt
+certificatePath: gateway.crt
+keyPath: gateway.key
+passPhrasePath: gateway.passwd

--- a/gateway/test/services/patch.ts
+++ b/gateway/test/services/patch.ts
@@ -33,7 +33,7 @@ export const patch = (target: any, propertyName: string, mock: any): void => {
 
   if (classHasGetter(target, propertyName)) {
     // special case for getter without setter
-    let targetPrototype = Object.getPrototypeOf(target);
+    const targetPrototype = Object.getPrototypeOf(target);
 
     Object.defineProperty(targetPrototype, propertyName, {
       get: mock,
@@ -66,7 +66,7 @@ export const unpatch = (): void => {
           target[propertyName] = target[key];
         } else {
           // the property is at a lower level in the object, it is likely a getter or setter
-          let targetPrototype = Object.getPrototypeOf(target);
+          const targetPrototype = Object.getPrototypeOf(target);
 
           Object.defineProperty(targetPrototype, propertyName, target[key]);
           Object.setPrototypeOf(target, targetPrototype);


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Proof of concept for the new configuration manager.

* Divides the overall configuration into namespaces, each namespace corresponds to a file.
* Allows modules to define their own default configurations.
* Uses the JSON schema standard to validate configurations, instead of hard-coded TypeScript interfaces.

I've included some documentations in the code on how to use it. I still need to write the test cases.
