### PR TITLE
feat / update broker ID for bitmart connector

### DIFF
--- a/hummingbot/connector/exchange/bitmart/bitmart_utils.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_utils.py
@@ -16,7 +16,7 @@ EXAMPLE_PAIR = "ETH-USDT"
 
 DEFAULT_FEES = [0.25, 0.25]
 
-HBOT_BROKER_ID = "hummingbot"
+HBOT_BROKER_ID = "hummingbot-"
 
 
 # deeply merge two dictionaries

--- a/hummingbot/connector/exchange/bitmart/bitmart_utils.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_utils.py
@@ -16,7 +16,7 @@ EXAMPLE_PAIR = "ETH-USDT"
 
 DEFAULT_FEES = [0.25, 0.25]
 
-HBOT_BROKER_ID = "HBOT-"
+HBOT_BROKER_ID = "hummingbot"
 
 
 # deeply merge two dictionaries

--- a/test/hummingbot/connector/exchange/bitmart/test_bitmart_utils.py
+++ b/test/hummingbot/connector/exchange/bitmart/test_bitmart_utils.py
@@ -16,4 +16,4 @@ class BitmartUtilsTests(TestCase):
     @patch('hummingbot.connector.exchange.bitmart.bitmart_utils.get_tracking_nonce')
     def test_client_order_id_creation(self, nonce_provider_mock):
         nonce_provider_mock.return_value = 1000
-        self.assertEqual("HBOT-B-BTC-USDT-1000", utils.get_new_client_order_id(True, "BTC-USDT"))
+        self.assertEqual("hummingbot-B-BTC-USDT-1000", utils.get_new_client_order_id(True, "BTC-USDT"))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Updated `HBOT_BROKER_ID` provided by BitMart team.
- Closes https://github.com/CoinAlpha/hummingbot/issues/4268

**Tests performed by the developer**:

- Ran unit tests - all passed

**Tips for QA testing**:

- Confirm if all order ID start with `hummingbot-` in logs and db
- Provide 3-5 order IDs generated in this pull request that I can forward to BitMart team
