### PR TITLE
feat/Set a larger upper threshold for bid_spread and ask_spread

### DIFF
--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making_config_map.py
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making_config_map.py
@@ -156,14 +156,14 @@ perpetual_market_making_config_map = {
                   prompt="How far away from the mid price do you want to place the "
                          "first bid order? (Enter 1 to indicate 1%) >>> ",
                   type_str="decimal",
-                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),
+                  validator=lambda v: validate_decimal(v, 0, 10e6, inclusive=False),
                   prompt_on_new=True),
     "ask_spread":
         ConfigVar(key="ask_spread",
                   prompt="How far away from the mid price do you want to place the "
                          "first ask order? (Enter 1 to indicate 1%) >>> ",
                   type_str="decimal",
-                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),
+                  validator=lambda v: validate_decimal(v, 0, 10e6, inclusive=False),
                   prompt_on_new=True),
     "minimum_spread":
         ConfigVar(key="minimum_spread",

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -128,14 +128,14 @@ pure_market_making_config_map = {
                   prompt="How far away from the mid price do you want to place the "
                          "first bid order? (Enter 1 to indicate 1%) >>> ",
                   type_str="decimal",
-                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),
+                  validator=lambda v: validate_decimal(v, 0, 10e6, inclusive=False),
                   prompt_on_new=True),
     "ask_spread":
         ConfigVar(key="ask_spread",
                   prompt="How far away from the mid price do you want to place the "
                          "first ask order? (Enter 1 to indicate 1%) >>> ",
                   type_str="decimal",
-                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),
+                  validator=lambda v: validate_decimal(v, 0, 10e6, inclusive=False),
                   prompt_on_new=True),
     "minimum_spread":
         ConfigVar(key="minimum_spread",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

A bigger `bid_spread` and `ask_spread` upper threshold are set for `perpetual_market_making` and `pure_market_making` strategies in the _User Interface_, so the user would not be constrained by the 100% previous value one.

This feature was requested in the issue https://github.com/CoinAlpha/hummingbot/issues/4660, as cryptocurrency exchange volatility could be high. The current _issue_ also contains the details on the walkthrough of the code and reliability concerns.

The upper threshold has been limited taking into account the `decimal.MAX_EMAX` value and the calculations performed in the  `hummingbot/hummingbot/strategy/pure_market_making/pure_market_making.pyx` file.
https://github.com/CoinAlpha/hummingbot/blob/f0cad0cd1fe64a6ca61d6b9f829436a7323b8d25/hummingbot/strategy/pure_market_making/pure_market_making.pyx#L781-L788

**Tests performed by the developer**:

A new configuration is created with the proposed changes that reflects the desired behavior.
![image](https://user-images.githubusercontent.com/25695302/140656317-c046c389-ccb8-4f05-b72f-1880a785fbd9.png)

**Tips for QA testing**:

A new test could be created for the case where values for the `bid_spread` and the `ask_spread` would be larger than `100` (e.g. `500`). These values were not restricted before in the _CLI_, as the user could run `config ask_spread 500` after setting up his initial configuration without inconvenience.

