### PR TITLE
fix / TWAP accepting invalid inputs

### DIFF
--- a/hummingbot/strategy/twap/twap_config_map.py
+++ b/hummingbot/strategy/twap/twap_config_map.py
@@ -54,10 +54,13 @@ def set_order_delay_default(value: str = None):
 
 def validate_order_step_size(value: str = None):
     """
-    Validates if order_step_size is less than the target_asset_amount value
+    Invalidates non-decimal input and checks if order_step_size is less than the target_asset_amount value
     :param value: User input for order_step_size parameter
     :return: Error message printed in output pane
     """
+    result = validate_decimal(value, min_value=Decimal("0"), inclusive=False)
+    if result is not None:
+        return result
     target_asset_amount = twap_config_map.get("target_asset_amount").value
     if Decimal(value) > target_asset_amount:
         return "Order step size cannot be greater than the total trade amount."

--- a/hummingbot/strategy/twap/twap_config_map.py
+++ b/hummingbot/strategy/twap/twap_config_map.py
@@ -4,7 +4,7 @@ from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_validators import (
     validate_bool,
     validate_exchange,
-    validate_market_trading_pair, validate_timestamp_iso_string,
+    validate_market_trading_pair, validate_timestamp_iso_string, validate_decimal,
 )
 from hummingbot.client.settings import (
     required_exchanges,
@@ -91,6 +91,7 @@ twap_config_map = {
                   prompt=target_asset_amount_prompt,
                   default=1.0,
                   type_str="decimal",
+                  validator=lambda v: validate_decimal(v, min_value=Decimal("0"), inclusive=False),
                   prompt_on_new=True),
     "order_step_size":
         ConfigVar(key="order_step_size",
@@ -104,6 +105,7 @@ twap_config_map = {
         ConfigVar(key="order_price",
                   prompt="What is the price for the limit orders? >>> ",
                   type_str="decimal",
+                  validator=lambda v: validate_decimal(v, min_value=Decimal("0"), inclusive=False),
                   prompt_on_new=True),
     "is_delayed_start_execution":
         ConfigVar(key="is_delayed_start_execution",
@@ -142,6 +144,7 @@ twap_config_map = {
                          " (Enter 10 to indicate 10 seconds)? >>> ",
                   type_str="float",
                   default=10,
+                  validator=lambda v: validate_decimal(v, 0, inclusive=False),
                   required_if=lambda: twap_config_map.get("is_time_span_execution").value or twap_config_map.get("is_delayed_start_execution").value,
                   prompt_on_new=True),
     "cancel_order_wait_time":
@@ -150,5 +153,6 @@ twap_config_map = {
                          "(Default is 60 seconds) ? >>> ",
                   type_str="float",
                   default=60,
+                  validator=lambda v: validate_decimal(v, 0, inclusive=False),
                   prompt_on_new=True)
 }

--- a/test/hummingbot/strategy/twap/test_twap_config_map.py
+++ b/test/hummingbot/strategy/twap/test_twap_config_map.py
@@ -74,6 +74,15 @@ class TwapConfigMapTests(TestCase):
         self.assertEqual(twap_config_map_module.twap_config_map.get("order_delay_time").default, 86400.0)
 
     def test_order_step_size(self):
+        # Test order_step_size with a non-decimal value
+        text = twap_config_map_module.validate_order_step_size("a!")
+        self.assertEqual(text, "a! is not in decimal format.")
+
+        # Test order_step_size below zero value
+        negative_value = twap_config_map_module.validate_order_step_size("-1")
+        self.assertEqual(negative_value, "Value must be more than 0.")
+
+        # Test order_step_size value greater than target_asset_amount
         twap_config_map_module.twap_config_map.get("target_asset_amount").value = Decimal("1.0")
         validate_order_step_size = twap_config_map_module.validate_order_step_size("1.1")
         self.assertEqual(validate_order_step_size,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Adds validator for TWAP parameters to accept only numerical values for input :

- `target_asset_amount`
- `order_step_size`
- `order_price`
- `order_delay_time`
- `cancel_order_wait_time`

Closes https://github.com/CoinAlpha/hummingbot/issues/4559

**Tests performed by the developer**:

- Entered negative and non-numeric values during prompts
- Confirmed the `order_step_size` still does not allow values greater than the `target_asset_amount`

**Tips for QA testing**:

Take note there's an error during validation, this error also shows on parameters from other strategies that uses `validate_decimal` for validator.

![Screen Shot 2021-11-08 at 3 04 27 PM](https://user-images.githubusercontent.com/50150287/140698358-04b1c561-2500-42d7-802f-b0195f3fdcdc.png)



