### PR TITLE
fix/ Docker build not initialising paper trade exchanges.

### DIFF
--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -31,7 +31,7 @@ from hummingbot.core.management.console import start_management_console
 from bin.hummingbot import (
     detect_available_port,
 )
-from hummingbot.client.settings import CONF_FILE_PATH
+from hummingbot.client.settings import CONF_FILE_PATH, AllConnectorSettings
 from hummingbot.client.config.security import Security
 
 
@@ -79,6 +79,8 @@ async def quick_start(args):
     await create_yml_files()
     init_logging("hummingbot_logs.yml")
     await read_system_configs_from_yml()
+
+    AllConnectorSettings.initialize_paper_trade_settings(global_config_map.get("paper_trade_exchanges").value)
 
     hb = HummingbotApplication.main_application()
     # Todo: validate strategy and config_file_name before assinging


### PR DESCRIPTION

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Include `initialize_paper_trade_settings()` function call in `hummingbot_quickstart.py`


**Tests performed by the developer**:
Minimal changes.


**Tips for QA testing**:
Test that Docker build would initialize paper trade exchanges.

