### PR TITLE
Fix/ AscendEx conflicting ex order

### DIFF
--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -129,6 +129,8 @@ class AscendExExchange(ExchangePyBase):
         self._account_uid = None  # required in order to produce deterministic order ids
         self._throttler = AsyncThrottler(rate_limits=CONSTANTS.RATE_LIMITS)
 
+        self._client_uuid_map: Dict[str, str] = {}
+
     @property
     def name(self) -> str:
         return CONSTANTS.EXCHANGE_NAME
@@ -503,8 +505,10 @@ class AscendExExchange(ExchangePyBase):
             raise ValueError("Order amount must be greater than zero.")
         try:
             timestamp = ascend_ex_utils.get_ms_timestamp()
+            # Order UUID is strictly used to enable AscendEx to construct a unique(still questionable) exchange_order_id
+            order_uuid = f"{ascend_ex_utils.HBOT_BROKER_ID}-{ascend_ex_utils.uuid32()}"[:32]
             api_params = {
-                "id": order_id,
+                "id": order_uuid,
                 "time": timestamp,
                 "symbol": ascend_ex_utils.convert_to_exchange_trading_pair(trading_pair),
                 "orderPrice": f"{price:f}",

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -129,8 +129,6 @@ class AscendExExchange(ExchangePyBase):
         self._account_uid = None  # required in order to produce deterministic order ids
         self._throttler = AsyncThrottler(rate_limits=CONSTANTS.RATE_LIMITS)
 
-        self._client_uuid_map: Dict[str, str] = {}
-
     @property
     def name(self) -> str:
         return CONSTANTS.EXCHANGE_NAME

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
@@ -75,9 +75,12 @@ def gen_exchange_order_id(userUid: str, client_order_id: str) -> Tuple[str, int]
 
 
 def gen_client_order_id(is_buy: bool, trading_pair: str) -> str:
+    """
+    Generates the client order id.
+    Note: All AscendEx API interactions, after order creation, utilizes the exchange_order_id instead.
+    """
     side = "B" if is_buy else "S"
     base, quote = trading_pair.split("-")
-    # TODO: Determine a better way uniquely identify client order id.
     return f"{HBOT_BROKER_ID}-{side}{base[:3]}{quote[:3]}{get_tracking_nonce()}"
 
 

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
@@ -1,7 +1,7 @@
 import random
 import string
 from typing import Tuple
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce_low_res
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce_low_res, get_tracking_nonce
 
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
@@ -50,6 +50,9 @@ def derive_order_id(user_uid: str, cl_order_id: str, ts: int) -> str:
     :param ts: order timestamp in milliseconds
     :return: order id of length 32
     """
+    # NOTE: The derived_order_id function details how AscendEx server generates the exchange_order_id
+    #       Currently, due to how the exchange constructs the exchange_order_id, there is a real possibility of
+    #       duplicate order ids
     return (HBOT_BROKER_ID + format(ts, 'x')[-11:] + user_uid[-11:] + cl_order_id[-5:])[:32]
 
 
@@ -74,7 +77,8 @@ def gen_exchange_order_id(userUid: str, client_order_id: str) -> Tuple[str, int]
 def gen_client_order_id(is_buy: bool, trading_pair: str) -> str:
     side = "B" if is_buy else "S"
     base, quote = trading_pair.split("-")
-    return f"{HBOT_BROKER_ID}-{side}{base[:3]}{quote[:3]}{uuid32()}"
+    # TODO: Determine a better way uniquely identify client order id.
+    return f"{HBOT_BROKER_ID}-{side}{base[:3]}{quote[:3]}{get_tracking_nonce()}"
 
 
 KEYS = {

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
@@ -5,7 +5,6 @@ from hummingbot.core.utils.tracking_nonce import get_tracking_nonce_low_res
 
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
 
 CENTRALIZED = True
@@ -75,7 +74,7 @@ def gen_exchange_order_id(userUid: str, client_order_id: str) -> Tuple[str, int]
 def gen_client_order_id(is_buy: bool, trading_pair: str) -> str:
     side = "B" if is_buy else "S"
     base, quote = trading_pair.split("-")
-    return f"{HBOT_BROKER_ID}-{side}{base[:3]}{quote[:3]}{get_tracking_nonce()}"
+    return f"{HBOT_BROKER_ID}-{side}{base[:3]}{quote[:3]}{uuid32()}"
 
 
 KEYS = {

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
@@ -10,28 +10,25 @@ class AscendExUtilsTests(TestCase):
     def _get_ms_timestamp(self):
         return 1633084102569
 
-    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.uuid32')
-    def test_gen_client_order_id(self, uuid_mock):
-        uuid_mock.return_value = "A" * 32
-        self.assertEqual(f"HMBot-BBTCUSD{uuid_mock.return_value}", utils.gen_client_order_id(True, "BTC-USDT"))
-        uuid_mock.return_value = "A" * 31 + "B"
-        self.assertEqual(f"HMBot-SETHUSD{uuid_mock.return_value}", utils.gen_client_order_id(False, "ETH-USDT"))
+    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_tracking_nonce')
+    def test_gen_client_order_id(self, nonce_provider_mock):
+        nonce_provider_mock.return_value = int(1e15)
+        self.assertEqual("HMBot-BBTCUSD1000000000000000", utils.gen_client_order_id(True, "BTC-USDT"))
+        nonce_provider_mock.return_value = int(1e15) + 1
+        self.assertEqual("HMBot-SETHUSD1000000000000001", utils.gen_client_order_id(False, "ETH-USDT"))
 
-    @patch("hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_ms_timestamp")
-    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.uuid32')
-    def test_gen_exchange_order_id(self, uuid_mock, get_ms_timestamp_mock):
-        uuid_mock.return_value = "A" * 32
+    def test_gen_exchange_order_id(self):
+        with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_ms_timestamp') as get_ms_timestamp_mock:
+            timestamp = self._get_ms_timestamp()
+            get_ms_timestamp_mock.return_value = timestamp
 
-        timestamp = self._get_ms_timestamp()
-        get_ms_timestamp_mock.return_value = timestamp
+            userUid = "abcdefghijklmnop1234"
+            client_order_id = "abcdefghijklmnop5678"
 
-        userUid = "U0123456789"  # "U" + 10 digits
-        client_order_id = f"HMBot-BBTCUSD{uuid_mock.return_value}"
+            order_id = utils.gen_exchange_order_id(userUid = userUid, client_order_id = client_order_id)
 
-        order_id = utils.gen_exchange_order_id(userUid = userUid, client_order_id = client_order_id)
-
-        self.assertEqual('HMBot17c3b65d7a9U0123456789AAAAA', order_id[0])
-        self.assertEqual(1633084102569, order_id[1])
+            self.assertEqual('HMBot17c3b65d7a9jklmnop1234p5678', order_id[0])
+            self.assertEqual(1633084102569, order_id[1])
 
     def test_convert_to_exchange_trading_pair(self):
         trading_pair = "BTC-USDT"

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
@@ -10,25 +10,28 @@ class AscendExUtilsTests(TestCase):
     def _get_ms_timestamp(self):
         return 1633084102569
 
-    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_tracking_nonce')
-    def test_gen_client_order_id(self, nonce_provider_mock):
-        nonce_provider_mock.return_value = int(1e15)
-        self.assertEqual("HMBot-BBTCUSD1000000000000000", utils.gen_client_order_id(True, "BTC-USDT"))
-        nonce_provider_mock.return_value = int(1e15) + 1
-        self.assertEqual("HMBot-SETHUSD1000000000000001", utils.gen_client_order_id(False, "ETH-USDT"))
+    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.uuid32')
+    def test_gen_client_order_id(self, uuid_mock):
+        uuid_mock.return_value = "A" * 32
+        self.assertEqual(f"HMBot-BBTCUSD{uuid_mock.return_value}", utils.gen_client_order_id(True, "BTC-USDT"))
+        uuid_mock.return_value = "A" * 31 + "B"
+        self.assertEqual(f"HMBot-SETHUSD{uuid_mock.return_value}", utils.gen_client_order_id(False, "ETH-USDT"))
 
-    def test_gen_exchange_order_id(self):
-        with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_ms_timestamp') as get_ms_timestamp_mock:
-            timestamp = self._get_ms_timestamp()
-            get_ms_timestamp_mock.return_value = timestamp
+    @patch("hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_ms_timestamp")
+    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.uuid32')
+    def test_gen_exchange_order_id(self, uuid_mock, get_ms_timestamp_mock):
+        uuid_mock.return_value = "A" * 32
 
-            userUid = "abcdefghijklmnop1234"
-            client_order_id = "abcdefghijklmnop5678"
+        timestamp = self._get_ms_timestamp()
+        get_ms_timestamp_mock.return_value = timestamp
 
-            order_id = utils.gen_exchange_order_id(userUid = userUid, client_order_id = client_order_id)
+        userUid = "U0123456789"  # "U" + 10 digits
+        client_order_id = f"HMBot-BBTCUSD{uuid_mock.return_value}"
 
-            self.assertEqual('HMBot17c3b65d7a9jklmnop1234p5678', order_id[0])
-            self.assertEqual(1633084102569, order_id[1])
+        order_id = utils.gen_exchange_order_id(userUid = userUid, client_order_id = client_order_id)
+
+        self.assertEqual('HMBot17c3b65d7a9U0123456789AAAAA', order_id[0])
+        self.assertEqual(1633084102569, order_id[1])
 
     def test_convert_to_exchange_trading_pair(self):
         trading_pair = "BTC-USDT"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes real possibility of conflicting order ids being sent to the AscendEx API server when placing orders between multiple HB instances.
Resolves #3970 

**Pending confirmation of broker id mechanism**

**Tests performed by the developer**:
Usage of uuid for trailing section of `client_order_id`


**Tips for QA testing**:
Test that conflicting order id error no longer occurs across multiple instances.
Instances need not be on the same market

