### PR TITLE
refactor/order collateral token

### DIFF
--- a/hummingbot/connector/budget_checker.py
+++ b/hummingbot/connector/budget_checker.py
@@ -1,0 +1,277 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, List, Optional
+from copy import copy
+
+from hummingbot.connector import exchange_base
+from hummingbot.connector.perpetual_trading import PerpetualTrading
+from hummingbot.connector.utils import split_hb_trading_pair
+from hummingbot.core.event.events import OrderType, TradeType
+
+
+@dataclass
+class OrderCandidate:
+    trading_pair: str
+    order_type: OrderType
+    order_side: TradeType
+    amount: Decimal
+    price: Decimal
+    collateral_amount: Optional[Decimal] = None
+    collateral_token: Optional[str] = None
+    leverage: Decimal = Decimal("1")
+
+
+class BudgetChecker:
+    def __init__(self, exchange: exchange_base.ExchangeBase):
+        """
+        Provides utilities for strategies to check if the required assets for trades are available.
+
+        Used to determine if sufficient balance is available to place a set of strategy-proposed orders.
+        The strategy can call `check_and_lock_available_collateral` for each one of the orders it intends to
+        place. On each call, the `BudgetChecker` locks in the collateral amount needed for that order
+        and makes it unavailable for the following hypothetical orders. Once the orders are sent to
+        the exchange, the strategy must call `reset_locked_collateral` to free the hypothetically locked
+        assets for the next set of checks.
+
+        :param exchange: The exchange against which available collateral assets will be checked.
+        """
+        self._exchange = exchange
+        self._locked_collateral: Dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
+
+    def reset_locked_collateral(self):
+        """
+        Frees collateral assets locked for hypothetical orders.
+        """
+        self._locked_collateral.clear()
+
+    def adjust_candidates_and_lock_available_collateral(
+        self, order_candidates: List[OrderCandidate], all_or_none: bool = True
+    ) -> List[OrderCandidate]:
+        self.reset_locked_collateral()
+        adjusted_candidates = [
+            self.adjust_candidate_and_lock_available_collateral(order_candidate, all_or_none)
+            for order_candidate in order_candidates
+        ]
+        self.reset_locked_collateral()
+        return adjusted_candidates
+
+    def adjust_candidate_and_lock_available_collateral(
+        self, order_candidate: OrderCandidate, all_or_none: bool = True
+    ) -> OrderCandidate:
+        """
+        Fills in the collateral token and collateral amount fields for the order candidate.
+        If there is insufficient assets to cover the collateral, the order amount is adjusted.
+
+        See the doc string for `adjust_candidate` to learn more about how the adjusted order
+        amount is derived.
+
+        :param order_candidate: The candidate order to check and adjust.
+        :param all_or_none: Should the order amount be set to zero on insufficient balance.
+        :return: The adjusted order candidate.
+        """
+        adjusted_candidate = self.adjust_candidate(
+            order_candidate, all_or_none
+        )
+        self._lock_available_collateral(adjusted_candidate)
+        return adjusted_candidate
+
+    def adjust_candidate(
+        self, order_candidate: OrderCandidate, all_or_none: bool = True
+    ) -> OrderCandidate:
+        """
+        Fills in the collateral token and collateral amount fields for the order candidate.
+
+        If there is insufficient collateral to cover the proposed order amount and
+        the `all_or_none` parameter is set to `False`, the order amount will be adjusted
+        to the greatest amount that the remaining collateral can provide for. If the parameter
+        is set to `True`, the order amount is set to zero.
+
+        :param order_candidate: The candidate order to check and adjust.
+        :param all_or_none: Should the order amount be set to zero on insufficient balance.
+        :return: The adjusted order candidate.
+        """
+        adjusted_candidate = self.populate_collateral_fields(order_candidate)
+        available_collateral = self._exchange.get_available_balance(adjusted_candidate.collateral_token)
+        if adjusted_candidate.collateral_amount < available_collateral:
+            if all_or_none:
+                adjusted_candidate.amount = Decimal("0")
+                adjusted_candidate.collateral_amount = Decimal("0")
+            else:
+                adjusted_candidate = self._adjust_amounts(adjusted_candidate, available_collateral)
+        return adjusted_candidate
+
+    def populate_collateral_fields(self, order_candidate: OrderCandidate) -> OrderCandidate:
+        """
+        Populates the required collateral amount and the collateral token fields for the given order.
+
+        This implementation assumes a spot-specific configuration for collaterals (i.e. the quote
+        token for buy orders and base for sell). It can be overridden to provide other
+        configurations such as in the case of perpetual connectors.
+
+        :param order_candidate: The candidate order to check and adjust.
+        :return: The adjusted order candidate.
+        """
+        trading_pair = order_candidate.trading_pair
+
+        base, quote = split_hb_trading_pair(trading_pair)
+        collateral_token = quote if TradeType.BUY else base
+
+        required_collateral = order_candidate.amount * order_candidate.price
+        adjustment = self._get_collateral_adjustment_for_fees(order_candidate)
+        required_collateral += adjustment
+
+        adjusted_candidate = copy(order_candidate)
+        adjusted_candidate.collateral_amount = required_collateral
+        adjusted_candidate.collateral_token = collateral_token
+
+        return adjusted_candidate
+
+    def _get_collateral_adjustment_for_fees(self, order_candidate: OrderCandidate) -> Decimal:
+        """
+        Returns the adjustment term for the required collateral amount due to fees.
+        The return value (adjustment term) is intended to be added to the base collateral amount.
+
+        Exchange-specific implementations of this class can override this method to model
+        the exchange's exact fee structure.
+
+        The default implementation assumes that, for buy orders, the trading fee is
+        charged on top of the order quoted amount; and it assumes that, for sell orders,
+        the fee is deducted from the returns after the sell has completed.
+
+        Example:
+             - Buy Order
+                 The user is submitting an order to buy 100 USDT worth of BTC on an exchange
+                 with a 1% fee. The required collateral will be 101 USDT (i.e. the adjustment term is 1).
+             - Sell Order
+                 The user is submitting an order to sell 1 ETH. The required collateral
+                 is 1 ETH, because the exchange will deduct the 1% fee from the quote asset
+                 returns after the sale has taken place (i.e. the adjustment term is zero).
+
+        Some exchanges can deduct the transaction fee from the buy order amount
+        (i.e. in the buy order example above, the user will only obtain 99 USDT worth of BTC).
+        Yet others can charge the fees for both buy and sell orders in the quote asset.
+        """
+        if order_candidate.order_side == TradeType.BUY:
+            trading_pair = order_candidate.trading_pair
+            price = order_candidate.price
+            amount = order_candidate.amount
+            base, quote = split_hb_trading_pair(trading_pair)
+            fee = self._exchange.get_fee(
+                base, quote, order_candidate.order_type, order_candidate.order_side, amount, price
+            )
+            fee_adjustment = fee.fee_amount_in_quote(trading_pair, price, amount)
+        else:
+            fee_adjustment = Decimal("0")
+        return fee_adjustment
+
+    def _lock_available_collateral(self, order_candidate: OrderCandidate):
+        self._locked_collateral[order_candidate.collateral_token] += order_candidate.collateral_amount
+
+    def _adjust_amounts(
+        self, order_candidate: OrderCandidate, available_collateral: Decimal
+    ) -> OrderCandidate:
+        if order_candidate.order_side == TradeType.BUY:
+            trading_pair = order_candidate.trading_pair
+            base, quote = split_hb_trading_pair(trading_pair)
+            fee = self._exchange.get_fee(
+                base,
+                quote,
+                order_candidate.order_type,
+                order_candidate.order_side,
+                order_candidate.amount,
+                order_candidate.price,
+            )
+            adjusted_amount = fee.order_amount_from_quote_with_fee(
+                trading_pair, order_candidate.price, available_collateral
+            )
+            adjusted_amount = self._exchange.quantize_order_amount(trading_pair, adjusted_amount)
+        else:
+            adjusted_amount = available_collateral / order_candidate.price
+
+        adjusted_candidate = copy(order_candidate)
+        adjusted_candidate.amount = adjusted_amount
+        adjusted_candidate.collateral_amount = available_collateral
+
+        return adjusted_candidate
+
+
+class PerpetualBudgetChecker(BudgetChecker):
+    def __init__(self, exchange: exchange_base.ExchangeBase):
+        """
+        In the case of derived instruments, the collateral can be any token.
+        To get this information, this class uses the `get_buy_collateral_token`
+        and `get_sell_collateral_token` methods provided by the `PerpetualTrading` interface.
+        """
+        super().__init__(exchange)
+        self._validate_perpetual_connector()
+
+    def populate_collateral_fields(self, order_candidate: OrderCandidate) -> OrderCandidate:
+        trading_pair = order_candidate.trading_pair
+
+        if order_candidate.order_side == TradeType.BUY:
+            collateral_token = await self._exchange.get_buy_collateral_token(trading_pair)
+        else:
+            collateral_token = await self._exchange.get_sell_collateral_token(trading_pair)
+
+        order_size = order_candidate.amount * order_candidate.price
+        required_collateral = order_size / order_candidate.leverage
+        adjustment = self._get_collateral_adjustment_for_fees(order_candidate)
+        required_collateral += adjustment
+
+        adjusted_candidate = copy(order_candidate)
+        adjusted_candidate.collateral_amount = required_collateral
+        adjusted_candidate.collateral_token = collateral_token
+
+        return adjusted_candidate
+
+    def _validate_perpetual_connector(self):
+        if not isinstance(self._exchange, PerpetualTrading):
+            raise TypeError(
+                f"{self.__class__} must be passed an exchange implementing the {PerpetualTrading} interface."
+            )
+
+    def _get_collateral_adjustment_for_fees(self, order_candidate: OrderCandidate) -> Decimal:
+        trading_pair = order_candidate.trading_pair
+        amount = order_candidate.amount
+        price = order_candidate.price
+
+        base, quote = split_hb_trading_pair(trading_pair)
+        fee = self._exchange.get_fee(
+            base, quote, order_candidate.order_type, order_candidate.order_side, amount, price
+        )
+        fee_adjustment = fee.fee_amount_in_quote(trading_pair, price, amount)
+
+        return fee_adjustment
+
+    def _adjust_amounts(
+        self, order_candidate: OrderCandidate, available_collateral: Decimal
+    ) -> OrderCandidate:
+        trading_pair = order_candidate.trading_pair
+        price = order_candidate.price
+
+        base, quote = split_hb_trading_pair(trading_pair)
+        if order_candidate.collateral_token not in [base, quote]:
+            raise NotImplementedError(
+                f"Cannot adjust the order amount if the collateral is neither of the order's"
+                f" base or quote tokens. Base = {base}, quote = {quote}, collateral token ="
+                f" {order_candidate.collateral_token}."
+            )
+        fee = self._exchange.get_fee(
+            base,
+            quote,
+            order_candidate.order_type,
+            order_candidate.order_side,
+            order_candidate.amount,
+            price,
+        )
+        adjusted_amount = fee.order_amount_from_quote_with_fee(
+            trading_pair, price, available_collateral
+        )
+        adjusted_amount = self._exchange.quantize_order_amount(trading_pair, adjusted_amount)
+
+        adjusted_candidate = copy(order_candidate)
+        adjusted_candidate.amount = adjusted_amount
+        adjusted_candidate.collateral_amount = available_collateral
+
+        return adjusted_candidate

--- a/hummingbot/connector/connector_base.pyx
+++ b/hummingbot/connector/connector_base.pyx
@@ -14,7 +14,7 @@ from hummingbot.core.event.events import (
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.network_iterator import NetworkIterator
 from hummingbot.connector.in_flight_order_base import InFlightOrderBase
-from hummingbot.connector.utils import TradeFillOrderDetails
+from hummingbot.connector.utils import TradeFillOrderDetails, split_hb_trading_pair
 from hummingbot.core.event.events import OrderFilledEvent
 from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.core.utils.estimate_fee import estimate_fee
@@ -100,7 +100,7 @@ cdef class ConnectorBase(NetworkIterator):
 
     @staticmethod
     def split_trading_pair(trading_pair: str) -> Tuple[str, str]:
-        return tuple(trading_pair.split('-'))
+        return split_hb_trading_pair(trading_pair)
 
     def in_flight_asset_balances(self, in_flight_orders: Dict[str, InFlightOrderBase]) -> Dict[str, Decimal]:
         """

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -1,50 +1,54 @@
-import aiohttp
 import asyncio
 import hashlib
 import hmac
 import logging
 import time
-
-import hummingbot.connector.derivative.binance_perpetual.constants as CONSTANTS
-import hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils as utils
-
-from async_timeout import timeout
 from collections import defaultdict
 from decimal import Decimal
 from enum import Enum
+from typing import Any, AsyncIterable, Dict, List, Optional
 from urllib.parse import urlencode
-from typing import Optional, List, Dict, Any, AsyncIterable
 
-from hummingbot.connector.derivative.perpetual_budget_checker import \
-    PerpetualBudgetChecker
-from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_in_flight_order import BinancePerpetualsInFlightOrder
-from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_order_book_tracker import BinancePerpetualOrderBookTracker
-from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_user_stream_tracker import BinancePerpetualUserStreamTracker
+import aiohttp
+from async_timeout import timeout
+
+import hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils as utils
+import hummingbot.connector.derivative.binance_perpetual.constants as CONSTANTS
+from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_in_flight_order import (
+    BinancePerpetualsInFlightOrder
+)
+from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_order_book_tracker import (
+    BinancePerpetualOrderBookTracker
+)
+from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_user_stream_tracker import (
+    BinancePerpetualUserStreamTracker
+)
+from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
 from hummingbot.connector.derivative.position import Position
-from hummingbot.connector.exchange_base import ExchangeBase, s_decimal_NaN
 from hummingbot.connector.exchange.binance.binance_time import BinanceTime
-from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.exchange_base import ExchangeBase, s_decimal_NaN
 from hummingbot.connector.perpetual_trading import PerpetualTrading
+from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.event.events import (
-    FundingInfo,
-    OrderType,
-    TradeType,
-    MarketOrderFailureEvent,
-    MarketEvent,
-    OrderCancelledEvent,
     BuyOrderCompletedEvent,
     BuyOrderCreatedEvent,
-    SellOrderCreatedEvent,
+    FundingInfo,
     FundingPaymentCompletedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
     OrderFilledEvent,
-    SellOrderCompletedEvent,
-    PositionSide,
-    PositionMode,
+    OrderType,
     PositionAction,
+    PositionMode,
+    PositionSide,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+    TradeType
 )
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -649,13 +649,16 @@ class BinancePerpetualDerivative(ExchangeBase, PerpetualTrading):
                     step_size = Decimal(filt_dict.get("LOT_SIZE").get("stepSize"))
                     tick_size = Decimal(filt_dict.get("PRICE_FILTER").get("tickSize"))
                     min_notional = Decimal(filt_dict.get("MIN_NOTIONAL").get("notional"))
+                    collateral_token = rule["marginAsset"]
 
                     return_val.append(
                         TradingRule(trading_pair,
                                     min_order_size=min_order_size,
                                     min_price_increment=Decimal(tick_size),
                                     min_base_amount_increment=Decimal(step_size),
-                                    min_notional_size=Decimal(min_notional)
+                                    min_notional_size=Decimal(min_notional),
+                                    buy_order_collateral_token=collateral_token,
+                                    sell_order_collateral_token=collateral_token,
                                     )
                     )
             except Exception as e:
@@ -1039,6 +1042,14 @@ class BinancePerpetualDerivative(ExchangeBase, PerpetualTrading):
 
     def supported_position_modes(self):
         return [PositionMode.ONEWAY, PositionMode.HEDGE]
+
+    async def get_buy_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.buy_order_collateral_token
+
+    async def get_sell_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.sell_order_collateral_token
 
     async def request(self,
                       path: str,

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -1,44 +1,41 @@
-import aiohttp
 import asyncio
 import copy
 import logging
 import math
-import pandas as pd
 import time
+from decimal import Decimal
+from typing import Any, AsyncIterable, Dict, List, Optional
+
+import aiohttp
+import pandas as pd
 import ujson
 
-import hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils as bybit_utils
 import hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_constants as CONSTANTS
-
-from decimal import Decimal
-from typing import (
-    Any,
-    AsyncIterable,
-    Dict,
-    List,
-    Optional,
-)
-
-from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
-from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_auth import BybitPerpetualAuth
+import hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils as bybit_utils
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_api_order_book_data_source import \
     BybitPerpetualAPIOrderBookDataSource as OrderBookDataSource
+from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_auth import BybitPerpetualAuth
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_in_flight_order import BybitPerpetualInFlightOrder
-from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_order_book_tracker import \
+from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_order_book_tracker import (
     BybitPerpetualOrderBookTracker
-from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_user_stream_tracker import \
+)
+from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_user_stream_tracker import (
     BybitPerpetualUserStreamTracker
-from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_websocket_adaptor import BybitPerpetualWebSocketAdaptor
+)
+from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_websocket_adaptor import (
+    BybitPerpetualWebSocketAdaptor
+)
+from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
 from hummingbot.connector.derivative.position import Position
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.perpetual_trading import PerpetualTrading
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
-from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
     BuyOrderCreatedEvent,
@@ -54,7 +51,7 @@ from hummingbot.core.event.events import (
     SellOrderCompletedEvent,
     SellOrderCreatedEvent,
     TradeFee,
-    TradeType,
+    TradeType
 )
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -3,6 +3,7 @@ from typing import Optional, Dict, List
 from hummingbot.client.config.config_methods import using_exchange
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.connector.derivative.bybit_perpetual import bybit_perpetual_constants as CONSTANTS
+from hummingbot.connector.utils import split_hb_trading_pair
 from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
@@ -32,15 +33,15 @@ def is_linear_perpetual(trading_pair: str) -> bool:
     """
     Returns True if trading_pair is in USDT(Linear) Perpetual
     """
-    _, quote_asset = trading_pair.split("-")
+    _, quote_asset = split_hb_trading_pair(trading_pair)
     return quote_asset == "USDT"
 
 
 def get_rest_api_market_for_endpoint(trading_pair: Optional[str] = None) -> str:
     if trading_pair and is_linear_perpetual(trading_pair):
-        market = "linear"
+        market = CONSTANTS.LINEAR_MARKET
     else:
-        market = "non_linear"
+        market = CONSTANTS.NON_LINEAR_MARKET
     return market
 
 

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
 
 from hummingbot.client.config.config_methods import using_exchange
 from hummingbot.client.config.config_var import ConfigVar

--- a/hummingbot/connector/derivative/dydx_perpetual/dydx_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/dydx_perpetual/dydx_perpetual_derivative.py
@@ -966,6 +966,7 @@ class DydxPerpetualDerivative(ExchangeBase, PerpetualTrading):
         for market_name in markets_info:
             market = markets_info[market_name]
             try:
+                collateral_token = market["quoteAsset"]  # all contracts settled in USDC
                 self._trading_rules[market_name] = TradingRule(
                     trading_pair=market_name,
                     min_order_size=Decimal(market['minOrderSize']),
@@ -973,7 +974,9 @@ class DydxPerpetualDerivative(ExchangeBase, PerpetualTrading):
                     min_base_amount_increment=Decimal(market['stepSize']),
                     min_notional_size=Decimal(market['minOrderSize']) * Decimal(market['tickSize']),
                     supports_limit_orders=True,
-                    supports_market_orders=True
+                    supports_market_orders=True,
+                    buy_order_collateral_token=collateral_token,
+                    sell_order_collateral_token=collateral_token,
                 )
                 self._margin_fractions[market_name] = {
                     "initial": Decimal(market['initialMarginFraction']),
@@ -1189,3 +1192,11 @@ class DydxPerpetualDerivative(ExchangeBase, PerpetualTrading):
     # TODO: Implement
     async def close_position(self, trading_pair: str):
         pass
+
+    async def get_buy_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.buy_order_collateral_token
+
+    async def get_sell_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.sell_order_collateral_token

--- a/hummingbot/connector/derivative/perpetual_budget_checker.py
+++ b/hummingbot/connector/derivative/perpetual_budget_checker.py
@@ -1,0 +1,50 @@
+import typing
+
+from hummingbot.connector.budget_checker import BudgetChecker, OrderCandidate
+from hummingbot.connector.perpetual_trading import PerpetualTrading
+from hummingbot.core.event.events import TradeType, TradeFee
+
+if typing.TYPE_CHECKING:  # avoid circular import problems
+    from hummingbot.connector.exchange_base import ExchangeBase
+
+
+class PerpetualBudgetChecker(BudgetChecker):
+    def __init__(self, exchange: "ExchangeBase"):
+        """
+        In the case of derived instruments, the collateral can be any token.
+        To get this information, this class uses the `get_buy_collateral_token`
+        and `get_sell_collateral_token` methods provided by the `PerpetualTrading` interface.
+        """
+        super().__init__(exchange)
+        self._validate_perpetual_connector()
+
+    def _validate_perpetual_connector(self):
+        if not isinstance(self._exchange, PerpetualTrading):
+            raise TypeError(
+                f"{self.__class__} must be passed an exchange implementing the {PerpetualTrading} interface."
+            )
+
+    def _get_collateral_token(self, order_candidate: OrderCandidate) -> str:
+        trading_pair = order_candidate.trading_pair
+        if order_candidate.order_side == TradeType.BUY:
+            collateral_token = self._exchange.get_buy_collateral_token(trading_pair)
+        else:
+            collateral_token = self._exchange.get_sell_collateral_token(trading_pair)
+        return collateral_token
+
+    def _get_fee(self, order_candidate: OrderCandidate) -> TradeFee:
+        _, size_token = self._get_order_size_and_size_token(order_candidate)
+        size_collateral_price = self._get_size_collateral_price(order_candidate)
+        adjustment_base = size_token
+        adjustment_quote = order_candidate.collateral_token
+
+        fee = self._exchange.get_fee(
+            adjustment_base,
+            adjustment_quote,
+            order_candidate.order_type,
+            order_candidate.order_side,
+            order_candidate.amount,
+            size_collateral_price,
+        )
+
+        return fee

--- a/hummingbot/connector/derivative/perpetual_budget_checker.py
+++ b/hummingbot/connector/derivative/perpetual_budget_checker.py
@@ -1,11 +1,19 @@
 import typing
+from dataclasses import dataclass
+from decimal import Decimal
 
 from hummingbot.connector.budget_checker import BudgetChecker, OrderCandidate
 from hummingbot.connector.perpetual_trading import PerpetualTrading
-from hummingbot.core.event.events import TradeType, TradeFee
+from hummingbot.core.event.events import TradeFee, TradeType
 
 if typing.TYPE_CHECKING:  # avoid circular import problems
     from hummingbot.connector.exchange_base import ExchangeBase
+
+
+@dataclass
+class PerpetualOrderCandidate(OrderCandidate):
+    leverage: Decimal = Decimal("1")
+    position_close: bool = False
 
 
 class PerpetualBudgetChecker(BudgetChecker):
@@ -24,7 +32,7 @@ class PerpetualBudgetChecker(BudgetChecker):
                 f"{self.__class__} must be passed an exchange implementing the {PerpetualTrading} interface."
             )
 
-    def _get_collateral_token(self, order_candidate: OrderCandidate) -> str:
+    def _get_collateral_token(self, order_candidate: PerpetualOrderCandidate) -> str:
         trading_pair = order_candidate.trading_pair
         if order_candidate.order_side == TradeType.BUY:
             collateral_token = self._exchange.get_buy_collateral_token(trading_pair)
@@ -32,7 +40,37 @@ class PerpetualBudgetChecker(BudgetChecker):
             collateral_token = self._exchange.get_sell_collateral_token(trading_pair)
         return collateral_token
 
-    def _get_fee(self, order_candidate: OrderCandidate) -> TradeFee:
+    def _get_base_required_collateral(self, order_candidate: PerpetualOrderCandidate) -> Decimal:
+        if order_candidate.position_close:
+            required_collateral = self._get_close_base_required_collateral()
+        else:
+            required_collateral = self._get_open_base_required_collateral(order_candidate)
+        return required_collateral
+
+    @staticmethod
+    def _get_close_base_required_collateral() -> Decimal:
+        required_collateral = Decimal("0")
+        return required_collateral
+
+    def _get_open_base_required_collateral(self, order_candidate: PerpetualOrderCandidate) -> Decimal:
+        order_size, size_token = self._get_order_size_and_size_token(order_candidate)
+        size_collateral_price = self._get_size_collateral_price(order_candidate)
+        required_collateral = order_size * size_collateral_price / order_candidate.leverage
+        return required_collateral
+
+    def _get_fee(self, order_candidate: PerpetualOrderCandidate) -> TradeFee:
+        if order_candidate.position_close:
+            fee = self._get_close_fee()
+        else:
+            fee = self._get_open_fee(order_candidate)
+        return fee
+
+    @staticmethod
+    def _get_close_fee() -> TradeFee:
+        fee = TradeFee(percent=Decimal("0"))
+        return fee
+
+    def _get_open_fee(self, order_candidate: PerpetualOrderCandidate) -> TradeFee:
         _, size_token = self._get_order_size_and_size_token(order_candidate)
         size_collateral_price = self._get_size_collateral_price(order_candidate)
         adjustment_base = size_token
@@ -48,3 +86,7 @@ class PerpetualBudgetChecker(BudgetChecker):
         )
 
         return fee
+
+    def _lock_available_collateral(self, order_candidate: PerpetualOrderCandidate):
+        if not order_candidate.position_close:
+            self._locked_collateral[order_candidate.collateral_token] += order_candidate.collateral_amount

--- a/hummingbot/connector/derivative/perpetual_finance/perpetual_finance_derivative.py
+++ b/hummingbot/connector/derivative/perpetual_finance/perpetual_finance_derivative.py
@@ -627,3 +627,7 @@ class PerpetualFinanceDerivative(ExchangeBase, PerpetualTrading):
     @property
     def in_flight_orders(self) -> Dict[str, PerpetualFinanceInFlightOrder]:
         return self._in_flight_orders
+
+    async def get_sell_collateral_token(self, trading_pair: str) -> str:
+        _, quote = self.split_trading_pair(trading_pair)
+        return quote

--- a/hummingbot/connector/derivative/perpetual_finance/perpetual_finance_derivative.py
+++ b/hummingbot/connector/derivative/perpetual_finance/perpetual_finance_derivative.py
@@ -1,47 +1,49 @@
-import logging
-from decimal import Decimal
 import asyncio
-import aiohttp
-from typing import Dict, Any, List, Optional
-import json
-import time
-import ssl
 import copy
+import json
+import logging
+import ssl
+import time
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
 
+import aiohttp
+
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.client.settings import GATEAWAY_CA_CERT_PATH, GATEAWAY_CLIENT_CERT_PATH, GATEAWAY_CLIENT_KEY_PATH
 from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
-from hummingbot.logger.struct_logger import METRICS_LOG_LEVEL
-from hummingbot.core.event.events import TradeFee
-from hummingbot.core.utils import async_ttl_cache
-from hummingbot.core.network_iterator import NetworkStatus
-from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
-from hummingbot.logger import HummingbotLogger
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
-from hummingbot.core.utils.estimate_fee import estimate_fee
-from hummingbot.core.data_type.limit_order import LimitOrder
-from hummingbot.core.data_type.cancellation_result import CancellationResult
-from hummingbot.core.event.events import (
-    MarketEvent,
-    BuyOrderCreatedEvent,
-    SellOrderCreatedEvent,
-    BuyOrderCompletedEvent,
-    SellOrderCompletedEvent,
-    MarketOrderFailureEvent,
-    FundingPaymentCompletedEvent,
-    OrderFilledEvent,
-    OrderType,
-    TradeType,
-    PositionSide,
-    PositionAction,
-    FundingInfo
+from hummingbot.connector.derivative.perpetual_finance.perpetual_finance_in_flight_order import (
+    PerpetualFinanceInFlightOrder
 )
+from hummingbot.connector.derivative.perpetual_finance.perpetual_finance_utils import convert_to_exchange_trading_pair
+from hummingbot.connector.derivative.position import Position
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.perpetual_trading import PerpetualTrading
-from hummingbot.connector.derivative.perpetual_finance.perpetual_finance_in_flight_order import PerpetualFinanceInFlightOrder
-from hummingbot.connector.derivative.perpetual_finance.perpetual_finance_utils import convert_to_exchange_trading_pair
-from hummingbot.client.settings import GATEAWAY_CA_CERT_PATH, GATEAWAY_CLIENT_CERT_PATH, GATEAWAY_CLIENT_KEY_PATH
-from hummingbot.client.config.global_config_map import global_config_map
-from hummingbot.connector.derivative.position import Position
-
+from hummingbot.core.data_type.cancellation_result import CancellationResult
+from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    FundingInfo,
+    FundingPaymentCompletedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
+    OrderFilledEvent,
+    OrderType,
+    PositionAction,
+    PositionSide,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+    TradeFee,
+    TradeType
+)
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.utils import async_ttl_cache
+from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
+from hummingbot.core.utils.estimate_fee import estimate_fee
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
+from hummingbot.logger import HummingbotLogger
+from hummingbot.logger.struct_logger import METRICS_LOG_LEVEL
 
 s_logger = None
 s_decimal_0 = Decimal("0")

--- a/hummingbot/connector/exchange/binance/binance_exchange.pyx
+++ b/hummingbot/connector/exchange/binance/binance_exchange.pyx
@@ -360,7 +360,7 @@ cdef class BinanceExchange(ExchangeBase):
             list retval = []
         for rule in trading_pair_rules:
             try:
-                trading_pair = rule.get("symbol")
+                trading_pair = convert_from_exchange_trading_pair(rule.get("symbol"))
                 filters = rule.get("filters")
                 price_filter = [f for f in filters if f.get("filterType") == "PRICE_FILTER"][0]
                 lot_size_filter = [f for f in filters if f.get("filterType") == "LOT_SIZE"][0]

--- a/hummingbot/connector/exchange/binance/binance_exchange.pyx
+++ b/hummingbot/connector/exchange/binance/binance_exchange.pyx
@@ -327,7 +327,7 @@ cdef class BinanceExchange(ExchangeBase):
             trading_rules_list = self._format_trading_rules(exchange_info)
             self._trading_rules.clear()
             for trading_rule in trading_rules_list:
-                self._trading_rules[convert_from_exchange_trading_pair(trading_rule.trading_pair)] = trading_rule
+                self._trading_rules[trading_rule.trading_pair] = trading_rule
 
     def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
         """

--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -361,7 +361,7 @@ cdef class HuobiExchange(ExchangeBase):
             trading_rules_list = self._format_trading_rules(exchange_info)
             self._trading_rules.clear()
             for trading_rule in trading_rules_list:
-                self._trading_rules[convert_from_exchange_trading_pair(trading_rule.trading_pair)] = trading_rule
+                self._trading_rules[trading_rule.trading_pair] = trading_rule
 
     def _format_trading_rules(self, raw_trading_pair_info: List[Dict[str, Any]]) -> List[TradingRule]:
         cdef:
@@ -370,7 +370,7 @@ cdef class HuobiExchange(ExchangeBase):
         for info in raw_trading_pair_info:
             try:
                 trading_rules.append(
-                    TradingRule(trading_pair=info["symbol"],
+                    TradingRule(trading_pair=convert_from_exchange_trading_pair(info["symbol"]),
                                 min_order_size=Decimal(info["min-order-amt"]),
                                 max_order_size=Decimal(info["max-order-amt"]),
                                 min_price_increment=Decimal(f"1e-{info['price-precision']}"),

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -62,6 +62,8 @@ from .market_config import (
     MarketConfig,
     AssetType
 )
+from ...budget_checker import BudgetChecker
+
 ptm_logger = None
 s_decimal_0 = Decimal(0)
 
@@ -168,7 +170,8 @@ cdef class PaperTradeExchange(ExchangeBase):
     def __init__(self, order_book_tracker: OrderBookTracker, config: MarketConfig, target_market: type):
         order_book_tracker.data_source.order_book_create_function = lambda: CompositeOrderBook()
         self._order_book_tracker = order_book_tracker
-        super().__init__()  # super(ExchangeBase, self).__init__() does not work
+        self._budget_checker = BudgetChecker(exchange=self)
+        super(ExchangeBase, self).__init__()  # super(ExchangeBase, self).__init__() does not work
         self._account_balances = {}
         self._account_available_balances = {}
         self._paper_trade_market_initialized = False
@@ -184,6 +187,10 @@ cdef class PaperTradeExchange(ExchangeBase):
     @property
     def order_book_tracker(self) -> OrderBookTracker:
         return self._order_book_tracker
+
+    @property
+    def budget_checker(self) -> BudgetChecker:
+        return self._budget_checker
 
     @classmethod
     def random_order_id(cls, order_side: str, trading_pair: str) -> str:

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -171,7 +171,7 @@ cdef class PaperTradeExchange(ExchangeBase):
         order_book_tracker.data_source.order_book_create_function = lambda: CompositeOrderBook()
         self._order_book_tracker = order_book_tracker
         self._budget_checker = BudgetChecker(exchange=self)
-        super(ExchangeBase, self).__init__()  # super(ExchangeBase, self).__init__() does not work
+        super(ExchangeBase, self).__init__()
         self._account_balances = {}
         self._account_available_balances = {}
         self._paper_trade_market_initialized = False

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -168,7 +168,7 @@ cdef class PaperTradeExchange(ExchangeBase):
     def __init__(self, order_book_tracker: OrderBookTracker, config: MarketConfig, target_market: type):
         order_book_tracker.data_source.order_book_create_function = lambda: CompositeOrderBook()
         self._order_book_tracker = order_book_tracker
-        super(ExchangeBase, self).__init__()
+        super().__init__()  # super(ExchangeBase, self).__init__() does not work
         self._account_balances = {}
         self._account_available_balances = {}
         self._paper_trade_market_initialized = False

--- a/hummingbot/connector/exchange_base.pxd
+++ b/hummingbot/connector/exchange_base.pxd
@@ -10,6 +10,7 @@ from hummingbot.core.data_type.order_book_query_result cimport(
 cdef class ExchangeBase(ConnectorBase):
     cdef:
         object _order_book_tracker
+        object _budget_checker
 
     cdef str c_buy(self, str trading_pair, object amount, object order_type=*, object price=*, dict kwargs=*)
     cdef str c_sell(self, str trading_pair, object amount, object order_type=*, object price=*, dict kwargs=*)

--- a/hummingbot/connector/perpetual_trading.py
+++ b/hummingbot/connector/perpetual_trading.py
@@ -2,10 +2,9 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import Dict, List, Optional
 
-from hummingbot.connector.utils import split_hb_trading_pair
-from hummingbot.core.event.events import PositionMode, FundingInfo, PositionSide
 from hummingbot.connector.derivative.position import Position
-
+from hummingbot.connector.utils import split_hb_trading_pair
+from hummingbot.core.event.events import FundingInfo, PositionMode, PositionSide
 
 NaN = float("nan")
 s_decimal_NaN = Decimal("nan")

--- a/hummingbot/connector/perpetual_trading.py
+++ b/hummingbot/connector/perpetual_trading.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from decimal import Decimal
 from typing import Dict, List, Optional
+
+from hummingbot.connector.utils import split_hb_trading_pair
 from hummingbot.core.event.events import PositionMode, FundingInfo, PositionSide
 from hummingbot.connector.derivative.position import Position
 
@@ -102,3 +104,11 @@ class PerpetualTrading:
         :return: funding info
         """
         return self._funding_info[trading_pair]
+
+    async def get_buy_collateral_token(self, trading_pair: str) -> str:
+        _, quote = split_hb_trading_pair(trading_pair)
+        return quote
+
+    async def get_sell_collateral_token(self, trading_pair: str) -> str:
+        _, quote = split_hb_trading_pair(trading_pair)
+        return quote

--- a/hummingbot/connector/perpetual_trading.py
+++ b/hummingbot/connector/perpetual_trading.py
@@ -105,10 +105,10 @@ class PerpetualTrading:
         """
         return self._funding_info[trading_pair]
 
-    async def get_buy_collateral_token(self, trading_pair: str) -> str:
+    def get_buy_collateral_token(self, trading_pair: str) -> str:
         _, quote = split_hb_trading_pair(trading_pair)
         return quote
 
-    async def get_sell_collateral_token(self, trading_pair: str) -> str:
+    def get_sell_collateral_token(self, trading_pair: str) -> str:
         _, quote = split_hb_trading_pair(trading_pair)
         return quote

--- a/hummingbot/connector/trading_rule.pxd
+++ b/hummingbot/connector/trading_rule.pxd
@@ -11,3 +11,5 @@ cdef class TradingRule:
         public object min_order_value                  # Calculated min base asset value based on the minimum accepted trade value (e.g. 0.078LTC is ~50,000 Satoshis)
         public bint supports_limit_orders              # if limit order is allowed for this trading pair
         public bint supports_market_orders             # if market order is allowed for this trading pair
+        public object buy_order_collateral_token       # Indicates the collateral token used for buy orders
+        public object sell_order_collateral_token      # Indicates the collateral token used for sell orders

--- a/hummingbot/connector/trading_rule.pyx
+++ b/hummingbot/connector/trading_rule.pyx
@@ -1,4 +1,7 @@
 from decimal import Decimal
+from typing import Optional
+
+from hummingbot.connector.utils import split_hb_trading_pair
 
 s_decimal_0 = Decimal(0)
 s_decimal_max = Decimal("1e56")
@@ -17,7 +20,9 @@ cdef class TradingRule:
                  min_order_value: Decimal = s_decimal_0,
                  max_price_significant_digits: Decimal = s_decimal_max,
                  supports_limit_orders: bool = True,
-                 supports_market_orders: bool = True):
+                 supports_market_orders: bool = True,
+                 buy_order_collateral_token: Optional[str] = None,
+                 sell_order_collateral_token: Optional[str] = None):
         self.trading_pair = trading_pair
         self.min_order_size = min_order_size
         self.max_order_size = max_order_size
@@ -29,6 +34,9 @@ cdef class TradingRule:
         self.max_price_significant_digits = max_price_significant_digits
         self.supports_limit_orders = supports_limit_orders
         self.supports_market_orders = supports_market_orders
+        quote_token = split_hb_trading_pair(self.trading_pair)[1]
+        self.buy_order_collateral_token = buy_order_collateral_token or quote_token
+        self.sell_order_collateral_token = sell_order_collateral_token or quote_token
 
     def __repr__(self) -> str:
         return f"TradingRule(trading_pair='{self.trading_pair}', " \
@@ -41,4 +49,6 @@ cdef class TradingRule:
                f"min_order_value={self.min_order_value}), " \
                f"max_price_significant_digits={self.max_price_significant_digits}), " \
                f"supports_limit_orders={self.supports_limit_orders}), " \
-               f"supports_market_orders={self.supports_market_orders})"
+               f"supports_market_orders={self.supports_market_orders}, " \
+               f"buy_order_collateral_token={self.buy_order_collateral_token}, " \
+               f"sell_order_collateral_token={self.sell_order_collateral_token})"

--- a/hummingbot/connector/utils.py
+++ b/hummingbot/connector/utils.py
@@ -4,7 +4,8 @@ import base64
 from collections import namedtuple
 from typing import (
     Dict,
-    Optional
+    Optional,
+    Tuple,
 )
 from zero_ex.order_utils import Order as ZeroExOrder
 
@@ -37,3 +38,8 @@ def json_to_zrx_order(data: Optional[Dict[str, any]]) -> Optional[ZeroExOrder]:
         else:
             intermediate[key] = value
     return ZeroExOrder(intermediate)
+
+
+def split_hb_trading_pair(trading_pair: str) -> Tuple[str, str]:
+    base, quote = trading_pair.split("-")
+    return base, quote

--- a/hummingbot/connector/utils.py
+++ b/hummingbot/connector/utils.py
@@ -43,3 +43,8 @@ def json_to_zrx_order(data: Optional[Dict[str, any]]) -> Optional[ZeroExOrder]:
 def split_hb_trading_pair(trading_pair: str) -> Tuple[str, str]:
     base, quote = trading_pair.split("-")
     return base, quote
+
+
+def combine_to_hb_trading_pair(base: str, quote: str) -> str:
+    trading_pair = f"{base}-{quote}"
+    return trading_pair

--- a/hummingbot/connector/utils.py
+++ b/hummingbot/connector/utils.py
@@ -2,13 +2,9 @@
 
 import base64
 from collections import namedtuple
-from typing import (
-    Dict,
-    Optional,
-    Tuple,
-)
-from zero_ex.order_utils import Order as ZeroExOrder
+from typing import Dict, Optional, Tuple
 
+from zero_ex.order_utils import Order as ZeroExOrder
 
 TradeFillOrderDetails = namedtuple("TradeFillOrderDetails", "market exchange_trade_id symbol")
 

--- a/hummingbot/core/event/events.py
+++ b/hummingbot/core/event/events.py
@@ -193,16 +193,18 @@ class TradeFee(NamedTuple):
                 fee_amount += flat_fee[1]
         return fee_amount
 
-    def order_amount_from_quote_with_fee(self, trading_pair: str, price: Decimal, order_size: Decimal):
-        order_amount = order_size
+    def order_amount_from_quote_with_fee(
+        self, trading_pair: str, price: Decimal, order_size_with_fee: Decimal
+    ):
+        fee_amount = order_size_with_fee
         base, quote = split_hb_trading_pair(trading_pair)
         for flat_fee in self.flat_fees:
             if interchangeable(flat_fee[0], base):
-                order_amount -= (flat_fee[1] * price)
+                fee_amount -= (flat_fee[1] * price)
             elif interchangeable(flat_fee[0], quote):
-                order_amount -= flat_fee[1]
-        if self.percent > 0:
-            order_amount /= self.percent * self.percent
+                fee_amount -= flat_fee[1]
+        order_size = order_size_with_fee / (Decimal("1") + self.percent)
+        order_amount = order_size / price
         return order_amount
 
 

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pxd
@@ -74,6 +74,8 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
     cdef c_apply_ping_pong(self, object proposal)
     cdef c_apply_order_price_modifiers(self, object proposal)
     cdef c_apply_budget_constraint(self, object proposal)
+    cdef list c_create_order_candidates_for_budget_check(self, object proposal)
+    cdef c_apply_adjusted_order_candidates_to_proposal(self, list adjusted_candidates, object proposal)
     cdef c_filter_out_takers(self, object proposal)
     cdef c_apply_order_optimization(self, object proposal)
     cdef c_apply_add_transaction_costs(self, object proposal)

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -2,22 +2,18 @@ from decimal import Decimal
 import logging
 import pandas as pd
 import numpy as np
-from typing import (
-    List,
-    Dict,
-    Optional
-)
+from typing import List, Dict
 from math import (
     floor,
     ceil
 )
 import time
+from itertools import chain
 from hummingbot.core.clock cimport Clock
 from hummingbot.core.event.events import (
     TradeType,
     PriceType,
     PositionAction,
-    PositionSide,
     PositionMode
 )
 from hummingbot.core.data_type.limit_order cimport LimitOrder
@@ -29,7 +25,6 @@ from hummingbot.core.event.events import OrderType
 
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.strategy_base import StrategyBase
-from hummingbot.client.config.global_config_map import global_config_map
 
 from .data_types import (
     Proposal,
@@ -41,7 +36,7 @@ from hummingbot.strategy.asset_price_delegate cimport AssetPriceDelegate
 from hummingbot.strategy.asset_price_delegate import AssetPriceDelegate
 from hummingbot.strategy.order_book_asset_price_delegate cimport OrderBookAssetPriceDelegate
 from hummingbot.core.utils import map_df_to_str
-
+from hummingbot.connector.budget_checker import OrderCandidate
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)
@@ -886,37 +881,48 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
         if self._add_transaction_costs_to_orders:
             self.c_apply_add_transaction_costs(proposal)
 
+    def apply_budget_constraint(self, proposal: Proposal):
+        self.c_apply_budget_constraint(proposal)
+
     cdef c_apply_budget_constraint(self, object proposal):
         cdef:
-            ExchangeBase market = self._market_info.market
-            object quote_size
-            object base_size
-            object quote_size_total = Decimal("0")
-            object base_size_total = Decimal("0")
+            object checker = self._market_info.market.budget_checker
+            list order_candidates
+            list adjusted_candidates
 
-        quote_balance = market.c_get_available_balance(self.quote_asset)
-        trading_fees = market.c_get_fee(self.base_asset, self.quote_asset, OrderType.LIMIT, TradeType.BUY,
-                                        s_decimal_zero, s_decimal_zero)
+        order_candidates = self.c_create_order_candidates_for_budget_check(proposal)
+        adjusted_candidates = checker.adjust_candidates(order_candidates, all_or_none=True)
+        self.c_apply_adjusted_order_candidates_to_proposal(adjusted_candidates, proposal)
 
-        for buy in proposal.buys:
-            order_size = buy.size * buy.price
-            quote_size = (order_size / self._leverage) + (order_size * trading_fees.percent)
-            if quote_balance < quote_size_total + quote_size:
-                self.logger().info(f"Insufficient balance: Buy order (price: {buy.price}, size: {buy.size}) is omitted, {self.quote_asset} available balance: {quote_balance - quote_size_total}.")
+    cdef list c_create_order_candidates_for_budget_check(self, object proposal):
+        cdef:
+            list order_candidates = []
+
+        order_candidates.extend(
+            [
+                OrderCandidate(self.trading_pair, OrderType.LIMIT, TradeType.BUY, buy.size, buy.price)
+                for buy in proposal.buys
+            ]
+        )
+        order_candidates.extend(
+            [
+                OrderCandidate(self.trading_pair, OrderType.LIMIT, TradeType.SELL, sell.size, sell.price)
+                for sell in proposal.sells
+            ]
+        )
+        return order_candidates
+
+    cdef c_apply_adjusted_order_candidates_to_proposal(self, list adjusted_candidates, object proposal):
+        for order in chain(proposal.buys, proposal.sells):
+            adjusted_candidate = adjusted_candidates.pop(0)
+            if adjusted_candidate.amount == s_decimal_zero:
+                self.logger().info(
+                    f"Insufficient balance: {adjusted_candidate.order_side.name} order (price: {order.price},"
+                    f" size: {order.size}) is omitted."
+                )
                 self.logger().warning("You are also at a possible risk of being liquidated if there happens to be an open loss.")
-                quote_size = s_decimal_zero
-                buy.size = s_decimal_zero
-            quote_size_total += quote_size
+                order.size = s_decimal_zero
         proposal.buys = [o for o in proposal.buys if o.size > 0]
-        for sell in proposal.sells:
-            order_size = sell.size * sell.price
-            quote_size = (order_size / self._leverage) + (order_size * trading_fees.percent)
-            if quote_balance < quote_size_total + quote_size:
-                self.logger().info(f"Insufficient balance: Sell order (price: {sell.price}, size: {sell.size}) is omitted, {self.quote_asset} available balance: {quote_balance - quote_size_total}.")
-                self.logger().warning("You are also at a possible risk of being liquidated if there happens to be an open loss.")
-                base_size = s_decimal_zero
-                sell.size = s_decimal_zero
-            quote_size_total += quote_size
         proposal.sells = [o for o in proposal.sells if o.size > 0]
 
     cdef c_filter_out_takers(self, object proposal):

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.pyx
@@ -36,7 +36,7 @@ from hummingbot.strategy.asset_price_delegate cimport AssetPriceDelegate
 from hummingbot.strategy.asset_price_delegate import AssetPriceDelegate
 from hummingbot.strategy.order_book_asset_price_delegate cimport OrderBookAssetPriceDelegate
 from hummingbot.core.utils import map_df_to_str
-from hummingbot.connector.budget_checker import OrderCandidate
+from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualOrderCandidate
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)
@@ -900,13 +900,27 @@ cdef class PerpetualMarketMakingStrategy(StrategyBase):
 
         order_candidates.extend(
             [
-                OrderCandidate(self.trading_pair, OrderType.LIMIT, TradeType.BUY, buy.size, buy.price)
+                PerpetualOrderCandidate(
+                    self.trading_pair,
+                    OrderType.LIMIT,
+                    TradeType.BUY,
+                    buy.size,
+                    buy.price,
+                    leverage=Decimal(self._leverage),
+                )
                 for buy in proposal.buys
             ]
         )
         order_candidates.extend(
             [
-                OrderCandidate(self.trading_pair, OrderType.LIMIT, TradeType.SELL, sell.size, sell.price)
+                PerpetualOrderCandidate(
+                    self.trading_pair,
+                    OrderType.LIMIT,
+                    TradeType.SELL,
+                    sell.size,
+                    sell.price,
+                    leverage=Decimal(self._leverage),
+                )
                 for sell in proposal.sells
             ]
         )

--- a/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
@@ -293,7 +293,7 @@ class SpotPerpetualArbitrageStrategy(StrategyPyBase):
         :param proposal: An arbitrage proposal
         :return: True if user has available balance enough for both orders submission.
         """
-        return (self.check_spot_budget_constraint(proposal) and self.check_perpetual_budget_constraint(proposal))
+        return self.check_spot_budget_constraint(proposal) and self.check_perpetual_budget_constraint(proposal)
 
     def check_spot_budget_constraint(self, proposal: ArbProposal) -> bool:
         """

--- a/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
@@ -25,7 +25,7 @@ from hummingbot.core.event.events import (
 from hummingbot.connector.derivative.position import Position
 
 from .arb_proposal import ArbProposalSide, ArbProposal
-
+from hummingbot.connector.budget_checker import OrderCandidate
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)
@@ -292,39 +292,38 @@ class SpotPerpetualArbitrageStrategy(StrategyPyBase):
         :param proposal: An arbitrage proposal
         :return: True if user has available balance enough for both orders submission.
         """
-        spot_side = proposal.spot_side
-        spot_token = spot_side.market_info.quote_asset if spot_side.is_buy else spot_side.market_info.base_asset
-        spot_avai_bal = spot_side.market_info.market.get_available_balance(spot_token)
-        if spot_side.is_buy:
-            fee = spot_side.market_info.market.get_fee(
-                spot_side.market_info.base_asset,
-                spot_side.market_info.quote_asset, OrderType.LIMIT, TradeType.BUY, s_decimal_zero, s_decimal_zero
-            )
-            spot_required_bal = (proposal.order_amount * proposal.spot_side.order_price) * (Decimal("1") + fee.percent)
-        else:
-            spot_required_bal = proposal.order_amount
-        if spot_avai_bal < spot_required_bal:
-            self.logger().info(f"Cannot arbitrage, {spot_side.market_info.market.display_name} {spot_token} balance "
-                               f"({spot_avai_bal}) is below required order amount ({spot_required_bal}).")
-            return False
-        perp_side = proposal.perp_side
-        if self.perp_positions and abs(self.perp_positions[0].amount) == proposal.order_amount:
-            cur_perp_pos_is_buy = True if self.perp_positions[0].amount > 0 else False
-            if perp_side != cur_perp_pos_is_buy:
-                # For perpetual, the collateral in the existing position should be enough to cover the closing call
-                return True
-        perp_token = perp_side.market_info.quote_asset
-        perp_avai_bal = perp_side.market_info.market.get_available_balance(perp_token)
-        fee = spot_side.market_info.market.get_fee(
-            spot_side.market_info.base_asset,
-            spot_side.market_info.quote_asset, OrderType.LIMIT, TradeType.BUY, s_decimal_zero, s_decimal_zero
+        possible = True
+        possible = possible and self.check_budget_constraint_single_side(proposal.spot_side, proposal.order_amount)
+        possible = possible and self.check_budget_constraint_single_side(proposal.perp_side, proposal.order_amount)
+        return possible
+
+    def check_budget_constraint_single_side(self, proposal_side: ArbProposalSide, order_amount: Decimal) -> bool:
+        """
+        Check balances on a single exchange if there is enough to submit the respective side's order.
+        :param proposal_side: An arbitrage proposal side.
+        :param order_amount: The proposal's order amount.
+        :return: True if user has available balance enough for both orders submission.
+        """
+        spot_side_market_info = proposal_side.market_info
+        spot_budget_checker = spot_side_market_info.market.budget_checker
+        order_candidate = OrderCandidate(
+            trading_pair=spot_side_market_info.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY if proposal_side.is_buy else TradeType.SELL,
+            amount=order_amount,
+            price=proposal_side.order_price,
         )
-        pos_size = (proposal.order_amount * proposal.spot_side.order_price)
-        perp_required_bal = (pos_size / self._perp_leverage) + (pos_size * fee.percent)
-        if perp_avai_bal < perp_required_bal:
-            self.logger().info(f"Cannot arbitrage, {perp_side.market_info.market.display_name} {perp_token} balance "
-                               f"({perp_avai_bal}) is below required position amount ({perp_required_bal}).")
+
+        adjusted_candidate_order = spot_budget_checker.adjust_candidate(order_candidate, all_or_none=True)
+
+        if adjusted_candidate_order.amount < order_amount:
+            self.logger().info(
+                f"Cannot arbitrage, {proposal_side.market_info.market.display_name}"
+                f" {adjusted_candidate_order.collateral_token} balance ({adjusted_candidate_order.collateral_amount})"
+                f" is below required to place the order amount {order_amount}."
+            )
             return False
+
         return True
 
     def execute_arb_proposal(self, proposal: ArbProposal):

--- a/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py
@@ -293,10 +293,7 @@ class SpotPerpetualArbitrageStrategy(StrategyPyBase):
         :param proposal: An arbitrage proposal
         :return: True if user has available balance enough for both orders submission.
         """
-        possible = True
-        possible = possible and self.check_spot_budget_constraint(proposal)
-        possible = possible and self.check_perpetual_budget_constraint(proposal)
-        return possible
+        return (self.check_spot_budget_constraint(proposal) and self.check_perpetual_budget_constraint(proposal))
 
     def check_spot_budget_constraint(self, proposal: ArbProposal) -> bool:
         """

--- a/test/connector/test_budget_checker.py
+++ b/test/connector/test_budget_checker.py
@@ -1,0 +1,362 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.connector.budget_checker import OrderCandidate, PerpetualBudgetChecker
+from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
+from hummingbot.connector.perpetual_trading import PerpetualTrading
+from hummingbot.core.event.events import OrderType, TradeType
+from test.mock.mock_paper_exchange import MockPaperExchange
+
+
+class BudgetCheckerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.base_asset = "COINALPHA"
+        self.quote_asset = "HBOT"
+        self.trading_pair = f"{self.base_asset}-{self.quote_asset}"
+
+        self.fee_percent = Decimal("1")
+        self.exchange = MockPaperExchange(self.fee_percent)
+        self.budget_checker = self.exchange.budget_checker
+
+    def test_populate_collateral_fields_buy_order(self):
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
+
+        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
+
+    def test_populate_collateral_fields_sell_order(self):
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
+
+        self.assertEqual(self.base_asset, populated_candidate.collateral_token)
+        self.assertEqual(Decimal("10"), populated_candidate.collateral_amount)
+
+    def test_adjust_candidate_sufficient_funds(self):
+        self.exchange.set_balance(self.quote_asset, Decimal("100"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("10"), adjusted_candidate.amount)
+
+    def test_adjust_candidate_insufficient_funds_all_or_none(self):
+        self.exchange.set_balance(self.quote_asset, Decimal("10"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=True)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("0"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("0"), adjusted_candidate.amount)
+
+    def test_adjust_candidate_buy_insufficient_funds_partial_adjustment_allowed(self):
+        q_params = QuantizationParams(
+            trading_pair=self.trading_pair,
+            price_precision=8,
+            price_decimals=2,
+            order_size_precision=8,
+            order_size_decimals=2,
+        )
+        self.exchange.set_quantization_param(q_params)
+        self.exchange.set_balance(self.quote_asset, Decimal("10"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimals
+
+    def test_adjust_candidate_sell_insufficient_funds_partial_adjustment_allowed(self):
+        self.exchange.set_balance(self.base_asset, Decimal("5"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        self.assertEqual(self.base_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("5"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("5"), adjusted_candidate.amount)
+
+    def test_adjust_candidate_and_lock_available_collateral(self):
+        self.exchange.set_balance(self.base_asset, Decimal("10"))
+
+        first_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("7"),
+            price=Decimal("2"),
+        )
+        first_adjusted_candidate = self.budget_checker.adjust_candidate_and_lock_available_collateral(
+            first_order_candidate, all_or_none=False
+        )
+        second_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("5"),
+            price=Decimal("2"),
+        )
+        second_adjusted_candidate = self.budget_checker.adjust_candidate_and_lock_available_collateral(
+            second_order_candidate, all_or_none=False
+        )
+        third_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("5"),
+            price=Decimal("2"),
+        )
+        third_adjusted_candidate = self.budget_checker.adjust_candidate_and_lock_available_collateral(
+            third_order_candidate, all_or_none=False
+        )
+
+        self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
+        self.assertEqual(Decimal("3"), second_adjusted_candidate.amount)
+        self.assertEqual(Decimal("0"), third_adjusted_candidate.amount)
+
+    def test_reset_locked_collateral(self):
+        self.exchange.set_balance(self.base_asset, Decimal("10"))
+
+        first_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("7"),
+            price=Decimal("2"),
+        )
+        first_adjusted_candidate = self.budget_checker.adjust_candidate_and_lock_available_collateral(
+            first_order_candidate, all_or_none=False
+        )
+
+        self.budget_checker.reset_locked_collateral()
+
+        second_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("5"),
+            price=Decimal("2"),
+        )
+        second_adjusted_candidate = self.budget_checker.adjust_candidate_and_lock_available_collateral(
+            second_order_candidate, all_or_none=False
+        )
+
+        self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
+        self.assertEqual(Decimal("5"), second_adjusted_candidate.amount)
+
+    def test_adjust_candidates(self):
+        self.exchange.set_balance(self.base_asset, Decimal("10"))
+
+        first_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("7"),
+            price=Decimal("2"),
+        )
+        second_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("5"),
+            price=Decimal("2"),
+        )
+        third_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("5"),
+            price=Decimal("2"),
+        )
+
+        first_adjusted_candidate, second_adjusted_candidate, third_adjusted_candidate = (
+            self.budget_checker.adjust_candidates(
+                [first_order_candidate, second_order_candidate, third_order_candidate], all_or_none=False
+            )
+        )
+
+        self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
+        self.assertEqual(Decimal("3"), second_adjusted_candidate.amount)
+        self.assertEqual(Decimal("0"), third_adjusted_candidate.amount)
+
+    def test_adjust_candidates_resets_locked_collateral(self):
+        self.exchange.set_balance(self.base_asset, Decimal("10"))
+
+        first_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("7"),
+            price=Decimal("2"),
+        )
+        first_adjusted_candidate, = self.budget_checker.adjust_candidates(
+            [first_order_candidate], all_or_none=False
+        )
+
+        second_order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("5"),
+            price=Decimal("2"),
+        )
+        second_adjusted_candidate = self.budget_checker.adjust_candidate_and_lock_available_collateral(
+            second_order_candidate, all_or_none=False
+        )
+
+        self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
+        self.assertEqual(Decimal("5"), second_adjusted_candidate.amount)
+
+
+class MockPerpetualExchange(MockPaperExchange, PerpetualTrading):
+    def __init__(self, fee_percent: Decimal = Decimal("0")):
+        super().__init__(fee_percent)
+        self._budget_checker = PerpetualBudgetChecker(exchange=self)
+
+    @property
+    def budget_checker(self) -> PerpetualBudgetChecker:
+        return self._budget_checker
+
+
+class PerpetualBudgetCheckerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.base_asset = "COINALPHA"
+        self.quote_asset = "HBOT"
+        self.trading_pair = f"{self.base_asset}-{self.quote_asset}"
+
+        self.fee_percent = Decimal("1")
+        self.exchange = MockPerpetualExchange(self.fee_percent)
+        self.budget_checker = self.exchange.budget_checker
+
+    def test_populate_collateral_fields_buy_order(self):
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
+
+        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
+
+    def test_populate_collateral_fields_sell_order(self):
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
+
+        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
+
+    def test_adjust_candidate_sufficient_funds(self):
+        self.exchange.set_balance(self.quote_asset, Decimal("100"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("10"), adjusted_candidate.amount)
+
+    def test_adjust_candidate_buy_insufficient_funds_partial_adjustment_allowed(self):
+        q_params = QuantizationParams(
+            trading_pair=self.trading_pair,
+            price_precision=8,
+            price_decimals=2,
+            order_size_precision=8,
+            order_size_decimals=2,
+        )
+        self.exchange.set_quantization_param(q_params)
+        self.exchange.set_balance(self.quote_asset, Decimal("10"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimal
+
+    def test_adjust_candidate_sell_insufficient_funds_partial_adjustment_allowed(self):
+        q_params = QuantizationParams(
+            trading_pair=self.trading_pair,
+            price_precision=8,
+            price_decimals=2,
+            order_size_precision=8,
+            order_size_decimals=2,
+        )
+        self.exchange.set_quantization_param(q_params)
+        self.exchange.set_balance(self.quote_asset, Decimal("10"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimal

--- a/test/hummingbot/connector/derivative/dydx/test_dydx_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/dydx/test_dydx_perpetual_derivative.py
@@ -11,6 +11,7 @@ from dydx3 import DydxApiError
 
 from hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_derivative import DydxPerpetualDerivative
 from hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_position import DydxPerpetualPosition
+from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.event.events import PositionSide, FundingInfo
 
 
@@ -102,14 +103,26 @@ class DydxPerpetualDerivativeTest(unittest.TestCase):
         }
         return account_message_mock
 
-    def get_markets_message_mock(self, index_price: float) -> Dict:
-        markets_message_mock = {
+    def get_markets_message_mock(
+        self,
+        index_price: float = 1,
+        min_order_size: float = 2,
+        min_price_increment: float = 3,
+        min_base_amount_increment: float = 4,
+    ) -> Dict:
+        markets_message_mock = {  # irrelevant fields removed
             "markets": {
                 self.trading_pair: {
+                    "quoteAsset": self.quote_asset,
+                    "minOrderSize": str(min_order_size),
+                    "tickSize": str(min_price_increment),
+                    "stepSize": str(min_base_amount_increment),
                     "indexPrice": str(index_price),
                     "oraclePrice": "10.1",
                     "nextFundingAt": str(datetime.now()),
                     "nextFundingRate": "0.1",
+                    "initialMarginFraction": "0.1",
+                    "maintenanceMarginFraction": "0.2",
                 }
             }
         }
@@ -318,3 +331,41 @@ class DydxPerpetualDerivativeTest(unittest.TestCase):
         self.exchange.tick(timestamp=initial_time_stamp + self.exchange.LONG_POLL_INTERVAL)
 
         self.assertTrue(self.exchange._poll_notifier.is_set())
+
+    @patch("hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_client_wrapper"
+           ".DydxPerpetualClientWrapper.get_markets")
+    def test_update_trading_rules(self, get_markets_mock: AsyncMock):
+        min_order_size = 1
+        min_price_increment = 2
+        min_base_amount_increment = 3
+        min_notional_size = min_order_size * min_price_increment
+        markets_message_mock = self.get_markets_message_mock(
+            min_order_size=min_order_size,
+            min_price_increment=min_price_increment,
+            min_base_amount_increment=min_base_amount_increment,
+        )
+        get_markets_mock.return_value = markets_message_mock
+
+        self.async_run_with_timeout(self.exchange._update_trading_rules())
+
+        trading_rule: TradingRule = self.exchange._trading_rules[self.trading_pair]
+
+        self.assertEqual(min_order_size, trading_rule.min_order_size)
+        self.assertEqual(min_price_increment, trading_rule.min_price_increment)
+        self.assertEqual(min_base_amount_increment, trading_rule.min_base_amount_increment)
+        self.assertEqual(min_notional_size, trading_rule.min_notional_size)
+        self.assertEqual(self.quote_asset, trading_rule.buy_order_collateral_token)
+        self.assertEqual(self.quote_asset, trading_rule.sell_order_collateral_token)
+
+    @patch("hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_client_wrapper"
+           ".DydxPerpetualClientWrapper.get_markets")
+    def test_get_buy_and_sell_collateral_token(self, get_markets_mock: AsyncMock):
+        markets_message_mock = self.get_markets_message_mock()
+        get_markets_mock.return_value = markets_message_mock
+
+        self.async_run_with_timeout(self.exchange._update_trading_rules())
+        buy_collateral_token = self.exchange.get_buy_collateral_token(self.trading_pair)
+        sell_collateral_token = self.exchange.get_sell_collateral_token(self.trading_pair)
+
+        self.assertEqual(self.quote_asset, buy_collateral_token)
+        self.assertEqual(self.quote_asset, sell_collateral_token)

--- a/test/hummingbot/connector/derivative/perpetual_finance/test_perpetual_finance_derivative.py
+++ b/test/hummingbot/connector/derivative/perpetual_finance/test_perpetual_finance_derivative.py
@@ -1,0 +1,25 @@
+import unittest
+
+from hummingbot.connector.derivative.perpetual_finance.perpetual_finance_derivative import (
+    PerpetualFinanceDerivative
+)
+
+
+class PerpetualFinanceDerivativeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.base = "HBOT"
+        self.quote = "COINALPHA"
+        self.trading_pair = f"{self.base}-{self.quote}"
+        self.exchange = PerpetualFinanceDerivative(
+            trading_pairs=[self.trading_pair],
+            wallet_private_key="someKey",
+            ethereum_rpc_url="someUrl",
+        )
+
+    def test_get_buy_and_sell_collateral_token(self):
+        buy_collateral_token = self.exchange.get_buy_collateral_token(self.trading_pair)
+        sell_collateral_token = self.exchange.get_sell_collateral_token(self.trading_pair)
+
+        self.assertEqual(self.quote, buy_collateral_token)
+        self.assertEqual(self.quote, sell_collateral_token)

--- a/test/hummingbot/connector/derivative/test_perpetual_budget_checker.py
+++ b/test/hummingbot/connector/derivative/test_perpetual_budget_checker.py
@@ -1,0 +1,122 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.connector.budget_checker import OrderCandidate
+from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
+from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
+from hummingbot.connector.perpetual_trading import PerpetualTrading
+from hummingbot.core.event.events import OrderType, TradeType
+from test.mock.mock_paper_exchange import MockPaperExchange
+
+
+class MockPerpetualExchange(MockPaperExchange, PerpetualTrading):
+    def __init__(self, fee_percent: Decimal = Decimal("0")):
+        super().__init__(fee_percent)
+        self._budget_checker = PerpetualBudgetChecker(exchange=self)
+
+    @property
+    def budget_checker(self) -> PerpetualBudgetChecker:
+        return self._budget_checker
+
+
+class PerpetualBudgetCheckerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.base_asset = "COINALPHA"
+        self.quote_asset = "HBOT"
+        self.trading_pair = f"{self.base_asset}-{self.quote_asset}"
+
+        self.fee_percent = Decimal("1")
+        self.exchange = MockPerpetualExchange(self.fee_percent)
+        self.budget_checker = self.exchange.budget_checker
+
+    def test_populate_collateral_fields_buy_order(self):
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
+
+        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
+
+    def test_populate_collateral_fields_sell_order(self):
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
+
+        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
+
+    def test_adjust_candidate_sufficient_funds(self):
+        self.exchange.set_balance(self.quote_asset, Decimal("100"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("20.2"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("10"), adjusted_candidate.amount)
+
+    def test_adjust_candidate_buy_insufficient_funds_partial_adjustment_allowed(self):
+        q_params = QuantizationParams(
+            trading_pair=self.trading_pair,
+            price_precision=8,
+            price_decimals=2,
+            order_size_precision=8,
+            order_size_decimals=2,
+        )
+        self.exchange.set_quantization_param(q_params)
+        self.exchange.set_balance(self.quote_asset, Decimal("10"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimal
+
+    def test_adjust_candidate_sell_insufficient_funds_partial_adjustment_allowed(self):
+        q_params = QuantizationParams(
+            trading_pair=self.trading_pair,
+            price_precision=8,
+            price_decimals=2,
+            order_size_precision=8,
+            order_size_decimals=2,
+        )
+        self.exchange.set_quantization_param(q_params)
+        self.exchange.set_balance(self.quote_asset, Decimal("10"))
+
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.SELL,
+            amount=Decimal("10"),
+            price=Decimal("2"),
+        )
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
+        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
+        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimal

--- a/test/hummingbot/connector/test_budget_checker.py
+++ b/test/hummingbot/connector/test_budget_checker.py
@@ -1,9 +1,8 @@
 import unittest
 from decimal import Decimal
 
-from hummingbot.connector.budget_checker import OrderCandidate, PerpetualBudgetChecker
+from hummingbot.connector.budget_checker import OrderCandidate
 from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
-from hummingbot.connector.perpetual_trading import PerpetualTrading
 from hummingbot.core.event.events import OrderType, TradeType
 from test.mock.mock_paper_exchange import MockPaperExchange
 
@@ -247,116 +246,3 @@ class BudgetCheckerTest(unittest.TestCase):
 
         self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
         self.assertEqual(Decimal("5"), second_adjusted_candidate.amount)
-
-
-class MockPerpetualExchange(MockPaperExchange, PerpetualTrading):
-    def __init__(self, fee_percent: Decimal = Decimal("0")):
-        super().__init__(fee_percent)
-        self._budget_checker = PerpetualBudgetChecker(exchange=self)
-
-    @property
-    def budget_checker(self) -> PerpetualBudgetChecker:
-        return self._budget_checker
-
-
-class PerpetualBudgetCheckerTest(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-
-        self.base_asset = "COINALPHA"
-        self.quote_asset = "HBOT"
-        self.trading_pair = f"{self.base_asset}-{self.quote_asset}"
-
-        self.fee_percent = Decimal("1")
-        self.exchange = MockPerpetualExchange(self.fee_percent)
-        self.budget_checker = self.exchange.budget_checker
-
-    def test_populate_collateral_fields_buy_order(self):
-        order_candidate = OrderCandidate(
-            trading_pair=self.trading_pair,
-            order_type=OrderType.LIMIT,
-            order_side=TradeType.BUY,
-            amount=Decimal("10"),
-            price=Decimal("2"),
-        )
-        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
-
-        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
-        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
-
-    def test_populate_collateral_fields_sell_order(self):
-        order_candidate = OrderCandidate(
-            trading_pair=self.trading_pair,
-            order_type=OrderType.LIMIT,
-            order_side=TradeType.SELL,
-            amount=Decimal("10"),
-            price=Decimal("2"),
-        )
-        populated_candidate = self.budget_checker.populate_collateral_fields(order_candidate)
-
-        self.assertEqual(self.quote_asset, populated_candidate.collateral_token)
-        self.assertEqual(Decimal("20.2"), populated_candidate.collateral_amount)
-
-    def test_adjust_candidate_sufficient_funds(self):
-        self.exchange.set_balance(self.quote_asset, Decimal("100"))
-
-        order_candidate = OrderCandidate(
-            trading_pair=self.trading_pair,
-            order_type=OrderType.LIMIT,
-            order_side=TradeType.BUY,
-            amount=Decimal("10"),
-            price=Decimal("2"),
-        )
-        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate)
-
-        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
-        self.assertEqual(Decimal("20.2"), adjusted_candidate.collateral_amount)
-        self.assertEqual(Decimal("10"), adjusted_candidate.amount)
-
-    def test_adjust_candidate_buy_insufficient_funds_partial_adjustment_allowed(self):
-        q_params = QuantizationParams(
-            trading_pair=self.trading_pair,
-            price_precision=8,
-            price_decimals=2,
-            order_size_precision=8,
-            order_size_decimals=2,
-        )
-        self.exchange.set_quantization_param(q_params)
-        self.exchange.set_balance(self.quote_asset, Decimal("10"))
-
-        order_candidate = OrderCandidate(
-            trading_pair=self.trading_pair,
-            order_type=OrderType.LIMIT,
-            order_side=TradeType.BUY,
-            amount=Decimal("10"),
-            price=Decimal("2"),
-        )
-        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
-
-        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
-        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
-        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimal
-
-    def test_adjust_candidate_sell_insufficient_funds_partial_adjustment_allowed(self):
-        q_params = QuantizationParams(
-            trading_pair=self.trading_pair,
-            price_precision=8,
-            price_decimals=2,
-            order_size_precision=8,
-            order_size_decimals=2,
-        )
-        self.exchange.set_quantization_param(q_params)
-        self.exchange.set_balance(self.quote_asset, Decimal("10"))
-
-        order_candidate = OrderCandidate(
-            trading_pair=self.trading_pair,
-            order_type=OrderType.LIMIT,
-            order_side=TradeType.SELL,
-            amount=Decimal("10"),
-            price=Decimal("2"),
-        )
-        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
-
-        self.assertEqual(self.quote_asset, adjusted_candidate.collateral_token)
-        self.assertEqual(Decimal("10"), adjusted_candidate.collateral_amount)
-        self.assertEqual(Decimal("4.95"), adjusted_candidate.amount)  # quantized at two decimal

--- a/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
+++ b/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
@@ -1,0 +1,72 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
+from hummingbot.strategy.data_types import Proposal, PriceSize
+from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+from hummingbot.strategy.perpetual_market_making import PerpetualMarketMakingStrategy
+from test.mock.mock_paper_exchange import MockPaperExchange
+
+
+class PerpetualMarketMakingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.base_asset = "HBOT"
+        self.quote_asset = "COINALPHA"
+        self.trading_pair = f"{self.base_asset}-{self.quote_asset}"
+        self.fee_percent = Decimal("1")
+        self.market: MockPaperExchange = MockPaperExchange(self.fee_percent)
+        self.market.set_quantization_param(
+            QuantizationParams(
+                self.trading_pair,
+                price_precision=6,
+                price_decimals=2,
+                order_size_precision=6,
+                order_size_decimals=2,
+            )
+        )
+        self.market_info = MarketTradingPairTuple(
+            self.market, self.trading_pair, self.base_asset, self.quote_asset
+        )
+
+        self.strategy = PerpetualMarketMakingStrategy()
+        self.strategy.init_params(
+            self.market_info,
+            leverage=2,
+            position_mode="Hedge",
+            bid_spread=Decimal("1"),
+            ask_spread=Decimal("1"),
+            order_amount=Decimal("2"),
+            position_management="Profit_taking",
+            long_profit_taking_spread=Decimal("1"),
+            short_profit_taking_spread=Decimal("1"),
+            ts_activation_spread=Decimal("1"),
+            ts_callback_rate=Decimal("1"),
+            stop_loss_spread=Decimal("1"),
+            close_position_order_type="LIMIT",
+        )
+
+    def test_c_apply_budget_constraint(self):
+        self.market.set_balance(self.base_asset, Decimal("2"))
+        self.market.set_balance(self.quote_asset, Decimal("10"))
+
+        buys = [
+            PriceSize(price=Decimal("5"), size=Decimal("1")),
+            PriceSize(price=Decimal("6"), size=Decimal("1")),
+        ]
+        sells = [
+            PriceSize(price=Decimal("7"), size=Decimal("1")),
+            PriceSize(price=Decimal("8"), size=Decimal("1")),
+        ]
+        proposal = Proposal(buys, sells)
+
+        self.strategy.apply_budget_constraint(proposal)
+
+        new_buys = proposal.buys
+        new_sells = proposal.sells
+
+        self.assertEqual(1, len(new_buys))
+        self.assertEqual(buys[0], new_buys[0])
+        self.assertEqual(2, len(new_sells))
+        self.assertEqual(sells[0], new_sells[0])
+        self.assertEqual(sells[1], new_sells[1])

--- a/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
+++ b/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
@@ -5,7 +5,7 @@ from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import Quant
 from hummingbot.strategy.data_types import Proposal, PriceSize
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.perpetual_market_making import PerpetualMarketMakingStrategy
-from test.mock.mock_paper_exchange import MockPaperExchange
+from test.mock.mock_perp_connector import MockPerpConnector
 
 
 class PerpetualMarketMakingTest(unittest.TestCase):
@@ -15,7 +15,7 @@ class PerpetualMarketMakingTest(unittest.TestCase):
         self.quote_asset = "COINALPHA"
         self.trading_pair = f"{self.base_asset}-{self.quote_asset}"
         self.fee_percent = Decimal("1")
-        self.market: MockPaperExchange = MockPaperExchange(self.fee_percent)
+        self.market: MockPerpConnector = MockPerpConnector(self.fee_percent)
         self.market.set_quantization_param(
             QuantizationParams(
                 self.trading_pair,
@@ -65,8 +65,8 @@ class PerpetualMarketMakingTest(unittest.TestCase):
         new_buys = proposal.buys
         new_sells = proposal.sells
 
-        self.assertEqual(1, len(new_buys))
+        self.assertEqual(2, len(new_buys))  # cumulative 11 for leverage of 20
         self.assertEqual(buys[0], new_buys[0])
-        self.assertEqual(2, len(new_sells))
+        self.assertEqual(buys[1], new_buys[1])
+        self.assertEqual(1, len(new_sells))  # cumulative 18 for leverage of 20
         self.assertEqual(sells[0], new_sells[0])
-        self.assertEqual(sells[1], new_sells[1])

--- a/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage.py
+++ b/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage.py
@@ -53,8 +53,7 @@ class TestSpotPerpetualArbitrage(unittest.TestCase):
         self.order_fill_logger: EventLogger = EventLogger()
         self.cancel_order_logger: EventLogger = EventLogger()
         self.clock: Clock = Clock(ClockMode.BACKTEST, 1, self.start_timestamp, self.end_timestamp)
-        self.fee_percent = Decimal("1")
-        self.spot_connector: MockPaperExchange = MockPaperExchange(self.fee_percent)
+        self.spot_connector: MockPaperExchange = MockPaperExchange()
         self.spot_connector.set_balanced_order_book(trading_pair=trading_pair,
                                                     mid_price=100,
                                                     min_price=1,
@@ -71,7 +70,7 @@ class TestSpotPerpetualArbitrage(unittest.TestCase):
         self.spot_market_info = MarketTradingPairTuple(self.spot_connector, trading_pair,
                                                        base_asset, quote_asset)
 
-        self.perp_connector: MockPerpConnector = MockPerpConnector(self.fee_percent)
+        self.perp_connector: MockPerpConnector = MockPerpConnector()
         self.perp_connector.set_leverage(trading_pair, 5)
         self.perp_connector.set_balanced_order_book(trading_pair=trading_pair,
                                                     mid_price=110,
@@ -255,7 +254,7 @@ class TestSpotPerpetualArbitrage(unittest.TestCase):
         self.spot_connector.set_balance(base_asset, 0.5)
         self.spot_connector.set_balance(quote_asset, 0)
         self.perp_connector.set_balance(base_asset, 0)
-        self.perp_connector.set_balance(quote_asset, 20)
+        self.perp_connector.set_balance(quote_asset, 21)
         # Since spot has 0.5 HBOT, not enough to sell on 1 order amount
         self.assertFalse(self.strategy.check_budget_constraint(proposal))
 

--- a/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage.py
+++ b/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage.py
@@ -53,7 +53,8 @@ class TestSpotPerpetualArbitrage(unittest.TestCase):
         self.order_fill_logger: EventLogger = EventLogger()
         self.cancel_order_logger: EventLogger = EventLogger()
         self.clock: Clock = Clock(ClockMode.BACKTEST, 1, self.start_timestamp, self.end_timestamp)
-        self.spot_connector: MockPaperExchange = MockPaperExchange()
+        self.fee_percent = Decimal("1")
+        self.spot_connector: MockPaperExchange = MockPaperExchange(self.fee_percent)
         self.spot_connector.set_balanced_order_book(trading_pair=trading_pair,
                                                     mid_price=100,
                                                     min_price=1,
@@ -70,7 +71,7 @@ class TestSpotPerpetualArbitrage(unittest.TestCase):
         self.spot_market_info = MarketTradingPairTuple(self.spot_connector, trading_pair,
                                                        base_asset, quote_asset)
 
-        self.perp_connector: MockPerpConnector = MockPerpConnector()
+        self.perp_connector: MockPerpConnector = MockPerpConnector(self.fee_percent)
         self.perp_connector.set_leverage(trading_pair, 5)
         self.perp_connector.set_balanced_order_book(trading_pair=trading_pair,
                                                     mid_price=110,

--- a/test/mock/mock_paper_exchange.pyx
+++ b/test/mock/mock_paper_exchange.pyx
@@ -8,6 +8,7 @@ from hummingbot.connector.exchange.paper_trade.trading_pair import TradingPair
 from hummingbot.core.data_type.order_book import OrderBookRow
 from hummingbot.core.data_type.composite_order_book cimport CompositeOrderBook
 from hummingbot.core.clock cimport Clock
+from hummingbot.core.data_type.order_book_tracker import OrderBookTracker
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.connector.exchange.paper_trade.market_config import MarketConfig
 from hummingbot.client.settings import AllConnectorSettings, ConnectorSetting, ConnectorType, TradeFeeType

--- a/test/mock/mock_perp_connector.py
+++ b/test/mock/mock_perp_connector.py
@@ -1,11 +1,13 @@
+from decimal import Decimal
+
 from hummingbot.connector.perpetual_trading import PerpetualTrading
 from hummingbot.core.event.events import PositionMode
 from test.mock.mock_paper_exchange import MockPaperExchange
 
 
 class MockPerpConnector(MockPaperExchange, PerpetualTrading):
-    def __init__(self):
-        MockPaperExchange.__init__(self)
+    def __init__(self, fee_percent: Decimal = Decimal("0")):
+        MockPaperExchange.__init__(self, fee_percent)
         PerpetualTrading.__init__(self)
         self._funding_payment_span = [0, 10]
 

--- a/test/mock/mock_perp_connector.py
+++ b/test/mock/mock_perp_connector.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
 from hummingbot.connector.perpetual_trading import PerpetualTrading
 from hummingbot.core.event.events import PositionMode
 from test.mock.mock_paper_exchange import MockPaperExchange
@@ -9,6 +10,7 @@ class MockPerpConnector(MockPaperExchange, PerpetualTrading):
     def __init__(self, fee_percent: Decimal = Decimal("0")):
         MockPaperExchange.__init__(self, fee_percent)
         PerpetualTrading.__init__(self)
+        self._budget_checker = PerpetualBudgetChecker(exchange=self)
         self._funding_payment_span = [0, 10]
 
     def supported_position_modes(self):
@@ -17,3 +19,7 @@ class MockPerpConnector(MockPaperExchange, PerpetualTrading):
     @property
     def name(self):
         return "MockPerpConnector"
+
+    @property
+    def budget_checker(self) -> PerpetualBudgetChecker:
+        return self._budget_checker


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR introduces the functionality proposed by @Nullably to allow more accurate sizing of the collateral required for perpetual orders. It adopts the approach, proposed by @aarmoa, of implementing a dedicated component that the exchange holds a reference to and the strategies use, as an attempt to avoid the need to introduce concepts specific to perpetual trading in the `ExchangeBase` class.


**Tests performed by the developer**:
- Tests for the new components.
- Tests for the modified parts of the perpetual exchanges.
- Tests for the relevant part of the perpetual mm strategy.
- All tests for spot perp arb pass.


**Tips for QA testing**:
This will be a tricky one. Essentially, this PR modifies the perpetual mm strategy, the spot perp arb strategy, and all of the spot connectors (binance, bybit, dydx, perpetual finance / gateway) in the parts of the code that handle adjusting order proposals based on available budget.

To see that the functionality is as expected, the test must make the strategies try to place orders that they don't have sufficient balance for and some of those orders must get rejected by the strategy (not by the exchange), while at the same time, the strategy should use the max balance available (i.e. should not reject an order if there is sufficient balance for it).

In addition, the sizing must consider fees. To test that, you override the fee to something large and observe an order be rejected.

The sizing should also consider leverage (i.e. open a position for which there is not enough real collateral, but there is enough when taking into consideration leverage).

The intricacies of the sizing don't need to be tested on each exchange. That logic lives elsewhere, so as long as it works on one exchange, and the other exchanges work for a small subset of those, this should be sufficient.

