### PR TITLE
fix/ GateIO continue tracking orders not meeting trading rule requirement

### DIFF
--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py
@@ -298,8 +298,8 @@ class TestGateIoExchange(unittest.TestCase):
         self.assertEqual(0, len(self.event_listener.event_log))
         self.assertNotIn(order_id, self.exchange.in_flight_orders)
         self.assertTrue(self._is_logged(
-            "WARNING",
-            "Buy order amount 0.000 is lower than the minimum order size 0.001."
+            "ERROR",
+            "Error submitting BUY LIMIT order to gate_io for 0.000 COINALPHA-HBOT 5.100000 - Buy order amount 0.000 is lower than the minimum order size 0.001.."
         ))
 
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Resolves #4647 .
It appears that the connector continues to track the order and even send a create order request even though it does not meet the trading rule requirements


**Tests performed by the developer**:
Made changes to the `_create_order()` function
Update unit tests


**Tips for QA testing**:
Ensure that the issue as reported in the bug no longer occurs.

