### PR TITLE
fix/gateway-v2 fix for bash configuration file

### DIFF
--- a/gateway/setup/config.sh
+++ b/gateway/setup/config.sh
@@ -47,5 +47,6 @@ prompt_to_allow_telemetry
 
 # update config file
 CONFIGURATION_FILE="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../conf/gateway-config.yml"
-echo "ENABLE_TELEMETRY: '$TELEMETRY'"  >> $CONFIGURATION_FILE
+sed -i '/ENABLE_TELEMETRY: .*/d;/^ *$/d' $CONFIGURATION_FILE
+echo "ENABLE_TELEMETRY: $TELEMETRY"  >> $CONFIGURATION_FILE
 echo "" >> $CONFIGURATION_FILE


### PR DESCRIPTION
A new fix is submitted for correctly generating the configuration file ENABLE_TELEMETRY parameter, replacing its value if exists with a boolean true or false by using sed.

Fixes https://github.com/CoinAlpha/hummingbot/issues/4686

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

A change was needed to modify the configuration file `ENABLE_TELEMETRY` parameter by using `sed`

**Tests performed by the developer**:

The bash script was executed without any inconvenience.

**Tips for QA testing**:

It would be good to know if removing empty lines as I did is a good option, or maybe just remove the last added line.
