### PR TITLE
Refactor/calculation of the greek parameters (kappa, gamma and eta)

### DIFF
--- a/hummingbot/strategy/__utils__/trailing_indicators/instant_volatility.py
+++ b/hummingbot/strategy/__utils__/trailing_indicators/instant_volatility.py
@@ -7,8 +7,14 @@ class InstantVolatilityIndicator(BaseTrailingIndicator):
         super().__init__(sampling_length, processing_length)
 
     def _indicator_calculation(self) -> float:
-        return np.var(self._sampling_buffer.get_as_numpy_array())
+        # The variance should be calculated between ticks and not with a mean of the whole buffer
+        # Otherwise if the asset is trending, changing the length of the buffer would result in a greater volatility as more ticks would be further away from the mean
+        # which is a nonsense result. If volatility of the underlying doesn't change in fact, changing the length of the buffer shouldn't change the result.
+        np_sampling_buffer = self._sampling_buffer.get_as_numpy_array()
+        # https://corporatefinanceinstitute.com/resources/knowledge/trading-investing/volatility-vol/
+        vol = np.sqrt(np.sum(np.square(np.diff(np_sampling_buffer))) / np_sampling_buffer.size)
+        return vol
 
     def _processing_calculation(self) -> float:
-        processing_array = self._processing_buffer.get_as_numpy_array()
-        return np.sqrt(np.mean(processing_array))
+        # Only the last calculated volatlity, not an average of multiple past volatilities
+        return self._processing_buffer.get_last_value()

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
@@ -8,6 +8,5 @@ cdef class TradingIntensityIndicator():
         list _trades
         object _bids_df
         object _asks_df
-        float _order_amount
         int _sampling_length
         int _samples_length

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
@@ -10,3 +10,6 @@ cdef class TradingIntensityIndicator():
         object _asks_df
         int _sampling_length
         int _samples_length
+
+    cdef c_simulate_execution(self, bids_df, asks_df)
+    cdef c_estimate_intensity(self)

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
@@ -1,0 +1,13 @@
+from libc.stdint cimport int64_t
+
+
+cdef class TradingIntensityIndicator():
+    cdef:
+        double _alpha
+        double _kappa
+        list _trades
+        object _bids_df
+        object _asks_df
+        float _order_amount
+        int _sampling_length
+        int _samples_length

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -1,0 +1,149 @@
+from math import floor, ceil
+from decimal import Decimal
+import numpy as np
+import pandas as pd
+from scipy.optimize import curve_fit
+from scipy.optimize import OptimizeWarning
+import csv
+import warnings
+
+from typing import (
+    Tuple,
+)
+
+
+cdef class TradingIntensityIndicator():
+
+    def __init__(self, sampling_length: int = 30, order_amount: float = 1, price_levels: Tuple[float] = (0)):
+        self._alpha = 0
+        self._kappa = 0
+        self._trades = []
+        self._bids_df = None
+        self._asks_df = None
+        self._order_amount = order_amount
+        self._sampling_length = sampling_length
+        self._samples_length = 0
+
+        warnings.simplefilter("ignore", OptimizeWarning)
+
+    def _simulate_execution(self, timestamp, bids_df, asks_df):
+        # Estimate market orders that happened
+        # Assume every movement in the BBO is caused by a market order and its size is the volume differential
+
+        bid = bids_df["price"].iloc[0]
+        ask = asks_df["price"].iloc[0]
+        price = (bid + ask) / 2
+
+        bid_prev = self._bids_df["price"].iloc[0]
+        ask_prev = self._asks_df["price"].iloc[0]
+        price_prev = (bid_prev + ask_prev) / 2
+
+        trades = []
+
+        # Higher bids were filled - someone matched them - a determined seller
+        # Equal bids - if amount lower - partially filled
+        for index, row in self._bids_df[self._bids_df['price'] >= bid].iterrows():
+            if row['price'] == bid:
+                if bids_df["amount"].iloc[0] < row['amount']:
+                    amount = row['amount'] - bids_df["amount"].iloc[0]
+                    price_level = abs(row['price'] - price_prev)
+                    trades += [{'price_level': price_level, 'amount': amount}]
+            else:
+                amount = row['amount']
+                price_level = abs(row['price'] - price_prev)
+                trades += [{'price_level': price_level, 'amount': amount}]
+
+        # Lower asks were filled - someone matched them - a determined buyer
+        # Equal asks - if amount lower - partially filled
+        for index, row in self._asks_df[self._asks_df['price'] <= ask].iterrows():
+            if row['price'] == ask:
+                if asks_df["amount"].iloc[0] < row['amount']:
+                    amount = row['amount'] - asks_df["amount"].iloc[0]
+                    price_level = abs(row['price'] - price_prev)
+                    trades += [{'price_level': price_level, 'amount': amount}]
+            else:
+                amount = row['amount']
+                price_level = abs(row['price'] - price_prev)
+                trades += [{'price_level': price_level, 'amount': amount}]
+
+        # Add trades
+        self._trades += [trades]
+        if len(self._trades) > self._sampling_length:
+            self._trades = self._trades[1:]
+
+    def _estimate_intensity(self):
+        # Calculate lambdas / trading intensities
+        lambdas = []
+
+        trades_consolidated = {}
+        price_levels = []
+        for tick in self._trades:
+            for trade in tick:
+                if trade['price_level'] not in trades_consolidated.keys():
+                    trades_consolidated[trade['price_level']] = 0
+                    price_levels += [trade['price_level']]
+
+                trades_consolidated[trade['price_level']] += trade['amount']
+
+        price_levels = sorted(price_levels, reverse=True)
+
+        with open('/Users/matejhorvath/github/hummingbot/logs/intensity.csv', 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+
+            for price_level in price_levels:
+                if len(lambdas) == 0:
+                    lambdas += [trades_consolidated[price_level]]
+                else:
+                    lambdas += [trades_consolidated[price_level]]
+                writer.writerow([price_level, lambdas[-1]])
+
+        # Adjust to be able to calculate log
+        lambdas_adj = [10**-10 if x==0 else x for x in lambdas]
+
+        # Fit the probability density function; reuse previously calculated parameters as initial values
+        try:
+            params = curve_fit(lambda t, a, b: a*np.exp(-b*t), price_levels, lambdas_adj, p0=(self._alpha, self._kappa), method='dogbox')
+
+            self._kappa = Decimal(str(params[0][1]))
+            self._alpha = Decimal(str(params[0][0]))
+        except (RuntimeError, ValueError) as e:
+            pass
+
+    def add_sample(self, timestamp: float, value: Tuple[pd.DataFrame, pd.DataFrame]):
+        bids_df = value[0]
+        asks_df = value[1]
+
+        if bids_df.empty or asks_df.empty:
+            return
+
+        # Skip snapshots where no trades occured
+        if self._bids_df is not None and self._bids_df.equals(bids_df):
+            return
+
+        if self._asks_df is not None and self._asks_df.equals(asks_df):
+            return
+
+        if self._bids_df is not None and self._asks_df is not None:
+            # Retrieve previous order book, evaluate execution
+            self._simulate_execution(timestamp, bids_df, asks_df)
+
+            # Estimate alpha and kappa
+            self._estimate_intensity()
+
+        # Store the orderbook
+        self._bids_df = bids_df
+        self._asks_df = asks_df
+
+    @property
+    def current_value(self) -> Tuple[float, float]:
+        return self._alpha, self._kappa
+
+    @property
+    def is_sampling_buffer_full(self) -> bool:
+        return len(self._trades) == self._sampling_length
+
+    @property
+    def is_sampling_buffer_changed(self) -> bool:
+        is_changed = self._samples_length != len(self._trades)
+        self._samples_length = len(self._trades)
+        return is_changed

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -23,7 +23,7 @@ cdef class TradingIntensityIndicator():
 
         warnings.simplefilter("ignore", OptimizeWarning)
 
-    def _simulate_execution(self, timestamp, bids_df, asks_df):
+    def _simulate_execution(self, bids_df, asks_df):
         # Estimate market orders that happened
         # Assume every movement in the BBO is caused by a market order and its size is the volume differential
 
@@ -102,7 +102,7 @@ cdef class TradingIntensityIndicator():
         except (RuntimeError, ValueError) as e:
             pass
 
-    def add_sample(self, timestamp: float, value: Tuple[pd.DataFrame, pd.DataFrame]):
+    def add_sample(self, value: Tuple[pd.DataFrame, pd.DataFrame]):
         bids_df = value[0]
         asks_df = value[1]
 
@@ -118,7 +118,7 @@ cdef class TradingIntensityIndicator():
 
         if self._bids_df is not None and self._asks_df is not None:
             # Retrieve previous order book, evaluate execution
-            self._simulate_execution(timestamp, bids_df, asks_df)
+            self._simulate_execution(bids_df, asks_df)
 
             # Estimate alpha and kappa
             self._estimate_intensity()
@@ -140,3 +140,7 @@ cdef class TradingIntensityIndicator():
         is_changed = self._samples_length != len(self._trades)
         self._samples_length = len(self._trades)
         return is_changed
+
+    @property
+    def sampling_length(self) -> int:
+        return self._sampling_length

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -1,15 +1,13 @@
-from math import floor, ceil
 from decimal import Decimal
+from math import floor, ceil
 import numpy as np
 import pandas as pd
 from scipy.optimize import curve_fit
 from scipy.optimize import OptimizeWarning
-import csv
-import warnings
-
 from typing import (
     Tuple,
 )
+import warnings
 
 
 cdef class TradingIntensityIndicator():
@@ -86,15 +84,11 @@ cdef class TradingIntensityIndicator():
 
         price_levels = sorted(price_levels, reverse=True)
 
-        with open('/Users/matejhorvath/github/hummingbot/logs/intensity.csv', 'w', newline='') as csvfile:
-            writer = csv.writer(csvfile)
-
-            for price_level in price_levels:
-                if len(lambdas) == 0:
-                    lambdas += [trades_consolidated[price_level]]
-                else:
-                    lambdas += [trades_consolidated[price_level]]
-                writer.writerow([price_level, lambdas[-1]])
+        for price_level in price_levels:
+            if len(lambdas) == 0:
+                lambdas += [trades_consolidated[price_level]]
+            else:
+                lambdas += [trades_consolidated[price_level]]
 
         # Adjust to be able to calculate log
         lambdas_adj = [10**-10 if x==0 else x for x in lambdas]

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -14,13 +14,12 @@ from typing import (
 
 cdef class TradingIntensityIndicator():
 
-    def __init__(self, sampling_length: int = 30, order_amount: float = 1, price_levels: Tuple[float] = (0)):
+    def __init__(self, sampling_length: int = 30):
         self._alpha = 0
         self._kappa = 0
         self._trades = []
         self._bids_df = None
         self._asks_df = None
-        self._order_amount = order_amount
         self._sampling_length = sampling_length
         self._samples_length = 0
 

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -145,8 +145,9 @@ cdef class TradingIntensityIndicator():
             # Retrieve previous order book, evaluate execution
             self._simulate_execution(bids_df, asks_df)
 
-            # Estimate alpha and kappa
-            self._estimate_intensity()
+            if self.is_sampling_buffer_full:
+                # Estimate alpha and kappa
+                self._estimate_intensity()
 
         # Store the orderbook
         self._bids_df = bids_df

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -143,11 +143,11 @@ cdef class TradingIntensityIndicator():
 
         if self._bids_df is not None and self._asks_df is not None:
             # Retrieve previous order book, evaluate execution
-            self._simulate_execution(bids_df, asks_df)
+            self.c_simulate_execution(bids_df, asks_df)
 
             if self.is_sampling_buffer_full:
                 # Estimate alpha and kappa
-                self._estimate_intensity()
+                self.c_estimate_intensity()
 
         # Store the orderbook
         self._bids_df = bids_df

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -37,15 +37,12 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         double _last_sampling_timestamp
         bint _parameters_based_on_spread
         int _ticks_to_be_ready
-        object _min_spread
-        object _max_spread
-        object _vol_to_spread_multiplier
-        object _volatility_sensibility
-        object _inventory_risk_aversion
+        object _alpha
         object _kappa
         object _gamma
         object _eta
         object _closing_time
+        double _min_spread
         object _time_left
         object _q_adjustment_factor
         object _reserved_price
@@ -53,13 +50,15 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _optimal_bid
         object _optimal_ask
         object _latest_parameter_calculation_vol
+        object _latest_parameter_calculation_trading_intensity
         str _debug_csv_path
         object _avg_vol
+        object _trading_intensity
         bint _should_wait_order_cancel_confirmation
 
     cdef object c_get_mid_price(self)
+    cdef object c_get_order_book_snapshot(self)
     cdef _create_proposal_based_on_order_override(self)
-    cdef _create_proposal_based_on_order_levels(self)
     cdef _create_basic_proposal(self)
     cdef object c_create_base_proposal(self)
     cdef tuple c_get_adjusted_available_balance(self, list orders)
@@ -77,7 +76,8 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
     cdef double c_get_spread(self)
     cdef c_collect_market_variables(self, double timestamp)
     cdef bint c_is_algorithm_ready(self)
+    cdef bint c_is_algorithm_changed(self)
+    cdef c_measure_order_book_liquidity(self)
     cdef c_calculate_reserved_price_and_optimal_spread(self)
     cdef object c_calculate_target_inventory(self)
-    cdef c_recalculate_parameters(self)
     cdef c_did_complete_order(self, object order_completed_event)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -14,6 +14,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _order_refresh_tolerance_pct
         double _filled_order_delay
         int _order_levels
+        object _level_distances
         object _order_override
         bint _hanging_orders_enabled
         object _hanging_orders_tracker
@@ -58,6 +59,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
     cdef object c_get_mid_price(self)
     cdef object c_get_order_book_snapshot(self)
+    cdef _create_proposal_based_on_order_levels(self)
     cdef _create_proposal_based_on_order_override(self)
     cdef _create_basic_proposal(self)
     cdef object c_create_base_proposal(self)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -1,20 +1,20 @@
+import datetime
 from decimal import Decimal
 import logging
-import pandas as pd
-import numpy as np
-from typing import (
-    List,
-    Dict,
-    Tuple,
-)
 from math import (
     floor,
     ceil,
     isnan
 )
-import time
-import datetime
+import numpy as np
 import os
+import pandas as pd
+import time
+from typing import (
+    List,
+    Dict,
+    Tuple,
+)
 
 from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.connector.exchange_base import ExchangeBase

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -158,6 +158,14 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._latest_parameter_calculation_vol = value
 
     @property
+    def min_spread(self):
+        return self._min_spread
+
+    @min_spread.setter
+    def min_spread(self, value):
+        self._min_spread = value
+
+    @property
     def avg_vol(self):
         return self._avg_vol
 

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -338,20 +338,20 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._optimal_bid = value
 
     @property
-    def q_adjustment_factor(self):
-        return self._q_adjustment_factor
-
-    @q_adjustment_factor.setter
-    def q_adjustment_factor(self, value):
-        self._q_adjustment_factor = value
-
-    @property
     def time_left(self):
         return self._time_left
+
+    @time_left.setter
+    def time_left(self, value):
+        self._time_left = value
 
     @property
     def closing_time(self):
         return self._closing_time
+
+    @closing_time.setter
+    def closing_time(self, value):
+        self._closing_time = value
 
     def get_price(self) -> float:
         return self.get_mid_price()
@@ -629,12 +629,11 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         price = self.get_price()
         snapshot = self.get_order_book_snapshot()
         self._avg_vol.add_sample(price)
-        self._trading_intensity.add_sample(timestamp, snapshot)
+        self._trading_intensity.add_sample(snapshot)
         # Calculate adjustment factor to have 0.01% of inventory resolution
         base_balance = market.get_balance(base_asset)
         quote_balance = market.get_balance(quote_asset)
         inventory_in_base = quote_balance / price + base_balance
-        self._q_adjustment_factor = (Decimal("1e5") / inventory_in_base) if inventory_in_base else Decimal("1e5")
         if self._time_left == 0:
             # Re-cycle algorithm
             self._time_left = self._closing_time
@@ -673,6 +672,9 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         if self._is_debug:
             self.logger().info(f"alpha={self._alpha:.4f} | "
                                f"kappa={self._kappa:.4f}")
+
+    def measure_order_book_liquidity(self):
+        return self.c_measure_order_book_liquidity()
 
     cdef c_calculate_reserved_price_and_optimal_spread(self):
         cdef:

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -709,10 +709,10 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
             self._optimal_spread = self._gamma * mid_price_variance * time_left_fraction
             self._optimal_spread += 2 * Decimal(1 + self._gamma / self._kappa).ln() / self._gamma
 
-            min_spread = price / 100 * self._min_spread
+            min_spread = price / 100 * Decimal(str(self._min_spread))
 
-            max_limit_bid = price - Decimal(str(min_spread / 2))
-            min_limit_ask = price + Decimal(str(min_spread / 2))
+            max_limit_bid = price - min_spread / 2
+            min_limit_ask = price + min_spread / 2
 
             self._optimal_ask = max(self._reserved_price + self._optimal_spread / 2, min_limit_ask)
             self._optimal_bid = min(self._reserved_price - self._optimal_spread / 2, max_limit_bid)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -122,7 +122,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
         self.c_add_markets([market_info.market])
         self._ticks_to_be_ready = max(volatility_buffer_size, trading_intensity_buffer_size)
-        self._avg_vol = InstantVolatilityIndicator()
+        self._avg_vol = InstantVolatilityIndicator(sampling_length=volatility_buffer_size)
         self._trading_intensity = TradingIntensityIndicator(trading_intensity_buffer_size)
         self._last_sampling_timestamp = 0
         self._alpha = None
@@ -709,8 +709,10 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
             self._optimal_spread = self._gamma * mid_price_variance * time_left_fraction
             self._optimal_spread += 2 * Decimal(1 + self._gamma / self._kappa).ln() / self._gamma
 
-            max_limit_bid = price - Decimal(str(self._min_spread / 2))
-            min_limit_ask = price + Decimal(str(self._min_spread / 2))
+            min_spread = price / 100 * self._min_spread
+
+            max_limit_bid = price - Decimal(str(min_spread / 2))
+            min_limit_ask = price + Decimal(str(min_spread / 2))
 
             self._optimal_ask = max(self._reserved_price + self._optimal_spread / 2, min_limit_ask)
             self._optimal_bid = min(self._reserved_price - self._optimal_spread / 2, max_limit_bid)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -85,8 +85,7 @@ avellaneda_market_making_config_map = {
                   prompt="Enter order amount shape factor (\u03B7) >>> ",
                   type_str="decimal",
                   default=Decimal("0"),
-                  validator=lambda v: validate_decimal(v, 0, 1, inclusive=True),
-                  prompt_on_new=True),
+                  validator=lambda v: validate_decimal(v, 0, 1, inclusive=True)),
     "closing_time":
         ConfigVar(key="closing_time",
                   prompt="Enter operational closing time (T). (How long will each trading cycle last "
@@ -159,6 +158,12 @@ avellaneda_market_making_config_map = {
                   type_str="int",
                   validator=lambda v: validate_int(v, min_value=-1, inclusive=False),
                   default=1),
+    "level_distances":
+        ConfigVar(key="level_distances",
+                  prompt="How far apart in % of optimal spread should orders on one side be? >>> ",
+                  type_str="decimal",
+                  validator=lambda v: validate_decimal(v, min_value=0, inclusive=True),
+                  default=0),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -150,7 +150,7 @@ avellaneda_market_making_config_map = {
         ConfigVar(key="trading_intensity_buffer_size",
                   prompt="Enter amount of ticks that will be stored to estimate order book liquidity >>> ",
                   type_str="int",
-                  validator=lambda v: validate_decimal(v, 1, 10000),
+                  validator=lambda v: validate_int(v, 1, 10000),
                   default=200),
     "order_levels":
         ConfigVar(key="order_levels",

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -28,22 +28,6 @@ def validate_exchange_trading_pair(value: str) -> Optional[str]:
     return validate_market_trading_pair(exchange, value)
 
 
-def validate_max_spread(value: str) -> Optional[str]:
-    is_invalid_decimal = validate_decimal(value, 0, 100, inclusive=False)
-    if is_invalid_decimal:
-        return is_invalid_decimal
-    if avellaneda_market_making_config_map["min_spread"].value is not None:
-        min_spread = Decimal(avellaneda_market_making_config_map["min_spread"].value)
-        max_spread = Decimal(value)
-        if min_spread >= max_spread:
-            return f"Max spread cannot be lesser or equal to min spread {max_spread}%<={min_spread}%"
-
-
-def onvalidated_min_spread(value: str):
-    # If entered valid min_spread, max_spread is invalidated so user sets it up again
-    avellaneda_market_making_config_map["max_spread"].value = None
-
-
 def order_amount_prompt() -> str:
     trading_pair = avellaneda_market_making_config_map["market"].value
     base_asset, quote_asset = trading_pair.split("-")
@@ -57,18 +41,6 @@ def on_validated_price_source_exchange(value: str):
 
 def exchange_on_validated(value: str):
     required_exchanges.append(value)
-
-
-def on_validated_parameters_based_on_spread(value: str):
-    if value == 'True':
-        avellaneda_market_making_config_map.get("risk_factor").value = None
-        avellaneda_market_making_config_map.get("order_book_depth_factor").value = None
-        avellaneda_market_making_config_map.get("order_amount_shape_factor").value = None
-    else:
-        avellaneda_market_making_config_map.get("max_spread").value = None
-        avellaneda_market_making_config_map.get("min_spread").value = None
-        avellaneda_market_making_config_map.get("vol_to_spread_multiplier").value = None
-        avellaneda_market_making_config_map.get("inventory_risk_aversion").value = None
 
 
 avellaneda_market_making_config_map = {
@@ -99,77 +71,20 @@ avellaneda_market_making_config_map = {
                   type_str="bool",
                   default=True,
                   validator=validate_bool),
-    "parameters_based_on_spread":
-        ConfigVar(key="parameters_based_on_spread",
-                  prompt="Do you want to automate Avellaneda-Stoikov parameters based on min/max spread? >>> ",
-                  type_str="bool",
-                  validator=validate_bool,
-                  on_validated=on_validated_parameters_based_on_spread,
-                  default=True,
-                  prompt_on_new=True),
-    "min_spread":
-        ConfigVar(key="min_spread",
-                  prompt="Enter the minimum spread allowed from mid-price in percentage "
-                         "(Enter 1 to indicate 1%) >>> ",
-                  type_str="decimal",
-                  required_if=lambda: avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),
-                  prompt_on_new=True,
-                  on_validated=onvalidated_min_spread),
-    "max_spread":
-        ConfigVar(key="max_spread",
-                  prompt="Enter the maximum spread allowed from mid-price in percentage "
-                         "(Enter 1 to indicate 1%) >>> ",
-                  type_str="decimal",
-                  required_if=lambda: avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_max_spread(v),
-                  prompt_on_new=True),
-    "vol_to_spread_multiplier":
-        ConfigVar(key="vol_to_spread_multiplier",
-                  prompt="Enter the Volatility threshold multiplier: "
-                         "(If market volatility multiplied by this value is above the minimum spread, "
-                         "it will increase the minimum and maximum spread value) >>> ",
-                  type_str="decimal",
-                  required_if=lambda: avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_decimal(v, 0, 10, inclusive=True),
-                  prompt_on_new=True),
-    "volatility_sensibility":
-        ConfigVar(key="volatility_sensibility",
-                  prompt="Enter volatility change threshold to trigger parameter recalculation >>> ",
-                  type_str="decimal",
-                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=True),
-                  default=20),
-    "inventory_risk_aversion":
-        ConfigVar(key="inventory_risk_aversion",
-                  prompt="Enter Inventory risk aversion between 0 and 1: (For values close to 0.999 spreads will be more "
-                         "skewed to meet the inventory target, while close to 0.001 spreads will be close to symmetrical, "
-                         "increasing profitability but also increasing inventory risk) >>>",
-                  type_str="decimal",
-                  required_if=lambda: avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_decimal(v, 0, 1, inclusive=False),
-                  prompt_on_new=True),
-    "order_book_depth_factor":
-        ConfigVar(key="order_book_depth_factor",
-                  printable_key="order_book_depth_factor(\u03BA)",
-                  prompt="Enter order book depth factor (\u03BA) >>> ",
-                  type_str="decimal",
-                  required_if=lambda: not avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_decimal(v, 0, 1e10, inclusive=False),
-                  prompt_on_new=True),
     "risk_factor":
         ConfigVar(key="risk_factor",
                   printable_key="risk_factor(\u03B3)",
                   prompt="Enter risk factor (\u03B3) >>> ",
                   type_str="decimal",
-                  required_if=lambda: not avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
-                  validator=lambda v: validate_decimal(v, 0, 1e10, inclusive=False),
+                  default=Decimal("1"),
+                  validator=lambda v: validate_decimal(v, 0, inclusive=True),
                   prompt_on_new=True),
     "order_amount_shape_factor":
         ConfigVar(key="order_amount_shape_factor",
                   printable_key="order_amount_shape_factor(\u03B7)",
                   prompt="Enter order amount shape factor (\u03B7) >>> ",
                   type_str="decimal",
-                  required_if=lambda: not avellaneda_market_making_config_map.get("parameters_based_on_spread").value,
+                  default=Decimal("0"),
                   validator=lambda v: validate_decimal(v, 0, 1, inclusive=True),
                   prompt_on_new=True),
     "closing_time":
@@ -179,6 +94,12 @@ avellaneda_market_making_config_map = {
                   type_str="decimal",
                   validator=lambda v: validate_decimal(v, 0, 10, inclusive=False),
                   default=Decimal("0.041666667")),
+    "min_spread":
+        ConfigVar(key="min_spread",
+                  prompt="Enter minimum spread limit >>> ",
+                  type_str="decimal",
+                  validator=lambda v: validate_decimal(v, 0, inclusive=True),
+                  default=Decimal("0")),
     "order_refresh_time":
         ConfigVar(key="order_refresh_time",
                   prompt="How often do you want to cancel and replace bids and asks "
@@ -224,8 +145,14 @@ avellaneda_market_making_config_map = {
         ConfigVar(key="volatility_buffer_size",
                   prompt="Enter amount of ticks that will be stored to calculate volatility >>> ",
                   type_str="int",
-                  validator=lambda v: validate_decimal(v, 5, 600),
-                  default=60),
+                  validator=lambda v: validate_decimal(v, 1, 10000),
+                  default=200),
+    "trading_intensity_buffer_size":
+        ConfigVar(key="trading_intensity_buffer_size",
+                  prompt="Enter amount of ticks that will be stored to estimate order book liquidity >>> ",
+                  type_str="int",
+                  validator=lambda v: validate_decimal(v, 1, 10000),
+                  default=200),
     "order_levels":
         ConfigVar(key="order_levels",
                   prompt="How many orders do you want to place on both sides? >>> ",

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making_config_map.py
@@ -95,7 +95,7 @@ avellaneda_market_making_config_map = {
                   default=Decimal("0.041666667")),
     "min_spread":
         ConfigVar(key="min_spread",
-                  prompt="Enter minimum spread limit >>> ",
+                  prompt="Enter minimum spread limit (as % of mid price) >>> ",
                   type_str="decimal",
                   validator=lambda v: validate_decimal(v, 0, inclusive=True),
                   default=Decimal("0")),

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -28,6 +28,7 @@ def start(self):
         filled_order_delay = c_map.get("filled_order_delay").value
         order_refresh_tolerance_pct = c_map.get("order_refresh_tolerance_pct").value / Decimal('100')
         order_levels = c_map.get("order_levels").value
+        level_distances = c_map.get("level_distances").value
         order_override = c_map.get("order_override").value
         hanging_orders_enabled = c_map.get("hanging_orders_enabled").value
 
@@ -64,6 +65,7 @@ def start(self):
             order_refresh_tolerance_pct=order_refresh_tolerance_pct,
             filled_order_delay=filled_order_delay,
             order_levels=order_levels,
+            level_distances=level_distances,
             order_override=order_override,
             hanging_orders_enabled=hanging_orders_enabled,
             hanging_orders_cancel_pct=hanging_orders_cancel_pct,

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -49,6 +49,7 @@ def start(self):
         closing_time = c_map.get("closing_time").value * Decimal(3600 * 24 * 1e3)
         min_spread = c_map.get("min_spread").value
         volatility_buffer_size = c_map.get("volatility_buffer_size").value
+        trading_intensity_buffer_size = c_map.get("trading_intensity_buffer_size").value
         should_wait_order_cancel_confirmation = c_map.get("should_wait_order_cancel_confirmation")
         debug_csv_path = os.path.join(data_path(),
                                       HummingbotApplication.main_application().strategy_file_name.rsplit('.', 1)[0] +
@@ -78,6 +79,7 @@ def start(self):
             min_spread=min_spread,
             debug_csv_path=debug_csv_path,
             volatility_buffer_size=volatility_buffer_size,
+            trading_intensity_buffer_size=trading_intensity_buffer_size,
             should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
             is_debug=False
         )

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+import pandas as pd
 from typing import (
     List,
     Tuple,
@@ -11,8 +13,6 @@ from hummingbot.strategy.avellaneda_market_making import (
     AvellanedaMarketMakingStrategy,
 )
 from hummingbot.strategy.avellaneda_market_making.avellaneda_market_making_config_map import avellaneda_market_making_config_map as c_map
-from decimal import Decimal
-import pandas as pd
 
 
 def start(self):

--- a/hummingbot/strategy/avellaneda_market_making/start.py
+++ b/hummingbot/strategy/avellaneda_market_making/start.py
@@ -42,20 +42,11 @@ def start(self):
         self.market_trading_pair_tuples = [MarketTradingPairTuple(*maker_data)]
 
         strategy_logging_options = AvellanedaMarketMakingStrategy.OPTION_LOG_ALL
-        parameters_based_on_spread = c_map.get("parameters_based_on_spread").value
-        if parameters_based_on_spread:
-            risk_factor = order_book_depth_factor = order_amount_shape_factor = None
-            min_spread = c_map.get("min_spread").value / Decimal(100)
-            max_spread = c_map.get("max_spread").value / Decimal(100)
-            vol_to_spread_multiplier = c_map.get("vol_to_spread_multiplier").value
-            volatility_sensibility = c_map.get("volatility_sensibility").value / Decimal('100')
-            inventory_risk_aversion = c_map.get("inventory_risk_aversion").value
-        else:
-            min_spread = max_spread = vol_to_spread_multiplier = inventory_risk_aversion = volatility_sensibility = None
-            order_book_depth_factor = c_map.get("order_book_depth_factor").value
-            risk_factor = c_map.get("risk_factor").value
-            order_amount_shape_factor = c_map.get("order_amount_shape_factor").value
+        risk_factor = c_map.get("risk_factor").value
+        order_amount_shape_factor = c_map.get("order_amount_shape_factor").value
+
         closing_time = c_map.get("closing_time").value * Decimal(3600 * 24 * 1e3)
+        min_spread = c_map.get("min_spread").value
         volatility_buffer_size = c_map.get("volatility_buffer_size").value
         should_wait_order_cancel_confirmation = c_map.get("should_wait_order_cancel_confirmation")
         debug_csv_path = os.path.join(data_path(),
@@ -79,16 +70,10 @@ def start(self):
             add_transaction_costs_to_orders=add_transaction_costs_to_orders,
             logging_options=strategy_logging_options,
             hb_app_notification=True,
-            parameters_based_on_spread=parameters_based_on_spread,
-            min_spread=min_spread,
-            max_spread=max_spread,
-            vol_to_spread_multiplier=vol_to_spread_multiplier,
-            volatility_sensibility=volatility_sensibility,
-            inventory_risk_aversion=inventory_risk_aversion,
-            order_book_depth_factor=order_book_depth_factor,
             risk_factor=risk_factor,
             order_amount_shape_factor=order_amount_shape_factor,
             closing_time=closing_time,
+            min_spread=min_spread,
             debug_csv_path=debug_csv_path,
             volatility_buffer_size=volatility_buffer_size,
             should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,

--- a/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Avellaneda market making strategy config    ###
 ########################################################
 
-template_version: 6
+template_version: 7
 strategy: null
 
 # Exchange and token parameters.
@@ -60,19 +60,16 @@ order_override: null
 
 
 # Avellaneda - Stoikov algorithm parameters
-parameters_based_on_spread: null
-min_spread: null
-max_spread: null
-vol_to_spread_multiplier: null
-volatility_sensibility: null
-inventory_risk_aversion: null
-order_book_depth_factor: null
-risk_factor: null
-order_amount_shape_factor: null
+risk_factor: 1
+order_amount_shape_factor: 0
 closing_time: null
+min_spread: 0
 
 # Buffer size used to store historic samples and calculate volatility
 volatility_buffer_size: 60
+
+# Buffer size used to store historic trades and calculate order book liquidity
+trading_intensity_buffer_size: 200
 
 # If the strategy should wait to receive cancellations confirmation before creating new orders during refresh time
 should_wait_order_cancel_confirmation: True

--- a/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_avellaneda_market_making_strategy_TEMPLATE.yml
@@ -37,6 +37,9 @@ inventory_target_base_pct: null
 # Number of levels of orders to place on each side of the order book.
 order_levels: null
 
+# Distance between levels in % of optimal spread
+level_distances: null
+
 # Whether to enable adding transaction costs to order price calculation (true/false).
 add_transaction_costs: null
 

--- a/pyinstaller/bot.spec
+++ b/pyinstaller/bot.spec
@@ -101,7 +101,7 @@ if "SPEC" in globals():
     exe = EXE(pyz,
               a.scripts,
               [],
-          exclude_binaries=True,
+              exclude_binaries=True,
               name='bot',
               icon="hummingbot.ico",
               debug=False,

--- a/pyinstaller/bot.spec
+++ b/pyinstaller/bot.spec
@@ -6,10 +6,6 @@ from PyInstaller.building.build_main import (
     EXE,
     COLLECT,
 )
-from PyInstaller.utils.hooks import (
-    collect_submodules,
-    collect_data_files
-)
 import os
 import platform
 import re
@@ -66,8 +62,8 @@ if "SPEC" in globals():
     hidden_imports.extend([
         "aiokafka",
         "pkg_resources.py2_warn",
+        "scipy.spatial.transform._rotation_groups",
     ])
-    hidden_imports.extend(collect_submodules('scipy'))
 
     import _strptime
 
@@ -77,13 +73,14 @@ if "SPEC" in globals():
     ))
     datas.extend([(_strptime.__file__, ".")])
     datas.extend([(os.path.join(project_path(), "bin/path_util.py"), ".")])
-    datas.extend(collect_data_files('scipy'))
 
     binaries: List[Tuple[str, str]] = []
     if system_type == "Windows":
        import coincurve
+       conda_env_path = os.environ['CONDA_PREFIX']
        binaries.extend([(os.path.realpath(os.path.join(coincurve.__file__, "../libsecp256k1.dll")), "coincurve")])
        datas.extend([(os.path.realpath(os.path.join(project_path(), "redist/VC_redist.x64.exe")), "redist")])
+       datas.extend([(os.path.realpath(os.path.join(conda_env_path, "Library", "bin", "libiomp5md.dll")), ".")])
 
 
     a = Analysis([os.path.join(project_path(), "bin/bot")],
@@ -104,7 +101,7 @@ if "SPEC" in globals():
     exe = EXE(pyz,
               a.scripts,
               [],
-	      exclude_binaries=True,
+          exclude_binaries=True,
               name='bot',
               icon="hummingbot.ico",
               debug=False,

--- a/pyinstaller/bot.spec
+++ b/pyinstaller/bot.spec
@@ -6,6 +6,10 @@ from PyInstaller.building.build_main import (
     EXE,
     COLLECT,
 )
+from PyInstaller.utils.hooks import (
+    collect_submodules,
+    collect_data_files
+)
 import os
 import platform
 import re
@@ -63,6 +67,7 @@ if "SPEC" in globals():
         "aiokafka",
         "pkg_resources.py2_warn",
     ])
+    hidden_imports.extend(collect_submodules('scipy'))
 
     import _strptime
 
@@ -72,6 +77,7 @@ if "SPEC" in globals():
     ))
     datas.extend([(_strptime.__file__, ".")])
     datas.extend([(os.path.join(project_path(), "bin/path_util.py"), ".")])
+    datas.extend(collect_data_files('scipy'))
 
     binaries: List[Tuple[str, str]] = []
     if system_type == "Windows":

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
-from Cython.Build import cythonize
 import numpy as np
 import os
 from setuptools import find_packages, setup
 from setuptools.command.build_ext import build_ext
 import subprocess
 import sys
+
+from Cython.Build import cythonize
 
 is_posix = (os.name == "posix")
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
+from Cython.Build import cythonize
 import numpy as np
 import os
-import subprocess
-import sys
-
-from os import path
 from setuptools import find_packages, setup
 from setuptools.command.build_ext import build_ext
-from Cython.Build import cythonize
+import subprocess
+import sys
 
 is_posix = (os.name == "posix")
 
@@ -103,7 +101,7 @@ def main():
     }
 
     cython_sources = ["hummingbot/**/*.pyx"]
-    if path.exists('test'):
+    if os.path.exists('test'):
         cython_sources.append("test/**/*.pyx")
 
     if os.environ.get('WITHOUT_CYTHON_OPTIMIZATIONS'):

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ import os
 import subprocess
 import sys
 
-from Cython.Build import cythonize
 from setuptools import find_packages, setup
 from setuptools.command.build_ext import build_ext
+
+from Cython.Build import cythonize
 
 is_posix = (os.name == "posix")
 

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ def main():
         "requests",
         "rsa",
         "ruamel-yaml",
+        "scipy",
         "signalr-client-aio",
         "simplejson",
         "six",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import numpy as np
 import os
-from setuptools import find_packages, setup
-from setuptools.command.build_ext import build_ext
 import subprocess
 import sys
 
 from Cython.Build import cythonize
+from setuptools import find_packages, setup
+from setuptools.command.build_ext import build_ext
 
 is_posix = (os.name == "posix")
 

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy=1.6.2
+  - defaults::scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy=1.7.1
+  - scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.1
+  - scipy==1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy
+  - scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.6.2
+  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1
@@ -61,7 +62,6 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
-    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy==1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - defaults::scipy=1.6.2
+  - scipy=1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -16,7 +16,6 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.30.1
@@ -62,6 +61,7 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
+    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy
+  - scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.6.2
+  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,6 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
@@ -63,6 +62,7 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
+    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
@@ -62,7 +63,6 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
-    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy=1.6.2
+  - defaults::scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy=1.7.1
+  - scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy==1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.1
+  - scipy==1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - defaults::scipy=1.6.2
+  - scipy=1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,6 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
@@ -64,6 +63,7 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
+    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy=1.6.2
+  - defaults::scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
@@ -63,7 +64,6 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
-    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy==1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - defaults::scipy=1.6.2
+  - defaults::scipy=1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.1
+  - scipy==1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - defaults::scipy=1.7.1
+  - defaults::scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy
+  - scipy=1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.6.2
+  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - python=3.8.2
   - python-dateutil=2.8.1
   - six=1.14.0
-  - scipy=1.6.2
+  - defaults::scipy=1.6.2
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
   - tzlocal=2.0.0

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.1
+  - scipy==1.6.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - python=3.8.2
   - python-dateutil=2.8.1
   - six=1.14.0
-  - scipy
+  - scipy=1.6.2
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
   - tzlocal=2.0.0

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - python=3.8.2
   - python-dateutil=2.8.1
   - six=1.14.0
-  - scipy=1.7.1
+  - scipy=1.6.2
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
   - tzlocal=2.0.0

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
+  - scipy==1.7.1
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.6.2
+  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - python=3.8.2
   - python-dateutil=2.8.1
   - six=1.14.0
+  - scipy
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
   - tzlocal=2.0.0
@@ -63,7 +64,6 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
-    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - scipy==1.7.2
   - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
@@ -64,6 +63,7 @@ dependencies:
     - requests==2.22.0
     - rsa==4.7
     - ruamel-yaml==0.16.10
+    - scipy==1.7.2
     - setuptools==50.3.2
     - signalr-client-aio==0.0.1.6.2
     - simplejson==3.17.2

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - python=3.8.2
   - python-dateutil=2.8.1
   - six=1.14.0
-  - defaults::scipy=1.6.2
+  - scipy=1.7.1
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
   - tzlocal=2.0.0

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -17,8 +17,8 @@ dependencies:
   - pytables=3.6.1
   - python=3.8.2
   - python-dateutil=2.8.1
-  - six=1.14.0
   - scipy=1.6.2
+  - six=1.14.0
   - sqlalchemy=1.3.13
   - sqlite=3.31.1
   - tzlocal=2.0.0

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy==1.7.2
+scipy
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,6 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
+scipy==1.7.1
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy=1.7.1
+scipy=1.6.2
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,6 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy=1.6.2
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy=1.6.2
+scipy=1.7.1
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy==1.7.1
+scipy==1.6.2
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy
+scipy=1.6.2
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/setup/requirements-arm.txt
+++ b/setup/requirements-arm.txt
@@ -25,7 +25,7 @@ python-binance==0.7.5
 python-telegram-bot==12.4.2
 rsa==4.7
 ruamel-yaml==0.16.10
-scipy==1.6.2
+scipy==1.7.2
 signalr-client-aio==0.0.1.6.2
 simplejson==3.17.2
 sqlalchemy==1.3.13

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -199,14 +199,6 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Update the trading intensity indicator
         strategy.trading_intensity = trading_intensity_indicator
 
-        # # Simulates change in mid price to reflect last sample added
-        # strategy.market_info.market.set_balanced_order_book(trading_pair=strategy.trading_pair,
-        #                                                     mid_price=samples[-1],
-        #                                                     min_price=1,
-        #                                                     max_price=200,
-        #                                                     price_step_size=1,
-        #                                                     volume_step_size=10)
-
     @staticmethod
     def simulate_high_liquidity(strategy: AvellanedaMarketMakingStrategy, volatility):
         N_SAMPLES = 1000
@@ -233,14 +225,6 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Update the trading intensity indicator
         strategy.trading_intensity = trading_intensity_indicator
-
-        # # Simulates change in mid price to reflect last sample added
-        # strategy.market_info.market.set_balanced_order_book(trading_pair=strategy.trading_pair,
-        #                                                     mid_price=samples[-1],
-        #                                                     min_price=1,
-        #                                                     max_price=200,
-        #                                                     price_step_size=1,
-        #                                                     volume_step_size=10)
 
     @staticmethod
     def make_order_books(original_price_mid, original_spread, original_amount, volatility, spread_stdev, amount_stdev, samples):

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -701,8 +701,8 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
-        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.3004893648473526161284873639'), Decimal('0.6009787296947052322569747278'), Decimal('0.9014680945420578483854620917')]
-        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.3004893648473526161284873639'), Decimal('0.6009787296947052322569747278'), Decimal('0.9014680945420578483854620917')]
+        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.3004893648473526161284873639'), Decimal('0.5347170474218074567988620706'), Decimal('0.8020755711327111851982931059')]
+        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.3004893648473526161284873639'), Decimal('0.5347170474218074567988620706'), Decimal('0.8020755711327111851982931059')]
 
         bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
 

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -28,6 +28,7 @@ from hummingbot.strategy.avellaneda_market_making import AvellanedaMarketMakingS
 from hummingbot.strategy.data_types import PriceSize, Proposal
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.__utils__.trailing_indicators.instant_volatility import InstantVolatilityIndicator
+from hummingbot.strategy.__utils__.trailing_indicators.trading_intensity import TradingIntensityIndicator
 from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
 from test.mock.mock_paper_exchange import MockPaperExchange
 
@@ -54,18 +55,22 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         cls.clock_tick_size: int = 1
 
         # Testing Constants
+        # Volatility as a percentage, not absolute as in instant volatility indicator
         cls.low_vol: Decimal = Decimal("0.05")
         cls.expected_low_vol: Decimal = Decimal("0.0501863845537047")
         cls.high_vol: Decimal = Decimal("5")
         cls.expected_high_vol: Decimal = Decimal("5.018622242594793")
 
+        cls.low_liq_spread: Decimal = Decimal("10")
+        cls.low_liq_amount: Decimal = Decimal("1")
+        cls.high_liq_spread: Decimal = Decimal("0.1")
+        cls.high_liq_amount: Decimal = Decimal("100")
+
         # Strategy Initial Configuration Parameters
         cls.order_amount: Decimal = Decimal("10")
         cls.inventory_target_base_pct: Decimal = Decimal("0.5")     # Indicates 50%
-        cls.min_spread: Decimal = Decimal("0.2")                   # Default strategy value
-        cls.max_spread: Decimal = Decimal("0.5")                      # Default strategy value
-        cls.vol_to_spread_multiplier: Decimal = Decimal("1.3")      # Default strategy value
-        cls.ira: Decimal = Decimal("0.8")
+        cls.min_spread: Decimal = Decimal("0.0")                   # Default strategy value
+        cls.risk_factor: Decimal = Decimal("0.8")
 
     def setUp(self):
         super().setUp()
@@ -92,16 +97,17 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
             market_info=self.market_info,
             order_amount=self.order_amount,
             min_spread=self.min_spread,
-            max_spread=self.max_spread,
             inventory_target_base_pct=self.inventory_target_base_pct,
-            vol_to_spread_multiplier=self.vol_to_spread_multiplier,
-            inventory_risk_aversion=self.ira
+            risk_factor=self.risk_factor
         )
 
         self.avg_vol_indicator: InstantVolatilityIndicator = InstantVolatilityIndicator(sampling_length=100,
                                                                                         processing_length=1)
 
+        self.trading_intensity_indicator: TradingIntensityIndicator = TradingIntensityIndicator(sampling_length=200)
+
         self.strategy.avg_vol = self.avg_vol_indicator
+        self.strategy.trading_intensity = self.trading_intensity_indicator
 
         self.clock: Clock = Clock(ClockMode.BACKTEST, self.clock_tick_size, self.start_timestamp, self.end_timestamp)
 
@@ -139,14 +145,6 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
                                                             max_price=200,
                                                             price_step_size=1,
                                                             volume_step_size=10)
-        # Simulates c_collect_market_variables().
-        # This is required since c_collect_market_variables() calls avg_vol.add_sample() which would affect calculations.
-        price = strategy.get_price()
-        base_balance = strategy.market_info.market.get_balance("COINALPHA")
-        quote_balance = strategy.market_info.market.get_balance("HBOT")
-        inventory_in_base = quote_balance / price + base_balance
-
-        strategy.q_adjustment_factor = (Decimal("1e5") / inventory_in_base) if inventory_in_base else Decimal("1e5")
 
     @staticmethod
     def simulate_high_volatility(strategy: AvellanedaMarketMakingStrategy):
@@ -174,14 +172,123 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
                                                             price_step_size=1,
                                                             volume_step_size=10)
 
-        # Simulates c_collect_market_variables().
-        # This is required since c_collect_market_variables() calls avg_vol.add_sample() which would affect calculations.
-        price = strategy.get_price()
-        base_balance = strategy.market_info.market.get_balance("COINALPHA")
-        quote_balance = strategy.market_info.market.get_balance("HBOT")
-        inventory_in_base = quote_balance / price + base_balance
+    @staticmethod
+    def simulate_low_liquidity(strategy: AvellanedaMarketMakingStrategy, volatility):
+        N_SAMPLES = 1000
+        INITIAL_RANDOM_SEED = 3141592653
+        original_price_mid = 100
+        original_spread = AvellanedaMarketMakingUnitTests.low_liq_spread
+        volatility = volatility / Decimal("100")
+        original_amount = AvellanedaMarketMakingUnitTests.low_liq_amount
 
-        strategy.q_adjustment_factor = (Decimal("1e5") / inventory_in_base) if inventory_in_base else Decimal("1e5")
+        spread_stdev = original_spread * Decimal("0.01")
+        amount_stdev = original_amount * Decimal("0.01")
+
+        np.random.seed(INITIAL_RANDOM_SEED)     # Using this hardcoded random seed we guarantee random samples generated are always the same
+
+        # Generate orderbooks for all ticks
+        bids_df, asks_df = AvellanedaMarketMakingUnitTests.make_order_books(original_price_mid, original_spread, original_amount, volatility, spread_stdev, amount_stdev, N_SAMPLES)
+
+        # This replicates the same indicator Avellaneda uses for trading intensity estimation
+        trading_intensity_indicator = strategy.trading_intensity
+
+        for bid_df, ask_df in zip(bids_df, asks_df):
+            snapshot = (bid_df, ask_df)
+            trading_intensity_indicator.add_sample(snapshot)
+
+        # Update the trading intensity indicator
+        strategy.trading_intensity = trading_intensity_indicator
+
+        # # Simulates change in mid price to reflect last sample added
+        # strategy.market_info.market.set_balanced_order_book(trading_pair=strategy.trading_pair,
+        #                                                     mid_price=samples[-1],
+        #                                                     min_price=1,
+        #                                                     max_price=200,
+        #                                                     price_step_size=1,
+        #                                                     volume_step_size=10)
+
+    @staticmethod
+    def simulate_high_liquidity(strategy: AvellanedaMarketMakingStrategy, volatility):
+        N_SAMPLES = 1000
+        INITIAL_RANDOM_SEED = 3141592653
+        original_price_mid = 100
+        original_spread = AvellanedaMarketMakingUnitTests.high_liq_spread
+        volatility = volatility / Decimal("100")
+        original_amount = AvellanedaMarketMakingUnitTests.high_liq_amount
+
+        spread_stdev = original_spread * Decimal("0.01")
+        amount_stdev = original_amount * Decimal("0.01")
+
+        np.random.seed(INITIAL_RANDOM_SEED)     # Using this hardcoded random seed we guarantee random samples generated are always the same
+
+        # Generate orderbooks for all ticks
+        bids_df, asks_df = AvellanedaMarketMakingUnitTests.make_order_books(original_price_mid, original_spread, original_amount, volatility, spread_stdev, amount_stdev, N_SAMPLES)
+
+        # This replicates the same indicator Avellaneda uses for trading intensity estimation
+        trading_intensity_indicator = strategy.trading_intensity
+
+        for bid_df, ask_df in zip(bids_df, asks_df):
+            snapshot = (bid_df, ask_df)
+            trading_intensity_indicator.add_sample(snapshot)
+
+        # Update the trading intensity indicator
+        strategy.trading_intensity = trading_intensity_indicator
+
+        # # Simulates change in mid price to reflect last sample added
+        # strategy.market_info.market.set_balanced_order_book(trading_pair=strategy.trading_pair,
+        #                                                     mid_price=samples[-1],
+        #                                                     min_price=1,
+        #                                                     max_price=200,
+        #                                                     price_step_size=1,
+        #                                                     volume_step_size=10)
+
+    @staticmethod
+    def make_order_books(original_price_mid, original_spread, original_amount, volatility, spread_stdev, amount_stdev, samples):
+        # 0.1% quantization of prices in the orderbook
+        PRICE_STEP_FRACTION = 0.001
+
+        # Generate BBO quotes
+        samples_mid = np.random.normal(original_price_mid, volatility * original_price_mid, samples)
+        samples_spread = np.random.normal(original_spread, spread_stdev, samples)
+
+        samples_price_bid = np.subtract(samples_mid, np.divide(samples_spread, 2))
+        samples_price_ask = np.add(samples_mid, np.divide(samples_spread, 2))
+
+        samples_amount_bid = np.random.normal(original_amount, amount_stdev, samples)
+        samples_amount_ask = np.random.normal(original_amount, amount_stdev, samples)
+
+        # A full orderbook is not necessary, only up to the BBO max deviation
+        price_depth_max = max(max(samples_price_bid) - min(samples_price_bid), max(samples_price_ask) - min(samples_price_ask))
+
+        bid_dfs = []
+        ask_dfs = []
+
+        # Generate an orderbook for every tick
+        for price_bid, amount_bid, price_ask, amount_ask in zip(samples_price_bid, samples_amount_bid, samples_price_ask, samples_amount_ask):
+            bid_df, ask_df = AvellanedaMarketMakingUnitTests.make_order_book(price_bid, amount_bid, price_ask, amount_ask, price_depth_max, original_price_mid * PRICE_STEP_FRACTION, amount_stdev)
+            bid_dfs += [bid_df]
+            ask_dfs += [ask_df]
+
+        return bid_dfs, ask_dfs
+
+    @staticmethod
+    def make_order_book(price_bid, amount_bid, price_ask, amount_ask, price_depth, price_step, amount_stdev, ):
+
+        prices_bid = np.linspace(price_bid, price_bid - price_depth, math.ceil(price_depth / price_step))
+        amounts_bid = np.random.normal(amount_bid, amount_stdev, len(prices_bid))
+        amounts_bid[0] = amount_bid
+
+        prices_ask = np.linspace(price_ask, price_ask + price_depth, math.ceil(price_depth / price_step))
+        amounts_ask = np.random.normal(amount_ask, amount_stdev, len(prices_ask))
+        amounts_ask[0] = amount_ask
+
+        data_bid = {'price': prices_bid, 'amount': amounts_bid}
+        bid_df = pd.DataFrame(data=data_bid)
+
+        data_ask = {'price': prices_ask, 'amount': amounts_ask}
+        ask_df = pd.DataFrame(data=data_ask)
+
+        return bid_df, ask_df
 
     @staticmethod
     def simulate_place_limit_order(strategy: AvellanedaMarketMakingStrategy, market_info: MarketTradingPairTuple, order: LimitOrder):
@@ -462,27 +569,9 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.assertFalse(self.strategy.is_algorithm_ready())
 
         self.simulate_high_volatility(self.strategy)
+        self.simulate_low_liquidity(self.strategy, self.high_vol)
 
         self.assertTrue(self.strategy.is_algorithm_ready())
-
-    def test_volatility_diff_from_last_parameter_calculation(self):
-        # Initial volatility check. Should return s_decimal_zero
-        self.assertEqual(s_decimal_zero, self.strategy.volatility_diff_from_last_parameter_calculation(self.strategy.get_volatility()))
-
-        # Simulate buffers being filled and initial market volatility
-        self.simulate_low_volatility(self.strategy)
-        self.strategy.collect_market_variables(self.strategy.current_timestamp)
-        self.strategy.recalculate_parameters()
-        initial_vol: Decimal = self.strategy.get_volatility()
-
-        # Simulate change in volatitly
-        self.simulate_high_volatility(self.strategy)
-        new_vol = self.strategy.get_volatility()
-
-        self.assertNotEqual(s_decimal_zero, self.strategy.volatility_diff_from_last_parameter_calculation(self.strategy.get_volatility()))
-
-        expected_diff_vol: Decimal = abs(initial_vol - new_vol) / initial_vol
-        self.assertEqual(expected_diff_vol, self.strategy.volatility_diff_from_last_parameter_calculation(self.strategy.get_volatility()))
 
     def test_get_spread(self):
         order_book: OrderBook = self.market.get_order_book(self.trading_pair)
@@ -514,90 +603,44 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         self.assertEqual(expected_quantize_order_amount, self.strategy.calculate_target_inventory())
 
-    def test_get_min_and_max_spread(self):
-        # Simulate low volatility. vol approx. 0.5%
-        self.simulate_low_volatility(self.strategy)
+    def test_liquidity_estimation(self):
 
-        # Calculating min and max spread in low volatility
-        curr_price: Decimal = self.strategy.get_price()
-        expected_min_spread: Decimal = self.min_spread * curr_price
-        expected_max_spread: Decimal = self.max_spread * curr_price * (expected_min_spread / (self.min_spread * curr_price))
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
 
-        self.assertEqual((expected_min_spread, expected_max_spread), self.strategy._get_min_and_max_spread())
+        alpha, kappa = self.strategy.trading_intensity.current_value
 
-        # Simulate high volatility. vol approx. 10%
-        self.simulate_high_volatility(self.strategy)
+        self.assertAlmostEqual(100.58688318883304, alpha, 5)
+        self.assertAlmostEqual(0.03153874736059721, kappa, 5)
 
-        # Initialize strategy with high vol_to_spread_multiplier config
-        self.strategy.vol_to_spread_multiplier = Decimal("10")
+        # Simulate high liquidity
+        self.simulate_low_liquidity(self.strategy, self.high_vol)
 
-        curr_price: Decimal = self.strategy.get_price()
-        curr_vol: Decimal = self.strategy.get_volatility()
-        expected_min_spread: Decimal = self.strategy.vol_to_spread_multiplier * curr_vol
-        expected_max_spread: Decimal = self.max_spread * curr_price * (expected_min_spread / (self.min_spread * curr_price))
+        alpha, kappa = self.strategy.trading_intensity.current_value
 
-        self.assertEqual((expected_min_spread, expected_max_spread), self.strategy._get_min_and_max_spread())
-
-    def test_recalculate_parameters(self):
-
-        # Simulate low volatility
-        self.simulate_low_volatility(self.strategy)
-
-        # Calculate expected gamma, kappa and eta
-        q = (self.market.get_balance(self.base_asset) - self.strategy.calculate_target_inventory()) * self.strategy.q_adjustment_factor
-        vol = self.strategy.get_volatility()
-        min_spread, max_spread = self.strategy._get_min_and_max_spread()
-
-        expected_gamma = self.ira * (max_spread - min_spread) / (2 * abs(q) * (vol ** 2))
-
-        max_spread_around_reserved_price = max_spread * (2 - self.ira) + min_spread * self.ira
-        expected_kappa = expected_gamma / (Decimal.exp((max_spread_around_reserved_price * expected_gamma - (vol * expected_gamma) ** 2) / 2) - 1)
-
-        q_where_to_decay_order_amount = self.strategy.calculate_target_inventory() / (self.ira * Decimal.ln(Decimal("10")))
-        expected_eta = s_decimal_one / q_where_to_decay_order_amount
-
-        self.strategy.recalculate_parameters()
-        self.assertAlmostEqual(expected_gamma, self.strategy.gamma, 5)
-        self.assertAlmostEqual(expected_kappa, self.strategy.kappa, 5)
-        self.assertAlmostEqual(expected_eta, self.strategy.eta, 5)
-
-        # Simulate close to _inventory_target_base_pct
-        self.market.set_balance("COINALPHA", 5)
-        self.market.set_balance("HBOT", 500)
-
-        q = (self.market.get_balance(self.base_asset) - self.strategy.calculate_target_inventory()) * self.strategy.q_adjustment_factor
-        vol = self.strategy.get_volatility()
-        min_spread, max_spread = self.strategy._get_min_and_max_spread()
-
-        # TODO: Test for expected_gamma = self.ira * (max_spread * (2-self.ira) / self.ira + min_spread) / (vol ** 2)
+        self.assertAlmostEqual(1.000611883897753, alpha, 5)
+        self.assertAlmostEqual(0.00016076949233667087, kappa, 5)
 
     def test_calculate_reserved_price_and_optimal_spread(self):
         # Test (1) Low volatility, Default min_spread = Decimal(0.2)
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
-        # Prepare parameters for calculation
-        self.strategy.recalculate_parameters()
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
 
-        price = self.strategy.get_price()
-        q = (self.market.get_balance(self.base_asset) - self.strategy.calculate_target_inventory()) * self.strategy.q_adjustment_factor
-        vol = self.strategy.get_volatility()
-        mid_price_variance = vol ** 2
+        # Set time left
+        self.strategy.time_left = self.strategy.closing_time / 2
 
-        time_left_fraction = Decimal("1")
-        expected_reserved_price = price - (q * self.strategy.gamma * mid_price_variance * time_left_fraction)
-        expected_optimal_spread = self.strategy.gamma * mid_price_variance * time_left_fraction + 2 * Decimal(
-            1 + self.strategy.gamma / self.strategy.kappa).ln() / self.strategy.gamma
-        expected_optimal_ask = expected_reserved_price + expected_optimal_spread / 2
-        expected_optimal_bid = expected_reserved_price - expected_optimal_spread / 2
-
+        # Execute measurements and calculations
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Check reserved_price, optimal_ask and optimal_bid
-        self.assertAlmostEqual(expected_reserved_price, self.strategy.reserved_price, 2)
-        self.assertAlmostEqual(expected_optimal_spread, self.strategy.optimal_spread, 2)
-        self.assertAlmostEqual(expected_optimal_ask, self.strategy.optimal_ask, 1)
-        self.assertAlmostEqual(expected_optimal_bid, self.strategy.optimal_bid, 1)
+        self.assertAlmostEqual(Decimal("99.96461681009458792335454783"), self.strategy.reserved_price, 2)
+        self.assertAlmostEqual(Decimal("8.182025123173773376728372082"), self.strategy.optimal_spread, 2)
+        self.assertAlmostEqual(Decimal("104.0556293716814746117187339"), self.strategy.optimal_ask, 2)
+        self.assertAlmostEqual(Decimal("95.87360424850770123499036179"), self.strategy.optimal_bid, 2)
 
         # TODO: Test for different paths optimal_ask and optimal_bid. See AvellanedaMM line 631-648.
 
@@ -629,13 +672,15 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         self.assertEqual(str(expected_proposal), str(self.strategy.create_proposal_based_on_order_override()))
 
-    def test_get_logspaced_level_spreads(self):
+    def test_get_level_spreads(self):
         # Re-initialize strategy with order_level configurations
         self.strategy = AvellanedaMarketMakingStrategy()
         self.strategy.init_params(
             market_info=self.market_info,
             order_amount=self.order_amount,
-            order_levels=2,
+            order_levels=4,
+            level_distances=1,
+            inventory_target_base_pct=self.inventory_target_base_pct,
         )
         self.strategy.start(self.clock, self.start_timestamp)
 
@@ -643,20 +688,18 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Note: bid/ask_level_spreads Requires volatility, optimal_bid, optimal_ask to be defined
         self.simulate_low_volatility(self.strategy)
 
-        self.strategy.recalculate_parameters()
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
+        # Execute measurements and calculations
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
-        # Calculation for expected bid/ask_level_spreads
-        reference_price = self.strategy.get_price()
-        _, max_spread = self.strategy._get_min_and_max_spread()
-        optimal_ask_spread = self.strategy.optimal_ask - reference_price
-        optimal_bid_spread = reference_price - self.strategy.optimal_bid
-        expected_bid_spreads = np.logspace(0, np.log(float(max_spread - optimal_bid_spread) + 1), base=np.e,
-                                           num=2) - 1
-        expected_ask_spreads = np.logspace(0, np.log(float(max_spread - optimal_ask_spread) + 1), base=np.e,
-                                           num=2) - 1
+        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.0565051483703522252511557473'), Decimal('0.1130102967407044505023114946'), Decimal('0.1695154451110566757534672419')]
+        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.0565051483703522252511557473'), Decimal('0.1130102967407044505023114946'), Decimal('0.1695154451110566757534672419')]
 
-        bid_level_spreads, ask_level_spreads = self.strategy._get_logspaced_level_spreads()
+        bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
+
         for i, spread in enumerate(bid_level_spreads):
             self.assertAlmostEqual(expected_bid_spreads[i], spread, 1)
 
@@ -667,20 +710,18 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Note: bid/ask_level_spreads Requires volatility, optimal_bid, optimal_ask to be defined
         self.simulate_high_volatility(self.strategy)
 
-        self.strategy.recalculate_parameters()
+        # Simulate high liquidity
+        self.simulate_low_liquidity(self.strategy, self.high_vol)
+
+        # Execute measurements and calculations
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
-        # Calculation for expected bid/ask_level_spreads
-        reference_price = self.strategy.get_price()
-        _, max_spread = self.strategy._get_min_and_max_spread()
-        optimal_ask_spread = self.strategy.optimal_ask - reference_price
-        optimal_bid_spread = reference_price - self.strategy.optimal_bid
-        expected_bid_spreads = np.logspace(0, np.log(float(max_spread - optimal_bid_spread) + 1), base=np.e,
-                                           num=2) - 1
-        expected_ask_spreads = np.logspace(0, np.log(float(max_spread - optimal_ask_spread) + 1), base=np.e,
-                                           num=2) - 1
+        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.3004893648473526161284873639'), Decimal('0.6009787296947052322569747278'), Decimal('0.9014680945420578483854620917')]
+        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.3004893648473526161284873639'), Decimal('0.6009787296947052322569747278'), Decimal('0.9014680945420578483854620917')]
 
-        bid_level_spreads, ask_level_spreads = self.strategy._get_logspaced_level_spreads()
+        bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
+
         for i, spread in enumerate(bid_level_spreads):
             self.assertAlmostEqual(expected_bid_spreads[i], spread, 1)
 
@@ -691,8 +732,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Test(1) Check order_levels default = 0
@@ -703,7 +747,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.strategy.order_levels = 2
 
         # Calculate order levels
-        bid_level_spreads, ask_level_spreads = self.strategy._get_logspaced_level_spreads()
+        bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
 
         expected_buys = []
         expected_sells = []
@@ -725,8 +769,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         expected_order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair,
@@ -746,8 +793,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # (1) Default
@@ -798,7 +848,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.strategy.order_levels = 2
 
         # Calculate order levels
-        bid_level_spreads, ask_level_spreads = self.strategy._get_logspaced_level_spreads()
+        bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
 
         expected_buys = []
         expected_sells = []
@@ -836,8 +886,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Create a basic proposal.
@@ -861,8 +914,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Create a basic proposal.
@@ -887,8 +943,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Create a basic proposal.
@@ -937,8 +996,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Create a basic proposal.
@@ -992,8 +1054,11 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
 
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Create a basic proposal.
@@ -1199,10 +1264,8 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
             market_info=self.market_info,
             order_amount=self.order_amount,
             min_spread=self.min_spread,
-            max_spread=self.max_spread,
             inventory_target_base_pct=self.inventory_target_base_pct,
-            vol_to_spread_multiplier=self.vol_to_spread_multiplier,
-            inventory_risk_aversion=self.ira,
+            risk_factor=self.risk_factor,
             hanging_orders_enabled=True,
             hanging_orders_cancel_pct=Decimal(1),
             filled_order_delay=30
@@ -1218,8 +1281,12 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
+
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
@@ -1263,10 +1330,8 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
             market_info=self.market_info,
             order_amount=self.order_amount,
             min_spread=self.min_spread,
-            max_spread=self.max_spread,
             inventory_target_base_pct=self.inventory_target_base_pct,
-            vol_to_spread_multiplier=self.vol_to_spread_multiplier,
-            inventory_risk_aversion=self.ira,
+            risk_factor=self.risk_factor,
             hanging_orders_enabled=True,
             hanging_orders_cancel_pct=Decimal(1),
             order_refresh_time=refresh_time,
@@ -1282,8 +1347,12 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
+
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
@@ -1328,8 +1397,12 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Simulate low volatility
         self.simulate_low_volatility(self.strategy)
+
+        # Simulate high liquidity
+        self.simulate_high_liquidity(self.strategy, self.low_vol)
+
         # Prepare market variables and parameters for calculation
-        self.strategy.recalculate_parameters()
+        self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making_start.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making_start.py
@@ -24,14 +24,10 @@ class AvellanedaStartTest(unittest.TestCase):
         strategy_cmap.get("hanging_orders_enabled").value = True
         strategy_cmap.get("hanging_orders_cancel_pct").value = Decimal("1")
         # strategy_cmap.get("hanging_orders_aggregation_type").value = "VOLUME_WEIGHTED"
-        strategy_cmap.get("parameters_based_on_spread").value = True
         strategy_cmap.get("min_spread").value = Decimal("2")
-        strategy_cmap.get("max_spread").value = Decimal("3")
-        strategy_cmap.get("vol_to_spread_multiplier").value = Decimal("1.1")
-        strategy_cmap.get("volatility_sensibility").value = Decimal("2.2")
-        strategy_cmap.get("inventory_risk_aversion").value = Decimal("0.1")
         strategy_cmap.get("risk_factor").value = Decimal("1.11")
-        strategy_cmap.get("order_book_depth_factor").value = Decimal("2.22")
+        strategy_cmap.get("order_levels").value = Decimal("4")
+        strategy_cmap.get("level_distances").value = Decimal("1")
         strategy_cmap.get("order_amount_shape_factor").value = Decimal("3.33")
 
         self.raise_exception_for_market_initialization = False
@@ -56,21 +52,14 @@ class AvellanedaStartTest(unittest.TestCase):
     def test_parameters_based_on_spread_strategy_creation(self, mock_hbot):
         mock_hbot.main_application().strategy_file_name = "test.csv"
         strategy_start.start(self)
-        self.assertEqual(self.strategy.min_spread, Decimal("0.02"))
-        self.assertEqual(self.strategy.max_spread, Decimal("0.03"))
-        self.assertEqual(self.strategy.vol_to_spread_multiplier, Decimal("1.1"))
-        self.assertEqual(self.strategy.volatility_sensibility, Decimal("0.022"))
-        self.assertEqual(self.strategy.inventory_risk_aversion, Decimal("0.1"))
-        self.assertTrue(all(c is None for c in (self.strategy.gamma, self.strategy.kappa, self.strategy.eta)))
-        strategy_cmap.get("parameters_based_on_spread").value = False
-        strategy_start.start(self)
-        self.assertTrue(all(c is None for c in (self.strategy.min_spread, self.strategy.max_spread,
-                                                self.strategy.vol_to_spread_multiplier,
-                                                self.strategy.inventory_risk_aversion,
-                                                self.strategy.volatility_sensibility)))
+        self.assertEqual(self.strategy.min_spread, Decimal("2"))
         self.assertEqual(self.strategy.gamma, Decimal("1.11"))
-        self.assertEqual(self.strategy.kappa, Decimal("2.22"))
         self.assertEqual(self.strategy.eta, Decimal("3.33"))
+        self.assertEqual(self.strategy.order_levels, Decimal("4"))
+        self.assertEqual(self.strategy.level_distances, Decimal("1"))
+        self.assertTrue(all(c is not None for c in (self.strategy.gamma, self.strategy.eta)))
+        strategy_start.start(self)
+        self.assertTrue(all(c is not None for c in (self.strategy.min_spread, self.strategy.gamma)))
 
     def test_strategy_creation_when_something_fails(self):
         self.raise_exception_for_market_initialization = True

--- a/test/hummingbot/strategy/utils/trailing_indicators/test_instant_volatility.py
+++ b/test/hummingbot/strategy/utils/trailing_indicators/test_instant_volatility.py
@@ -10,7 +10,7 @@ class InstantVolatilityTest(unittest.TestCase):
     def setUp(self) -> None:
         np.random.seed(self.INITIAL_RANDOM_SEED)
 
-    def test_calculate_volatility_without_smoothing(self):
+    def test_calculate_volatility(self):
         original_price = 100
         volatility = 0.1
         samples = np.random.normal(original_price, volatility * original_price, self.BUFFER_LENGTH)
@@ -19,41 +19,4 @@ class InstantVolatilityTest(unittest.TestCase):
         for sample in samples:
             self.indicator.add_sample(sample)
 
-        self.assertAlmostEqual(self.indicator.current_value, volatility * original_price, 1)
-
-    def test_calculate_volatility_with_smoothing(self):
-        original_price = 100
-        volatility = 0.1
-        samples = np.random.normal(original_price, volatility * original_price, self.BUFFER_LENGTH)
-        self.indicator = InstantVolatilityIndicator(self.BUFFER_LENGTH, 20)
-
-        for sample in samples:
-            self.indicator.add_sample(sample)
-
-        self.assertAlmostEqual(self.indicator.current_value, volatility * original_price, 1)
-
-    def test_compare_volatility_with_smoothing(self):
-        original_price = 100
-        volatility = 0.1
-        # This time I'm creating 10 times the buffer length
-        samples = np.random.normal(original_price, volatility * original_price, self.BUFFER_LENGTH)
-        self.indicator_normal = InstantVolatilityIndicator(self.BUFFER_LENGTH, 1)
-        # Using 20 samples of smoothing
-        self.indicator_smoothed = InstantVolatilityIndicator(self.BUFFER_LENGTH, 20)
-
-        output_normal = []
-        output_smoothed = []
-        for sample in samples:
-            self.indicator_normal.add_sample(sample)
-            self.indicator_smoothed.add_sample(sample)
-            output_normal.append(self.indicator_normal.current_value)
-            output_smoothed.append(self.indicator_smoothed.current_value)
-
-        # Now we want to assert output from smoothed indicator is more "smoothed" than normal one.
-        # How do we do this? By measuring the energy of the first derivative of each output.
-        # Energy(diff) = Sum(diff(output)**2)
-
-        energy_normal = sum(x ** 2 for x in np.diff(output_normal))
-        energy_smoothed = sum(x ** 2 for x in np.diff(output_smoothed))
-
-        self.assertGreater(energy_normal, energy_smoothed)
+        self.assertAlmostEqual(self.indicator.current_value, 14.06933307647705, 4)

--- a/test/hummingbot/strategy/utils/trailing_indicators/test_trading_intensity.py
+++ b/test/hummingbot/strategy/utils/trailing_indicators/test_trading_intensity.py
@@ -8,7 +8,7 @@ from hummingbot.strategy.__utils__.trailing_indicators.trading_intensity import 
 
 class TradingIntensityTest(unittest.TestCase):
     INITIAL_RANDOM_SEED = 3141592653
-    BUFFER_LENGTH = 10000
+    BUFFER_LENGTH = 200
 
     def setUp(self) -> None:
         np.random.seed(self.INITIAL_RANDOM_SEED)

--- a/test/hummingbot/strategy/utils/trailing_indicators/test_trading_intensity.py
+++ b/test/hummingbot/strategy/utils/trailing_indicators/test_trading_intensity.py
@@ -1,0 +1,85 @@
+from decimal import Decimal
+import math
+import numpy as np
+import pandas as pd
+import unittest
+from hummingbot.strategy.__utils__.trailing_indicators.trading_intensity import TradingIntensityIndicator
+
+
+class TradingIntensityTest(unittest.TestCase):
+    INITIAL_RANDOM_SEED = 3141592653
+    BUFFER_LENGTH = 10000
+
+    def setUp(self) -> None:
+        np.random.seed(self.INITIAL_RANDOM_SEED)
+
+    @staticmethod
+    def make_order_books(original_price_mid, original_spread, original_amount, volatility, spread_stdev, amount_stdev, samples):
+        # 0.1% quantization of prices in the orderbook
+        PRICE_STEP_FRACTION = 0.001
+
+        # Generate BBO quotes
+        samples_mid = np.random.normal(original_price_mid, volatility * original_price_mid, samples)
+        samples_spread = np.random.normal(original_spread, spread_stdev, samples)
+
+        samples_price_bid = np.subtract(samples_mid, np.divide(samples_spread, 2))
+        samples_price_ask = np.add(samples_mid, np.divide(samples_spread, 2))
+
+        samples_amount_bid = np.random.normal(original_amount, amount_stdev, samples)
+        samples_amount_ask = np.random.normal(original_amount, amount_stdev, samples)
+
+        # A full orderbook is not necessary, only up to the BBO max deviation
+        price_depth_max = max(max(samples_price_bid) - min(samples_price_bid), max(samples_price_ask) - min(samples_price_ask))
+
+        bid_dfs = []
+        ask_dfs = []
+
+        # Generate an orderbook for every tick
+        for price_bid, amount_bid, price_ask, amount_ask in zip(samples_price_bid, samples_amount_bid, samples_price_ask, samples_amount_ask):
+            bid_df, ask_df = TradingIntensityTest.make_order_book(price_bid, amount_bid, price_ask, amount_ask, price_depth_max, original_price_mid * PRICE_STEP_FRACTION, amount_stdev)
+            bid_dfs += [bid_df]
+            ask_dfs += [ask_df]
+
+        return bid_dfs, ask_dfs
+
+    @staticmethod
+    def make_order_book(price_bid, amount_bid, price_ask, amount_ask, price_depth, price_step, amount_stdev, ):
+
+        prices_bid = np.linspace(price_bid, price_bid - price_depth, math.ceil(price_depth / price_step))
+        amounts_bid = np.random.normal(amount_bid, amount_stdev, len(prices_bid))
+        amounts_bid[0] = amount_bid
+
+        prices_ask = np.linspace(price_ask, price_ask + price_depth, math.ceil(price_depth / price_step))
+        amounts_ask = np.random.normal(amount_ask, amount_stdev, len(prices_ask))
+        amounts_ask[0] = amount_ask
+
+        data_bid = {'price': prices_bid, 'amount': amounts_bid}
+        bid_df = pd.DataFrame(data=data_bid)
+
+        data_ask = {'price': prices_ask, 'amount': amounts_ask}
+        ask_df = pd.DataFrame(data=data_ask)
+
+        return bid_df, ask_df
+
+    def test_calculate_trading_intensity(self):
+        N_SAMPLES = 1000
+
+        self.indicator = TradingIntensityIndicator(self.BUFFER_LENGTH)
+
+        original_price_mid = 100
+        original_spread = Decimal("10")
+        volatility = Decimal("5") / Decimal("100")
+        original_amount = Decimal("1")
+
+        spread_stdev = original_spread * Decimal("0.01")
+        amount_stdev = original_amount * Decimal("0.01")
+
+        # Generate orderbooks for all ticks
+        bids_df, asks_df = TradingIntensityTest.make_order_books(original_price_mid, original_spread, original_amount, volatility, spread_stdev, amount_stdev, N_SAMPLES)
+
+        for bid_df, ask_df in zip(bids_df, asks_df):
+            snapshot = (bid_df, ask_df)
+            self.indicator.add_sample(snapshot)
+
+        self.assertAlmostEqual(self.indicator.current_value[0], 1.0003827732841395, 4)
+        self.assertAlmostEqual(self.indicator.current_value[1], 3.2490000322096546e-05, 4)

--- a/test/hummingbot/strategy/utils/trailing_indicators/test_trading_intensity.py
+++ b/test/hummingbot/strategy/utils/trailing_indicators/test_trading_intensity.py
@@ -81,5 +81,5 @@ class TradingIntensityTest(unittest.TestCase):
             snapshot = (bid_df, ask_df)
             self.indicator.add_sample(snapshot)
 
-        self.assertAlmostEqual(self.indicator.current_value[0], 1.0003827732841395, 4)
-        self.assertAlmostEqual(self.indicator.current_value[1], 3.2490000322096546e-05, 4)
+        self.assertAlmostEqual(self.indicator.current_value[0], 1.0006118838992204, 4)
+        self.assertAlmostEqual(self.indicator.current_value[1], 0.00016076949224819458, 4)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Automatic estimation of order book liquidity parameters (alpha, kappa) as a new indicator "trading intensity"
Change in greeks calculation
Removal of artificial helper parameters altering the strategy behavior
Instant volatility calculation fix
Fixes of multiple equations and variables to achieve unit consistency and calculation correctness
Removal of min-max spread logic and logspaced levels
Implementation of new log levels based on optimal spread
Implementation of multi-tick deep order books for order book liquidity estimation in unit tests
Change of the "algorithm ready" condition to account for the order book liquidity estimation
Added scipy as a new package dependency

**Tests performed by the developer**:

Tested order book liquidity estimation logic and strategy performance on various pairs with the binance paper connector
Ran the unit tests
