### PR TITLE
Feat/gateway v2 eth base improvements

### DIFF
--- a/gateway/src/chains/ethereum/ethereum.controllers.ts
+++ b/gateway/src/chains/ethereum/ethereum.controllers.ts
@@ -75,11 +75,16 @@ export async function allowances(
   const approvals: Record<string, string> = {};
   await Promise.all(
     Object.keys(tokens).map(async (symbol) => {
+      // instantiate a contract and pass in provider for read-only access
+      const contract = ethereumish.getContract(
+        tokens[symbol].address,
+        ethereumish.provider
+      );
       approvals[symbol] = tokenValueToString(
         await ethereumish.getERC20Allowance(
+          contract,
           wallet,
           spender,
-          tokens[symbol].address,
           tokens[symbol].decimals
         )
       );
@@ -117,9 +122,11 @@ export async function balances(
       if (tokens[symbol] !== undefined) {
         const address = tokens[symbol].address;
         const decimals = tokens[symbol].decimals;
+        // instantiate a contract and pass in provider for read-only access
+        const contract = ethereumish.getContract(address, ethereumish.provider);
         const balance = await ethereumish.getERC20Balance(
+          contract,
           wallet,
-          address,
           decimals
         );
         balances[symbol] = tokenValueToString(balance);
@@ -195,16 +202,20 @@ export async function approve(
   if (maxPriorityFeePerGas) {
     maxPriorityFeePerGasBigNumber = BigNumber.from(maxPriorityFeePerGas);
   }
+  // instantiate a contract and pass in wallet, which act on behalf of that signer
+  const contract = ethereumish.getContract(fullToken.address, wallet);
+
   // convert strings to BigNumber
   // call approve function
   const approval = await ethereumish.approveERC20(
+    contract,
     wallet,
     spender,
-    fullToken.address,
     amountBigNumber,
     nonce,
     maxFeePerGasBigNumber,
-    maxPriorityFeePerGasBigNumber
+    maxPriorityFeePerGasBigNumber,
+    ethereumish.gasPrice
   );
 
   return {

--- a/gateway/src/chains/ethereum/ethereum.ts
+++ b/gateway/src/chains/ethereum/ethereum.ts
@@ -1,11 +1,10 @@
 import abi from '../../services/ethereum.abi.json';
 import axios from 'axios';
 import { logger } from '../../services/logger';
-import { BigNumber, Contract, Transaction, Wallet } from 'ethers';
+import { Contract, Transaction, Wallet } from 'ethers';
 import { EthereumBase } from '../../services/ethereum-base';
 import { ConfigManager } from '../../services/config-manager';
 import { EthereumConfig } from './ethereum.config';
-import { TokenValue } from '../../services/base';
 import { Provider } from '@ethersproject/abstract-provider';
 import { UniswapConfig } from './uniswap/uniswap.config';
 
@@ -15,6 +14,11 @@ const MKR_ADDRESS = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2';
 export interface Ethereumish extends EthereumBase {
   cancelTx(wallet: Wallet, nonce: number): Promise<Transaction>;
   getSpender(reqSpender: string): string;
+  getContract(
+    tokenAddress: string,
+    signerOrProvider?: Wallet | Provider
+  ): Contract;
+  gasPrice: number;
   nativeTokenSymbol: string;
   chain: string;
 }
@@ -137,52 +141,10 @@ export class Ethereum extends EthereumBase implements Ethereumish {
     }
   }
 
-  // override getERC20Balance definition to handle MKR edge case
-  async getERC20Balance(
-    wallet: Wallet,
+  getContract(
     tokenAddress: string,
-    decimals: number
-  ): Promise<TokenValue> {
-    // instantiate a contract and pass in provider for read-only access
-    const contract = this.getContract(tokenAddress, this.provider);
-
-    logger.info(
-      'Requesting balance for owner ' +
-        wallet.address +
-        ' for token ' +
-        tokenAddress +
-        '.'
-    );
-    const balance = await contract.balanceOf(wallet.address);
-    logger.info(balance);
-    return { value: balance, decimals: decimals };
-  }
-
-  // override getERC20Allowance
-  async getERC20Allowance(
-    wallet: Wallet,
-    spender: string,
-    tokenAddress: string,
-    decimals: number
-  ): Promise<TokenValue> {
-    // instantiate a contract and pass in provider for read-only access
-    const contract = this.getContract(tokenAddress, this.provider);
-
-    logger.info(
-      'Requesting spender ' +
-        spender +
-        ' allowance for owner ' +
-        wallet.address +
-        ' for token ' +
-        tokenAddress +
-        '.'
-    );
-    const allowance = await contract.allowance(wallet.address, spender);
-    logger.info(allowance);
-    return { value: allowance, decimals: decimals };
-  }
-
-  getContract(tokenAddress: string, signerOrProvider?: Wallet | Provider) {
+    signerOrProvider?: Wallet | Provider
+  ): Contract {
     return tokenAddress === MKR_ADDRESS
       ? new Contract(tokenAddress, abi.MKRAbi, signerOrProvider)
       : new Contract(tokenAddress, abi.ERC20Abi, signerOrProvider);
@@ -200,55 +162,6 @@ export class Ethereum extends EthereumBase implements Ethereumish {
       spender = reqSpender;
     }
     return spender;
-  }
-
-  // override approveERC20
-  async approveERC20(
-    wallet: Wallet,
-    spender: string,
-    tokenAddress: string,
-    amount: BigNumber,
-    nonce?: number,
-    maxFeePerGas?: BigNumber,
-    maxPriorityFeePerGas?: BigNumber
-  ): Promise<Transaction> {
-    // instantiate a contract and pass in wallet, which act on behalf of that signer
-    const contract = this.getContract(tokenAddress, wallet);
-
-    logger.info(
-      'Calling approve method called for spender ' +
-        spender +
-        ' requesting allowance ' +
-        amount.toString() +
-        ' from owner ' +
-        wallet.address +
-        ' on token ' +
-        tokenAddress +
-        '.'
-    );
-    if (!nonce) {
-      nonce = await this.nonceManager.getNonce(wallet.address);
-    }
-    let response;
-    if (maxFeePerGas || maxPriorityFeePerGas) {
-      response = await contract.approve(spender, amount, {
-        gasLimit: 100000,
-        nonce: nonce,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-      });
-    } else {
-      response = await contract.approve(spender, amount, {
-        gasPrice: this._gasPrice * 1e9,
-        gasLimit: 100000,
-        nonce: nonce,
-      });
-    }
-
-    logger.info(response);
-
-    await this.nonceManager.commitNonce(wallet.address, nonce);
-    return response;
   }
 
   // cancel transaction

--- a/gateway/test/chains/avalanche/avalanche.routes.test.ts
+++ b/gateway/test/chains/avalanche/avalanche.routes.test.ts
@@ -108,6 +108,9 @@ describe('POST /avalanche/nonce', () => {
 describe('POST /avalanche/approve', () => {
   it('should return 200', async () => {
     patchGetWallet();
+    avalanche.getContract = jest.fn().mockReturnValue({
+      address: '0xFaA12FD102FE8623C9299c72B03E45107F2772B5',
+    });
     patch(avalanche.nonceManager, 'getNonce', () => 115);
     patchGetTokenBySymbol();
     patchApproveERC20();

--- a/gateway/test/chains/avalanche/pangolin/pangolin.routes.test.ts
+++ b/gateway/test/chains/avalanche/pangolin/pangolin.routes.test.ts
@@ -111,6 +111,16 @@ const patchExecuteTrade = () => {
   });
 };
 
+describe('GET /avalanche/pangolin/', () => {
+  it('should get 200 OK', async () => {
+    await request(app)
+      .get(`/avalanche/pangolin`)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+});
+
 describe('POST /avalanche/pangolin/price', () => {
   it('should return 200 for BUY', async () => {
     patchGetWallet();

--- a/gateway/test/chains/ethereum/ethereum.controllers.test.ts
+++ b/gateway/test/chains/ethereum/ethereum.controllers.test.ts
@@ -92,6 +92,9 @@ describe('approve', () => {
     patch(eth, 'getSpender', () => {
       return uniswap;
     });
+    eth.getContract = jest.fn().mockReturnValue({
+      address: '0xFaA12FD102FE8623C9299c72B03E45107F2772B5',
+    });
 
     patch(eth, 'ready', () => true);
 

--- a/gateway/test/chains/ethereum/ethereum.routes.test.ts
+++ b/gateway/test/chains/ethereum/ethereum.routes.test.ts
@@ -116,8 +116,11 @@ describe('POST /eth/nonce', () => {
 });
 
 describe('POST /eth/approve', () => {
-  it('approve without nonce parmeter should return 200', async () => {
+  it('approve without nonce parameter should return 200', async () => {
     patchGetWallet();
+    eth.getContract = jest.fn().mockReturnValue({
+      address: '0xFaA12FD102FE8623C9299c72B03E45107F2772B5',
+    });
     patch(eth.nonceManager, 'getNonce', () => 115);
     patchGetTokenBySymbol();
     patchApproveERC20();

--- a/gateway/test/chains/ethereum/ethereum.routes.test.ts
+++ b/gateway/test/chains/ethereum/ethereum.routes.test.ts
@@ -25,16 +25,6 @@ beforeAll(async () => {
 
 afterEach(() => unpatch());
 
-describe('GET /eth', () => {
-  it('should return 200', async () => {
-    request(app)
-      .get(`/eth`)
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .expect((res) => expect(res.body.connection).toBe(true));
-  });
-});
-
 const patchGetWallet = () => {
   patch(eth, 'getWallet', () => {
     return {
@@ -47,15 +37,38 @@ const patchGetNonce = () => {
   patch(eth.nonceManager, 'getNonce', () => 2);
 };
 
+const patchGetERC20Balance = () => {
+  patch(eth, 'getERC20Balance', () => ({ value: 1, decimals: 3 }));
+};
+
+const patchGetEthBalance = () => {
+  patch(eth, 'getEthBalance', () => ({ value: 1, decimals: 3 }));
+};
+
 const patchGetTokenBySymbol = () => {
-  patch(eth, 'getTokenBySymbol', () => {
-    return {
-      chainId: 42,
-      name: 'WETH',
-      symbol: 'WETH',
-      address: '0xd0A1E359811322d97991E03f863a0C30C2cF029C',
-      decimals: 18,
-    };
+  patch(eth, 'getTokenBySymbol', (symbol: string) => {
+    let result;
+    switch (symbol) {
+      case 'WETH':
+        result = {
+          chainId: 42,
+          name: 'WETH',
+          symbol: 'WETH',
+          address: '0xd0A1E359811322d97991E03f863a0C30C2cF029C',
+          decimals: 18,
+        };
+        break;
+      case 'DAI':
+        result = {
+          chainId: 42,
+          name: 'DAI',
+          symbol: 'DAI',
+          address: '0xd0A1E359811322d97991E03f863a0C30C2cFFFFF',
+          decimals: 18,
+        };
+        break;
+    }
+    return result;
   });
 };
 
@@ -87,6 +100,50 @@ const patchApproveERC20 = (tx_type?: string) => {
     return default_tx;
   });
 };
+
+describe('GET /eth', () => {
+  it('should return 200', async () => {
+    request(app)
+      .get(`/eth`)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect((res) => expect(res.body.connection).toBe(true));
+  });
+});
+
+describe('POST /eth/balances', () => {
+  it('should return 200', async () => {
+    patchGetWallet();
+    patchGetTokenBySymbol();
+    patchGetEthBalance();
+    patchGetERC20Balance();
+    eth.getContract = jest.fn().mockReturnValue({
+      address: '0xFaA12FD102FE8623C9299c72B03E45107F2772B5',
+    });
+
+    await request(app)
+      .post(`/eth/balances`)
+      .send({
+        privateKey:
+          'da857cbda0ba96757fed842617a40693d06d00001e55aa972955039ae747bac4',
+        tokenSymbols: ['ETH', 'WETH', 'DAI'],
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect((res) => expect(res.body.balances.ETH).toBeDefined())
+      .expect((res) => expect(res.body.balances.WETH).toBeDefined())
+      .expect((res) => expect(res.body.balances.DAI).toBeDefined());
+  });
+  it('should return 404 when parameters are invalid', async () => {
+    await request(app)
+      .post(`/eth/balances`)
+      .send({
+        privateKey: 'da857cbda0ba96757fed842617a4',
+      })
+      .expect(404);
+  });
+});
 
 describe('POST /eth/nonce', () => {
   it('should return 200', async () => {


### PR DESCRIPTION
`getERC20Balance` and `getERC20Allowance` In eth-base now receive contract as parameter this way we don't have to override the entire function in ethereum class.
`approveERC20`  receives contract and gasprice.


