### PR TITLE
fix/memory leaks and order book desynchronization

### DIFF
--- a/hummingbot/client/ui/interface_utils.py
+++ b/hummingbot/client/ui/interface_utils.py
@@ -17,7 +17,7 @@ s_decimal_0 = Decimal("0")
 def format_bytes(size):
     for unit in ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"]:
         if abs(size) < 1024.0:
-            return f"{size:3.2f} {unit}"
+            return f"{size:.2f} {unit}"
         size /= 1024.0
     return f"{size:.2f} YB"
 
@@ -43,7 +43,9 @@ async def start_process_monitor(process_monitor):
         with hb_process.oneshot():
             threads = hb_process.num_threads()
             process_monitor.log("CPU: {:>5}%, ".format(hb_process.cpu_percent()) +
-                                "Mem: {:>10}, ".format(format_bytes(hb_process.memory_info()[1] / threads)) +
+                                "Mem: {:>10} ({}), ".format(
+                                    format_bytes(hb_process.memory_info().vms / threads),
+                                    format_bytes(hb_process.memory_info().rss)) +
                                 "Threads: {:>3}, ".format(threads)
                                 )
         await _sleep(1)

--- a/hummingbot/connector/exchange/gate_io/gate_io_active_order_tracker.pyx
+++ b/hummingbot/connector/exchange/gate_io/gate_io_active_order_tracker.pyx
@@ -99,8 +99,8 @@ cdef class GateIoActiveOrderTracker:
 
     cdef tuple c_convert_snapshot_message_to_np_arrays(self, object message):
         cdef:
-            float price
-            float amount
+            object price
+            double amount
             str order_id
             dict order_dict
 

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import time
 from collections import defaultdict
@@ -123,7 +124,7 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
         logger = logger or logging.getLogger()
         try:
             ex_pair = convert_to_exchange_trading_pair(trading_pair)
-            params = {"currency_pair": ex_pair, "with_id": 1}
+            params = {"currency_pair": ex_pair, "with_id": json.dumps(True)}
             endpoint = CONSTANTS.ORDER_BOOK_PATH_URL
             request = GateIORESTRequest(
                 method=RESTMethod.GET,

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import asyncio
 import logging
 import time
@@ -7,6 +6,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
+
 from hummingbot.connector.exchange.gate_io import gate_io_constants as CONSTANTS
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
@@ -32,8 +32,6 @@ from .gate_io_websocket import GateIoWebsocket
 
 class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
     _logger: Optional[HummingbotLogger] = None
-    _trades_queue_name = "trades"
-    _ob_queue_name = "ob"
 
     @classmethod
     def logger(cls) -> HummingbotLogger:
@@ -160,12 +158,6 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def listen_for_subscriptions(self):
         ws = None
-        ob_channels = [
-            CONSTANTS.ORDER_SNAPSHOT_ENDPOINT_NAME,
-            CONSTANTS.ORDERS_UPDATE_ENDPOINT_NAME,
-        ]
-        target_channels = [CONSTANTS.TRADES_ENDPOINT_NAME]
-        target_channels.extend(ob_channels)
 
         while True:
             try:
@@ -175,11 +167,6 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
                     if response.get("event") in ["subscribe", "unsubscribe"]:
                         continue
-                    elif channel == CONSTANTS.TRADES_ENDPOINT_NAME:
-                        self._message_queue[self._trades_queue_name].put_nowait(response)
-                    elif channel in ob_channels:
-                        self._message_queue[self._ob_queue_name].put_nowait(response)
-
                     self._message_queue[channel].put_nowait(response)
             except asyncio.CancelledError:
                 raise
@@ -200,8 +187,6 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 [convert_to_exchange_trading_pair(pair) for pair in self._trading_pairs],
             )
             for pair in self._trading_pairs:
-                await ws.subscribe(CONSTANTS.ORDER_SNAPSHOT_ENDPOINT_NAME,
-                                   [convert_to_exchange_trading_pair(pair), '5', '1000ms'])
                 await ws.subscribe(CONSTANTS.ORDERS_UPDATE_ENDPOINT_NAME,
                                    [convert_to_exchange_trading_pair(pair), '100ms'])
                 self.logger().info(f"Subscribed to {self._trading_pairs} orderbook data streams...")
@@ -216,7 +201,7 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
         """
         Listen for trades using websocket trade channel
         """
-        msg_queue = self._message_queue[self._trades_queue_name]
+        msg_queue = self._message_queue[CONSTANTS.TRADES_ENDPOINT_NAME]
         msg = None
         while True:
             try:
@@ -241,28 +226,23 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 self.logger().error(
                     f"Unexpected error while parsing ws trades message {msg}.", exc_info=True
                 )
-                await asyncio.sleep(5.0)
+                await self._sleep(5.0)
 
     async def listen_for_order_book_diffs(self, ev_loop: asyncio.AbstractEventLoop, output: asyncio.Queue):
         """
         Listen for orderbook diffs using websocket book channel
         """
-        msg_queue = self._message_queue[self._ob_queue_name]
+        msg_queue = self._message_queue[CONSTANTS.ORDERS_UPDATE_ENDPOINT_NAME]
         msg = None
         while True:
             try:
                 msg = await msg_queue.get()
-                channel: str = msg.get("channel", None)
                 order_book_data: str = msg.get("result", None)
 
                 timestamp: int = order_book_data["t"]
                 pair: str = convert_from_exchange_trading_pair(order_book_data["s"])
 
-                order_book_msg_cls = (GateIoOrderBook.diff_message_from_exchange
-                                      if channel == CONSTANTS.ORDERS_UPDATE_ENDPOINT_NAME else
-                                      GateIoOrderBook.snapshot_message_from_exchange)
-
-                orderbook_msg: OrderBookMessage = order_book_msg_cls(
+                orderbook_msg: OrderBookMessage = GateIoOrderBook.diff_message_from_exchange(
                     order_book_data,
                     timestamp,
                     metadata={"trading_pair": pair}
@@ -275,7 +255,7 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 self.logger().error(
                     f"Unexpected error while parsing ws order book message {msg}.", exc_info=True
                 )
-                await asyncio.sleep(30.0)
+                await self._sleep(5.0)
 
     async def listen_for_order_book_snapshots(self, ev_loop: asyncio.AbstractEventLoop, output: asyncio.Queue):
         """
@@ -295,7 +275,7 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         output.put_nowait(snapshot_msg)
                         self.logger().debug(f"Saved order book snapshot for {trading_pair}")
                         # Be careful not to go above API rate limits.
-                        await asyncio.sleep(5.0)
+                        await self._sleep(5.0)
                     except asyncio.CancelledError:
                         raise
                     except Exception:
@@ -303,16 +283,16 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                             "Unexpected error with WebSocket connection.", exc_info=True,
                             app_warning_msg="Unexpected error with WebSocket connection. Retrying in 5 seconds. "
                                             "Check network connection.")
-                        await asyncio.sleep(5.0)
+                        await self._sleep(5.0)
                 this_hour: pd.Timestamp = pd.Timestamp.utcnow().replace(minute=0, second=0, microsecond=0)
                 next_hour: pd.Timestamp = this_hour + pd.Timedelta(hours=1)
                 delta: float = next_hour.timestamp() - time.time()
-                await asyncio.sleep(delta)
+                await self._sleep(delta)
             except asyncio.CancelledError:
                 raise
             except Exception:
                 self.logger().error("Unexpected error.", exc_info=True)
-                await asyncio.sleep(5.0)
+                await self._sleep(5.0)
 
     async def _get_rest_assistant(self) -> RESTAssistant:
         if self._rest_assistant is None:

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
@@ -274,8 +274,7 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         )
                         output.put_nowait(snapshot_msg)
                         self.logger().debug(f"Saved order book snapshot for {trading_pair}")
-                        # Be careful not to go above API rate limits.
-                        await self._sleep(5.0)
+
                     except asyncio.CancelledError:
                         raise
                     except Exception:

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
@@ -239,7 +239,7 @@ class GateIoAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 msg = await msg_queue.get()
                 order_book_data: str = msg.get("result", None)
 
-                timestamp: int = order_book_data["t"]
+                timestamp: float = (order_book_data["t"]) * 1e-3
                 pair: str = convert_from_exchange_trading_pair(order_book_data["s"])
 
                 orderbook_msg: OrderBookMessage = GateIoOrderBook.diff_message_from_exchange(

--- a/hummingbot/connector/exchange/gate_io/gate_io_order_book.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_order_book.py
@@ -32,9 +32,9 @@ class GateIoOrderBook(OrderBook):
         :param timestamp: timestamp attached to incoming data
         :return: GateIoOrderBookMessage
         """
-
-        if metadata:
-            msg.update(metadata)
+        extra_data = metadata or {}
+        extra_data["update_id"] = msg["id"]
+        msg.update(extra_data)
 
         return GateIoOrderBookMessage(
             message_type=OrderBookMessageType.SNAPSHOT,
@@ -68,8 +68,9 @@ class GateIoOrderBook(OrderBook):
         :return: GateIoOrderBookMessage
         """
 
-        if metadata:
-            msg.update(metadata)
+        extra_data = metadata or {}
+        extra_data["update_id"] = msg["u"]
+        msg.update(extra_data)
 
         return GateIoOrderBookMessage(
             message_type=OrderBookMessageType.DIFF,

--- a/hummingbot/connector/exchange/gate_io/gate_io_order_book_message.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_order_book_message.py
@@ -28,13 +28,6 @@ class GateIoOrderBookMessage(OrderBookMessage):
         )
 
     @property
-    def update_id(self) -> int:
-        if self.type in [OrderBookMessageType.DIFF, OrderBookMessageType.SNAPSHOT]:
-            return int(self.timestamp * 1e3)
-        else:
-            return -1
-
-    @property
     def trade_id(self) -> int:
         if self.type is OrderBookMessageType.TRADE:
             return int(self.timestamp * 1e3)

--- a/hummingbot/connector/exchange/gate_io/gate_io_order_book_message.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_order_book_message.py
@@ -54,13 +54,17 @@ class GateIoOrderBookMessage(OrderBookMessage):
         raise NotImplementedError(CONSTANTS.EXCHANGE_NAME + " order book uses active_order_tracker.")
 
     def __eq__(self, other) -> bool:
-        return self.type == other.type and self.timestamp == other.timestamp
+        return (type(self) == type(other)
+                and self.type == other.type
+                and self.update_id == other.update_id
+                and self.timestamp == other.timestamp)
+
+    def __hash__(self):
+        return hash((self.type, self.update_id, self.timestamp))
 
     def __lt__(self, other) -> bool:
-        if self.timestamp != other.timestamp:
-            return self.timestamp < other.timestamp
-        else:
-            """
-            If timestamp is the same, the ordering is snapshot < diff < trade
-            """
-            return self.type.value < other.type.value
+        return (self.update_id < other.update_id or
+                (self.update_id == other.update_id and self.timestamp < other.timestamp) or
+                (self.update_id == other.update_id and
+                 self.timestamp == other.timestamp
+                 and self.type.value < other.type.value))

--- a/hummingbot/connector/exchange/gate_io/gate_io_order_book_tracker.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_order_book_tracker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import asyncio
 import bisect
 import logging
@@ -11,15 +10,16 @@ from hummingbot.connector.exchange.gate_io.gate_io_active_order_tracker import G
 from hummingbot.connector.exchange.gate_io.gate_io_api_order_book_data_source import GateIoAPIOrderBookDataSource
 from hummingbot.connector.exchange.gate_io.gate_io_order_book import GateIoOrderBook
 from hummingbot.connector.exchange.gate_io.gate_io_order_book_message import GateIoOrderBookMessage
-from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book_message import OrderBookMessageType
 from hummingbot.core.data_type.order_book_tracker import OrderBookTracker
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 from hummingbot.logger import HummingbotLogger
 
 
 class GateIoOrderBookTracker(OrderBookTracker):
+    PAST_DIFF_WINDOW_SIZE: int = 100
     _logger: Optional[HummingbotLogger] = None
 
     @classmethod
@@ -71,7 +71,7 @@ class GateIoOrderBookTracker(OrderBookTracker):
         """
         Update an order book with changes from the latest batch of received messages
         """
-        past_diffs_window: Deque[GateIoOrderBookMessage] = deque()
+        past_diffs_window: Deque[GateIoOrderBookMessage] = deque(maxlen=self.PAST_DIFF_WINDOW_SIZE)
         self._past_diffs_windows[trading_pair] = past_diffs_window
 
         message_queue: asyncio.Queue = self._tracking_message_queues[trading_pair]
@@ -83,20 +83,11 @@ class GateIoOrderBookTracker(OrderBookTracker):
 
         while True:
             try:
-                message: GateIoOrderBookMessage = None
-                saved_messages: Deque[GateIoOrderBookMessage] = self._saved_message_queues[trading_pair]
-                # Process saved messages first if there are any
-                if len(saved_messages) > 0:
-                    message = saved_messages.popleft()
-                else:
-                    message = await message_queue.get()
-
+                message: GateIoOrderBookMessage = await message_queue.get()
                 if message.type is OrderBookMessageType.DIFF:
                     bids, asks = active_order_tracker.convert_diff_message_to_order_book_row(message)
                     order_book.apply_diffs(bids, asks, message.update_id)
                     past_diffs_window.append(message)
-                    while len(past_diffs_window) > self.PAST_DIFF_WINDOW_SIZE:
-                        past_diffs_window.popleft()
                     diff_messages_accepted += 1
 
                     # Output some statistics periodically.

--- a/hummingbot/connector/exchange/gate_io/gate_io_utils.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_utils.py
@@ -143,6 +143,13 @@ async def rest_response_with_errors(request_coroutine):
     return http_status, parsed_response, request_errors
 
 
+async def _sleep(delay):
+    """
+    Function added only to facilitate patching the sleep in unit tests without affecting the asyncio module
+    """
+    await asyncio.sleep(delay)
+
+
 async def api_call_with_retries(request: GateIORESTRequest,
                                 rest_assistant: RESTAssistant,
                                 throttler: AsyncThrottler,
@@ -173,7 +180,7 @@ async def api_call_with_retries(request: GateIORESTRequest,
                 f"Error fetching data from {request.url}. HTTP status is {http_status}."
                 f" Retrying in {time_sleep:.0f}s."
             )
-            await asyncio.sleep(time_sleep)
+            await _sleep(time_sleep)
             return await api_call_with_retries(
                 request, rest_assistant, throttler, logger, gate_io_auth, try_count
             )

--- a/hummingbot/core/data_type/order_book_tracker.py
+++ b/hummingbot/core/data_type/order_book_tracker.py
@@ -246,7 +246,7 @@ class OrderBookTracker(ABC):
                 await asyncio.sleep(5.0)
 
     async def _track_single_book(self, trading_pair: str):
-        past_diffs_window: Deque[OrderBookMessage] = deque()
+        past_diffs_window: Deque[OrderBookMessage] = deque(maxlen=self.PAST_DIFF_WINDOW_SIZE)
         self._past_diffs_windows[trading_pair] = past_diffs_window
 
         message_queue: asyncio.Queue = self._tracking_message_queues[trading_pair]

--- a/hummingbot/core/data_type/order_book_tracker.py
+++ b/hummingbot/core/data_type/order_book_tracker.py
@@ -260,8 +260,6 @@ class OrderBookTracker(ABC):
                 if message.type is OrderBookMessageType.DIFF:
                     order_book.apply_diffs(message.bids, message.asks, message.update_id)
                     past_diffs_window.append(message)
-                    while len(past_diffs_window) > self.PAST_DIFF_WINDOW_SIZE:
-                        past_diffs_window.popleft()
                     diff_messages_accepted += 1
 
                     # Output some statistics periodically.

--- a/hummingbot/core/event/event_logger.pxd
+++ b/hummingbot/core/event/event_logger.pxd
@@ -5,6 +5,8 @@ cdef class EventLogger(EventListener):
     cdef:
         str _event_source
         object _logged_events
+        object _generic_logged_events
+        object _order_filled_logged_events
         dict _waiting
         dict _wait_returns
     cdef c_call(self, object event_object)

--- a/hummingbot/core/event/event_logger.pyx
+++ b/hummingbot/core/event/event_logger.pyx
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
-
 import asyncio
+from collections import deque
+
 from async_timeout import timeout
 from typing import (
     List,
@@ -8,26 +8,31 @@ from typing import (
 )
 
 from hummingbot.core.event.event_listener cimport EventListener
-
+from hummingbot.core.event.events import OrderFilledEvent
 
 cdef class EventLogger(EventListener):
     def __init__(self, event_source: Optional[str] = None):
         super().__init__()
         self._event_source = event_source
-        self._logged_events = []
+        # We limit the amount of events we keep reference to the most recent ones
+        # But we keep all references to order fill events, because they are required for PnL calculation
+        self._generic_logged_events = deque(maxlen=50)
+        self._order_filled_logged_events = deque()
+        self._logged_events = {OrderFilledEvent: self._order_filled_logged_events}
         self._waiting = {}
         self._wait_returns = {}
 
     @property
     def event_log(self) -> List[any]:
-        return self._logged_events.copy()
+        return list(self._generic_logged_events) + list(self._order_filled_logged_events)
 
     @property
     def event_source(self) -> str:
         return self._event_source
 
     def clear(self):
-        self._logged_events.clear()
+        self._generic_logged_events.clear()
+        self._order_filled_logged_events.clear()
 
     async def wait_for(self, event_type, timeout_seconds: float = 180):
         notifier = asyncio.Event()
@@ -45,7 +50,7 @@ cdef class EventLogger(EventListener):
         self.c_call(event_object)
 
     cdef c_call(self, object event_object):
-        self._logged_events.append(event_object)
+        self._logged_events.get(type(event_object), default=self._generic_logged_events).append(event_object)
         event_object_type = type(event_object)
 
         should_notify = []

--- a/hummingbot/core/event/event_logger.pyx
+++ b/hummingbot/core/event/event_logger.pyx
@@ -50,7 +50,7 @@ cdef class EventLogger(EventListener):
         self.c_call(event_object)
 
     cdef c_call(self, object event_object):
-        self._logged_events.get(type(event_object), default=self._generic_logged_events).append(event_object)
+        self._logged_events.get(type(event_object), self._generic_logged_events).append(event_object)
         event_object_type = type(event_object)
 
         should_notify = []

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_order_book_data_source.py
@@ -17,6 +17,9 @@ from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAs
 
 
 class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
+    # logging.Level required to receive logs from the data source logger
+    level = 0
+
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -33,12 +36,23 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
         self.data_source = GateIoAPIOrderBookDataSource(
             self.throttler, trading_pairs=[self.trading_pair], api_factory=api_factory
         )
+        self.data_source.logger().setLevel(1)
+        self.data_source.logger().addHandler(self)
+
+        self.log_records = []
         self.async_tasks: List[asyncio.Task] = []
 
     def tearDown(self) -> None:
         for task in self.async_tasks:
             task.cancel()
         super().tearDown()
+
+    def handle(self, record):
+        self.log_records.append(record)
+
+    def _is_logged(self, log_level: str, message: str) -> bool:
+        return any(record.levelname == log_level and record.getMessage() == message
+                   for record in self.log_records)
 
     def async_run_with_timeout(self, coroutine: Awaitable, timeout: int = 1):
         ret = self.ev_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
@@ -250,6 +264,37 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
         self.assertTrue(output_queue.empty())
 
     @patch("aiohttp.client.ClientSession.ws_connect", new_callable=AsyncMock)
+    @patch("hummingbot.connector.exchange.gate_io.gate_io_api_order_book_data_source.GateIoAPIOrderBookDataSource._sleep")
+    def test_listen_for_trades_logs_error_when_exception_happens(self, _, ws_connect_mock):
+        ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
+        incomplete_response = {
+            "time": 1606292218,
+            "channel": "spot.trades",
+            "event": "update",
+            "result": {
+                "id": 309143071,
+                "currency_pair": f"{self.base_asset}_{self.quote_asset}",
+            }
+        }
+
+        self.mocking_assistant.add_websocket_aiohttp_message(
+            ws_connect_mock.return_value, json.dumps(incomplete_response)
+        )
+        output_queue = asyncio.Queue()
+
+        t = self.ev_loop.create_task(self.data_source.listen_for_subscriptions())
+        self.async_tasks.append(t)
+        t = self.ev_loop.create_task(self.data_source.listen_for_trades(self.ev_loop, output_queue))
+        self.async_tasks.append(t)
+        self.mocking_assistant.run_until_all_aiohttp_messages_delivered(websocket_mock=ws_connect_mock.return_value)
+
+        self.assertTrue(
+            self._is_logged(
+                "ERROR",
+                f"Unexpected error while parsing ws trades message {incomplete_response}."
+            ))
+
+    @patch("aiohttp.client.ClientSession.ws_connect", new_callable=AsyncMock)
     def test_listen_for_order_book_diffs_update(self, ws_connect_mock):
         ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
         resp = self.get_order_book_update_mock()
@@ -266,6 +311,35 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
 
         self.assertTrue(not output_queue.empty())
         self.assertTrue(isinstance(output_queue.get_nowait(), OrderBookMessage))
+
+    @patch("aiohttp.client.ClientSession.ws_connect", new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.gate_io.gate_io_api_order_book_data_source.GateIoAPIOrderBookDataSource._sleep",
+        new_callable=AsyncMock)
+    def test_listen_for_order_book_diffs_update_logs_error_when_exception_happens(self, _, ws_connect_mock):
+        ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
+        incomplete_response = {
+            "time": 1606294781,
+            "channel": "spot.order_book_update",
+            "event": "update",
+            "result": {}
+        }
+        self.mocking_assistant.add_websocket_aiohttp_message(
+            ws_connect_mock.return_value, json.dumps(incomplete_response)
+        )
+        output_queue = asyncio.Queue()
+
+        t = self.ev_loop.create_task(self.data_source.listen_for_subscriptions())
+        self.async_tasks.append(t)
+        t = self.ev_loop.create_task(self.data_source.listen_for_order_book_diffs(self.ev_loop, output_queue))
+        self.async_tasks.append(t)
+        self.mocking_assistant.run_until_all_aiohttp_messages_delivered(websocket_mock=ws_connect_mock.return_value)
+
+        self.assertTrue(
+            self._is_logged(
+                "ERROR",
+                f"Unexpected error while parsing ws order book message {incomplete_response}."
+            ))
 
     @patch("aiohttp.client.ClientSession.ws_connect", new_callable=AsyncMock)
     def test_listen_for_order_book_diffs_snapshot(self, ws_connect_mock):
@@ -321,10 +395,66 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
         mock_api.get(regex_url, body=json.dumps(resp))
         output_queue = asyncio.Queue()
 
-        t = self.ev_loop.create_task(self.data_source.listen_for_subscriptions())
-        self.async_tasks.append(t)
         t = self.ev_loop.create_task(self.data_source.listen_for_order_book_snapshots(self.ev_loop, output_queue))
         self.async_tasks.append(t)
         ret = self.async_run_with_timeout(coroutine=output_queue.get())
 
         self.assertTrue(isinstance(ret, OrderBookMessage))
+
+    @aioresponses()
+    @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
+    @patch(
+        "hummingbot.connector.exchange.gate_io.gate_io_api_order_book_data_source.GateIoAPIOrderBookDataSource._sleep",
+        new_callable=AsyncMock)
+    @patch("hummingbot.connector.exchange.gate_io.gate_io_utils._sleep", new_callable=AsyncMock)
+    def test_listen_for_order_book_snapshots_logs_error_when_exception_happens(
+            self,
+            mock_api,
+            utils_sleep,
+            sleep_mock,
+            _):
+        url = f"{CONSTANTS.REST_URL}/{CONSTANTS.ORDER_BOOK_PATH_URL}"
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(regex_url, exception=Exception("Test Error"))
+        output_queue = asyncio.Queue()
+        sleep_mock.side_effect = asyncio.CancelledError
+
+        t = self.ev_loop.create_task(self.data_source.listen_for_order_book_snapshots(self.ev_loop, output_queue))
+        self.async_tasks.append(t)
+
+        try:
+            self.async_run_with_timeout(t)
+        except asyncio.CancelledError:
+            # Ignore the CancelledError raised by the mocked _sleep
+            pass
+
+        self.assertTrue(
+            self._is_logged(
+                "NETWORK",
+                "Unexpected error with WebSocket connection."
+            )
+        )
+
+    @patch("aiohttp.client.ClientSession.ws_connect", new_callable=AsyncMock)
+    @patch(
+        "hummingbot.connector.exchange.gate_io.gate_io_api_order_book_data_source.GateIoAPIOrderBookDataSource._sleep",
+        new_callable=AsyncMock)
+    def test_listen_for_subscriptions_logs_error_when_exception_happens(self, sleep_mock, ws_connect_mock):
+        # ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
+        ws_connect_mock.side_effect = Exception("Test Error")
+        sleep_mock.side_effect = asyncio.CancelledError
+
+        t = self.ev_loop.create_task(self.data_source.listen_for_subscriptions())
+        self.async_tasks.append(t)
+
+        try:
+            self.async_run_with_timeout(t)
+        except asyncio.CancelledError:
+            # Ignore the CancelledError raised by the mocked _sleep
+            pass
+
+        self.assertTrue(
+            self._is_logged(
+                "ERROR",
+                "Unexpected error occurred when listening to order book streams. Retrying in 5 seconds..."
+            ))

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_order_book.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_order_book.py
@@ -1,0 +1,75 @@
+from unittest import TestCase
+
+from hummingbot.connector.exchange.gate_io.gate_io_order_book import GateIoOrderBook
+
+
+class GateIoOrderBookTests(TestCase):
+
+    def test_snapshot_message_creation_from_exchange(self):
+        message_dict = {
+            "id": 123456,
+            "current": 1623898993123,
+            "update": 1623898993121,
+            "asks": [
+                [
+                    "1.52",
+                    "1.151"
+                ],
+                [
+                    "1.53",
+                    "1.218"
+                ]
+            ],
+            "bids": [
+                [
+                    "1.17",
+                    "201.863"
+                ],
+                [
+                    "1.16",
+                    "725.464"
+                ]
+            ]
+        }
+
+        message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        self.assertEqual(message_dict["id"], message.update_id)
+        self.assertEqual(message_dict["current"] * 1e-3, message.timestamp)
+
+    def test_diff_message_creation_from_exchange(self):
+        message_dict = {
+            "t": 1606294781123,
+            "e": "depthUpdate",
+            "E": 1606294781,
+            "s": "BTC_USDT",
+            "U": 48776301,
+            "u": 48776306,
+            "b": [
+                [
+                    "19137.74",
+                    "0.0001"
+                ],
+                [
+                    "19088.37",
+                    "0"
+                ]
+            ],
+            "a": [
+                [
+                    "19137.75",
+                    "0.6135"
+                ]
+            ]
+        }
+
+        message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        self.assertEqual(message_dict["u"], message.update_id)
+        self.assertEqual(message_dict["t"] * 1e-3, message.timestamp)

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_order_book_message.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_order_book_message.py
@@ -1,0 +1,313 @@
+from unittest import TestCase
+
+from hummingbot.connector.exchange.gate_io.gate_io_order_book import GateIoOrderBook
+
+
+class GateIoOrderBookTests(TestCase):
+
+    def test_snapshot_message_equality_with_snapshot_message(self):
+        id_a = 123456
+        id_b = 234567
+        timestamp_a = 1623898900000
+        timestamp_b = 1623899000000
+
+        message_dict = {
+            "id": id_a,
+            "current": timestamp_a,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        equal_message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        self.assertEqual(message, equal_message)
+        self.assertEqual(hash(message), hash(equal_message))
+
+        message_dict = {
+            "id": id_b,
+            "current": timestamp_a,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        different_id_message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        self.assertNotEqual(message, different_id_message)
+
+        message_dict = {
+            "id": id_a,
+            "current": timestamp_b,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        different_timestamp_message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        self.assertNotEqual(message, different_timestamp_message)
+
+    def test_diff_message_equality_with_diff_message(self):
+        id_a = 123456
+        id_b = 234567
+        timestamp_a = 1623898900000
+        timestamp_b = 1623899000000
+
+        message_dict = {
+            "t": timestamp_a,
+            "e": "depthUpdate",
+            "E": 1606294781,
+            "s": "BTC_USDT",
+            "U": 48776301,
+            "u": id_a,
+            "b": [],
+            "a": []
+        }
+
+        message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        equal_message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        self.assertEqual(message, equal_message)
+        self.assertEqual(hash(message), hash(equal_message))
+
+        message_dict = {
+            "t": timestamp_a,
+            "e": "depthUpdate",
+            "E": 1606294781,
+            "s": "BTC_USDT",
+            "U": 48776301,
+            "u": id_b,
+            "b": [],
+            "a": []
+        }
+
+        different_id_message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        self.assertNotEqual(message, different_id_message)
+
+        message_dict = {
+            "t": timestamp_b,
+            "e": "depthUpdate",
+            "E": 1606294781,
+            "s": "BTC_USDT",
+            "U": 48776301,
+            "u": id_a,
+            "b": [],
+            "a": []
+        }
+
+        different_timestamp_message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        self.assertNotEqual(message, different_timestamp_message)
+
+    def test_trade_message_equality_with_trade_message(self):
+        timestamp_a = 1623898900
+        timestamp_b = 1623899000
+
+        message_dict = {
+            "id": 5736713,
+            "user_id": 1000001,
+            "order_id": "30784428",
+            "currency_pair": "BTC_USDT",
+            "create_time": timestamp_a,
+            "create_time_ms": "1605176741123.456",
+            "side": "sell",
+            "amount": "1.00000000",
+            "role": "taker",
+            "price": "10000.00000000",
+            "fee": "0.00200000000000",
+            "point_fee": "0",
+            "gt_fee": "0",
+            "text": "apiv4"
+        }
+
+        message = GateIoOrderBook.trade_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["create_time"],
+        )
+
+        equal_message = GateIoOrderBook.trade_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["create_time"],
+        )
+
+        self.assertEqual(message, equal_message)
+        self.assertEqual(hash(message), hash(equal_message))
+
+        message_dict = {
+            "id": 5736713,
+            "user_id": 1000001,
+            "order_id": "30784428",
+            "currency_pair": "BTC_USDT",
+            "create_time": timestamp_b,
+            "create_time_ms": "1605176741123.456",
+            "side": "sell",
+            "amount": "1.00000000",
+            "role": "taker",
+            "price": "10000.00000000",
+            "fee": "0.00200000000000",
+            "point_fee": "0",
+            "gt_fee": "0",
+            "text": "apiv4"
+        }
+
+        different_timestamp_message = GateIoOrderBook.trade_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["create_time"],
+        )
+
+        self.assertNotEqual(message, different_timestamp_message)
+
+    def test_different_type_messages_are_not_equal(self):
+        id = 123456
+        timestamp = 1623898900000
+
+        message_dict = {
+            "id": id,
+            "current": timestamp,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        snapshot_message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        message_dict = {
+            "t": timestamp,
+            "e": "depthUpdate",
+            "E": 1606294781,
+            "s": "BTC_USDT",
+            "U": 48776301,
+            "u": id,
+            "b": [],
+            "a": []
+        }
+
+        diff_message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        message_dict = {
+            "id": 5736713,
+            "user_id": 1000001,
+            "order_id": "30784428",
+            "currency_pair": "BTC_USDT",
+            "create_time": timestamp,
+            "create_time_ms": "1605176741123.456",
+            "side": "sell",
+            "amount": "1.00000000",
+            "role": "taker",
+            "price": "10000.00000000",
+            "fee": "0.00200000000000",
+            "point_fee": "0",
+            "gt_fee": "0",
+            "text": "apiv4"
+        }
+
+        trade_message = GateIoOrderBook.trade_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["create_time"],
+        )
+
+        self.assertNotEqual(snapshot_message, diff_message)
+        self.assertNotEqual(diff_message, trade_message)
+        self.assertNotEqual(snapshot_message, trade_message)
+
+    def test_less_than_compares_update_id_and_timestamp_and_type(self):
+        id_a = 123456
+        id_b = 234567
+        timestamp_a = 1623898900000
+        timestamp_b = 1623899000000
+
+        message_dict = {
+            "id": id_a,
+            "current": timestamp_a,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        message_dict = {
+            "id": id_b,
+            "current": timestamp_a,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        greater_id_message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        self.assertLess(message, greater_id_message)
+
+        message_dict = {
+            "id": id_a,
+            "current": timestamp_b,
+            "update": 1623898993121,
+            "asks": [],
+            "bids": []
+        }
+
+        equal_id_greater_timestamp_message = GateIoOrderBook.snapshot_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["current"] * 1e-3,
+        )
+
+        self.assertLess(message, equal_id_greater_timestamp_message)
+
+        message_dict = {
+            "t": timestamp_a,
+            "e": "depthUpdate",
+            "E": 1606294781,
+            "s": "BTC_USDT",
+            "U": 48776301,
+            "u": id_a,
+            "b": [],
+            "a": []
+        }
+
+        same_id_and_timestamp_diff_message = GateIoOrderBook.diff_message_from_exchange(
+            msg=message_dict,
+            timestamp=message_dict["t"] * 1e-3,
+        )
+
+        self.assertLess(message, same_id_and_timestamp_diff_message)

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -19,11 +19,12 @@ from hummingbot.connector.exchange.ndax.ndax_order_book import NdaxOrderBook
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import (
+    MarketEvent,
     MarketOrderFailureEvent,
     OrderCancelledEvent,
     OrderFilledEvent,
     OrderType,
-    TradeType, MarketEvent,
+    TradeType,
 )
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -17,12 +17,13 @@ from hummingbot.connector.exchange.ndax.ndax_in_flight_order import (
 )
 from hummingbot.connector.exchange.ndax.ndax_order_book import NdaxOrderBook
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import (
     MarketOrderFailureEvent,
     OrderCancelledEvent,
     OrderFilledEvent,
     OrderType,
-    TradeType,
+    TradeType, MarketEvent,
 )
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
@@ -60,6 +61,18 @@ class NdaxExchangeTests(TestCase):
         self.exchange.logger().setLevel(1)
         self.exchange.logger().addHandler(self)
         self.exchange._account_id = 1
+
+        self.order_fill_logger: EventLogger = EventLogger()
+        self.cancel_order_logger: EventLogger = EventLogger()
+        self.buy_order_completed_logger: EventLogger = EventLogger()
+        self.sell_order_completed_logger: EventLogger = EventLogger()
+        self.order_failure_logger: EventLogger = EventLogger()
+
+        self.exchange.add_listener(MarketEvent.BuyOrderCompleted, self.buy_order_completed_logger)
+        self.exchange.add_listener(MarketEvent.SellOrderCompleted, self.sell_order_completed_logger)
+        self.exchange.add_listener(MarketEvent.OrderFilled, self.order_fill_logger)
+        self.exchange.add_listener(MarketEvent.OrderCancelled, self.cancel_order_logger)
+        self.exchange.add_listener(MarketEvent.OrderFailure, self.order_failure_logger)
 
         self.mocking_assistant = NetworkMockingAssistant()
         self.mock_done_event = asyncio.Event()
@@ -270,8 +283,8 @@ class NdaxExchangeTests(TestCase):
         self.assertTrue(inflight_order.is_cancelled)
         self.assertFalse(inflight_order.client_order_id in self.exchange.in_flight_orders)
         self.assertTrue(self._is_logged("INFO", f"Successfully cancelled order {inflight_order.client_order_id}"))
-        self.assertEqual(1, len(self.exchange.event_logs))
-        cancel_event = self.exchange.event_logs[0]
+        self.assertEqual(1, len(self.cancel_order_logger.event_log))
+        cancel_event = self.cancel_order_logger.event_log[0]
         self.assertEqual(OrderCancelledEvent, type(cancel_event))
         self.assertEqual(inflight_order.client_order_id, cancel_event.order_id)
 
@@ -321,8 +334,8 @@ class NdaxExchangeTests(TestCase):
                                         f"The market order {inflight_order.client_order_id} "
                                         f"has failed according to order status event. "
                                         f"Reason: {payload['ChangeReason']}"))
-        self.assertEqual(1, len(self.exchange.event_logs))
-        failure_event = self.exchange.event_logs[0]
+        self.assertEqual(1, len(self.order_failure_logger.event_log))
+        failure_event = self.order_failure_logger.event_log[0]
         self.assertEqual(MarketOrderFailureEvent, type(failure_event))
         self.assertEqual(inflight_order.client_order_id, failure_event.order_id)
 
@@ -375,8 +388,8 @@ class NdaxExchangeTests(TestCase):
         self.assertTrue(self._is_logged("INFO", f"The {inflight_order.trade_type.name} order "
                                                 f"{inflight_order.client_order_id} has completed "
                                                 f"according to order status API"))
-        self.assertEqual(2, len(self.exchange.event_logs))
-        fill_event = self.exchange.event_logs[0]
+        self.assertEqual(1, len(self.order_fill_logger.event_log))
+        fill_event = self.order_fill_logger.event_log[0]
         self.assertEqual(OrderFilledEvent, type(fill_event))
         self.assertEqual(inflight_order.client_order_id, fill_event.order_id)
         self.assertEqual(inflight_order.trading_pair, fill_event.trading_pair)
@@ -387,7 +400,8 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(Decimal("0.002"), fill_event.trade_fee.percent)
         self.assertEqual(0, len(fill_event.trade_fee.flat_fees))
         self.assertEqual("213", fill_event.exchange_trade_id)
-        buy_event = self.exchange.event_logs[1]
+        self.assertEqual(1, len(self.buy_order_completed_logger.event_log))
+        buy_event = self.buy_order_completed_logger.event_log[0]
         self.assertEqual(inflight_order.client_order_id, buy_event.order_id)
         self.assertEqual(inflight_order.base_asset, buy_event.base_asset)
         self.assertEqual(inflight_order.quote_asset, buy_event.quote_asset)
@@ -448,8 +462,8 @@ class NdaxExchangeTests(TestCase):
         self.assertTrue(self._is_logged("INFO", f"The {inflight_order.trade_type.name} order "
                                                 f"{inflight_order.client_order_id} has completed "
                                                 f"according to order status API"))
-        self.assertEqual(2, len(self.exchange.event_logs))
-        fill_event = self.exchange.event_logs[0]
+        self.assertEqual(1, len(self.order_fill_logger.event_log))
+        fill_event = self.order_fill_logger.event_log[0]
         self.assertEqual(OrderFilledEvent, type(fill_event))
         self.assertEqual(inflight_order.client_order_id, fill_event.order_id)
         self.assertEqual(inflight_order.trading_pair, fill_event.trading_pair)
@@ -460,7 +474,8 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(Decimal("0.002"), fill_event.trade_fee.percent)
         self.assertEqual(0, len(fill_event.trade_fee.flat_fees))
         self.assertEqual("213", fill_event.exchange_trade_id)
-        buy_event = self.exchange.event_logs[1]
+        self.assertEqual(1, len(self.sell_order_completed_logger.event_log))
+        buy_event = self.sell_order_completed_logger.event_log[0]
         self.assertEqual(inflight_order.client_order_id, buy_event.order_id)
         self.assertEqual(inflight_order.base_asset, buy_event.base_asset)
         self.assertEqual(inflight_order.quote_asset, buy_event.quote_asset)

--- a/test/hummingbot/strategy/test_hanging_orders_tracker.py
+++ b/test/hummingbot/strategy/test_hanging_orders_tracker.py
@@ -57,7 +57,7 @@ class TestHangingOrdersTracker(unittest.TestCase):
 
         strategy = MagicMock()
         type(strategy).max_order_age = PropertyMock(return_value=1800.0)
-        type(strategy).order_refresh_time = PropertyMock(return_value=45.0)
+
         strategy.get_price.return_value = self.current_market_price
         type(strategy).market_info = PropertyMock(return_value=market_info)
         type(strategy).trading_pair = PropertyMock(return_value="BTC-USDT")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When analyzing memory consumption for #4683 it was found that the EventLogger keeps an array in memory with all events triggered since the client is started.
This PR reduces that storage to the last 50 events. The only exception are the order filled events. The client needs to keep all of them because they are used to calculate PnL and update balance calculation. We might need an improvement in the future to make it possible to do those calculations without requiring all the events.

To facilitate testing I have added the physical memory consumption to the process monitor indicators in the lower right corner of the screen:

![image](https://user-images.githubusercontent.com/30988000/142414565-31070349-7c53-4b79-8be9-2a2d727414a9.png)

UPDATE:
I discovered a memory leak in the order book data source from GateIO connector. I include the fix as part of the PR. QA team please test that the order book is updated correctly after the fix.

UPDATE 2:
During the testing phase it was discovered that the connector was not keeping the local order book synchronized with the server order book all the time.
I include some changes to start using the numeric id included in order book updates messages and snapshot messages as the identifier, instead of the timestamp.

**Tests performed by the developer**:
Tested by running pure market making strategy for ETH-USDT connected to GateIO exchange.


**Tips for QA testing**:
- Verify the order book is updated correctly.

Fixes #4683 