### PR TITLE
fix/ascendex auth timestamp

### DIFF
--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
@@ -1,7 +1,8 @@
 import random
 import string
+import time
 from typing import Tuple
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce_low_res, get_tracking_nonce
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
@@ -33,9 +34,17 @@ def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
     return hb_trading_pair.replace("-", "/")
 
 
+def _time():
+    """
+    Private function created just to have a method that can be safely patched during unit tests and make tests
+    independent from real time
+    """
+    return time.time()
+
+
 # get timestamp in milliseconds
 def get_ms_timestamp() -> int:
-    return get_tracking_nonce_low_res()
+    return int(_time() * 1e3)
 
 
 def uuid32():

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
@@ -50,16 +50,16 @@ class AscendExUtilsTests(TestCase):
         url = utils.get_ws_url_private(account_id=account_id)
         self.assertEqual(f"wss://ascendex.com/{account_id}/api/pro/v1", url)
 
-    def test_get_ms_timestamp(self):
-        with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils._time') as get_tracking_nonce_low_res_mock:
-            get_tracking_nonce_low_res_mock.return_value = 1234567891.23456
+    @patch("hummingbot.connector.exchange.ascend_ex.ascend_ex_utils._time")
+    def test_get_ms_timestamp(self, time_mock):
+        time_mock.return_value = 1234567891.23456
 
-            timestamp = utils.get_ms_timestamp()
-            self.assertEqual(1234567891234, timestamp)
-            # If requested two times at the same moment it should return the same value (writen this way to ensure
-            # we are not using the nonce any more
-            timestamp = utils.get_ms_timestamp()
-            self.assertEqual(1234567891234, timestamp)
+        timestamp = utils.get_ms_timestamp()
+        self.assertEqual(1234567891234, timestamp)
+        # If requested two times at the same moment it should return the same value (writen this way to ensure
+        # we are not using the nonce any more
+        timestamp = utils.get_ms_timestamp()
+        self.assertEqual(1234567891234, timestamp)
 
     def test_uuid32(self):
         with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.random.choice') as random_choice_mock:

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
@@ -51,11 +51,15 @@ class AscendExUtilsTests(TestCase):
         self.assertEqual(f"wss://ascendex.com/{account_id}/api/pro/v1", url)
 
     def test_get_ms_timestamp(self):
-        with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_tracking_nonce_low_res') as get_tracking_nonce_low_res_mock:
-            get_tracking_nonce_low_res_mock.return_value = 123456789
+        with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils._time') as get_tracking_nonce_low_res_mock:
+            get_tracking_nonce_low_res_mock.return_value = 1234567891.23456
 
             timestamp = utils.get_ms_timestamp()
-            self.assertEqual(123456789, timestamp)
+            self.assertEqual(1234567891234, timestamp)
+            # If requested two times at the same moment it should return the same value (writen this way to ensure
+            # we are not using the nonce any more
+            timestamp = utils.get_ms_timestamp()
+            self.assertEqual(1234567891234, timestamp)
 
     def test_uuid32(self):
         with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.random.choice') as random_choice_mock:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Change in the logic that generates the auth headers for Ascendex. The code now uses the real timestamp instead of a nonce. The same change is applied in the timestamp parameter used when creating and cancelling orders.


**Tests performed by the developer**:
Added a unit test


**Tips for QA testing**:
Check private websocket events are received correctly (order status updates, balance updates and trade events). Also test that orders are created and cancelled without issues.

Closes #4800 4800

