### PR TITLE
fix/ GateIO handling of trade updates from both REST and WS API

### DIFF
--- a/hummingbot/connector/exchange/gate_io/gate_io_constants.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_constants.py
@@ -18,6 +18,7 @@ ORDER_STATUS_PATH_URL = "spot/orders/{id}"
 USER_ORDERS_PATH_URL = "spot/open_orders"
 TICKER_PATH_URL = "spot/tickers"
 ORDER_BOOK_PATH_URL = "spot/order_book"
+MY_TRADES_PATH_URL = "spot/my_trades"
 
 TRADES_ENDPOINT_NAME = "spot.trades"
 ORDER_SNAPSHOT_ENDPOINT_NAME = "spot.order_book"
@@ -59,5 +60,6 @@ RATE_LIMITS = [
     RateLimit(limit_id=ORDER_STATUS_LIMIT_ID, limit=900, time_interval=1, linked_limits=[LinkedLimitWeightPair(PRIVATE_URL_POINTS_LIMIT_ID)]),
     RateLimit(limit_id=USER_ORDERS_PATH_URL, limit=900, time_interval=1, linked_limits=[LinkedLimitWeightPair(PRIVATE_URL_POINTS_LIMIT_ID)]),
     RateLimit(limit_id=TICKER_PATH_URL, limit=900, time_interval=1, linked_limits=[LinkedLimitWeightPair(PUBLIC_URL_POINTS_LIMIT_ID)]),
-    RateLimit(limit_id=ORDER_BOOK_PATH_URL, limit=900, time_interval=1, linked_limits=[LinkedLimitWeightPair(PUBLIC_URL_POINTS_LIMIT_ID)])
+    RateLimit(limit_id=ORDER_BOOK_PATH_URL, limit=900, time_interval=1, linked_limits=[LinkedLimitWeightPair(PUBLIC_URL_POINTS_LIMIT_ID)]),
+    RateLimit(limit_id=MY_TRADES_PATH_URL, limit=900, time_interval=1, linked_limits=[LinkedLimitWeightPair(PRIVATE_URL_POINTS_LIMIT_ID)]),
 ]

--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -632,6 +632,21 @@ class GateIoExchange(ExchangeBase):
             self.logger().network(f"Unexpected error while fetching balance update - {str(e)}", exc_info=True,
                                   app_warning_msg=warn_msg)
 
+    def stop_tracking_order_exceed_not_found_limit(self, tracked_order: GateIoInFlightOrder):
+        """
+        Increments and checks if the tracked order has exceed the ORDER_NOT_EXIST_CONFIRMATION_COUNT limit.
+        If true, Triggers a MarketOrderFailureEvent and stops tracking the order.
+        """
+        client_order_id = tracked_order.client_order_id
+        self._order_not_found_records[client_order_id] = self._order_not_found_records.get(client_order_id, 0) + 1
+        if self._order_not_found_records[client_order_id] >= self.ORDER_NOT_EXIST_CONFIRMATION_COUNT:
+            # Wait until the order not found error have repeated a few times before actually treating
+            # it as failed. See: https://github.com/CoinAlpha/hummingbot/issues/601
+            self.trigger_event(MarketEvent.OrderFailure,
+                               MarketOrderFailureEvent(
+                                   self.current_timestamp, client_order_id, tracked_order.order_type))
+            self.stop_tracking_order(client_order_id)
+
     async def _update_order_status(self):
         """
         Calls REST API to get status update for each in-flight order.
@@ -641,8 +656,11 @@ class GateIoExchange(ExchangeBase):
                         else int(self.current_timestamp / CONSTANTS.UPDATE_ORDER_STATUS_INTERVAL))
 
         if current_tick > last_tick and len(self._in_flight_orders) > 0:
-            tracked_orders = list(self._in_flight_orders.values())
-            tasks = []
+            tracked_orders: List[GateIoInFlightOrder] = list(self._in_flight_orders.values())
+
+            order_status_tasks = []
+            order_trade_tasks = []
+
             for tracked_order in tracked_orders:
                 try:
                     exchange_order_id = await tracked_order.get_exchange_order_id()
@@ -651,39 +669,52 @@ class GateIoExchange(ExchangeBase):
                                           "- waiting for exchange order id.")
                     continue
                 trading_pair = convert_to_exchange_trading_pair(tracked_order.trading_pair)
-                endpoint = CONSTANTS.ORDER_STATUS_PATH_URL.format(id=exchange_order_id)
-                params = {'currency_pair': trading_pair}
-                request = GateIORESTRequest(
+
+                params = {"currency_pair": trading_pair}
+                order_status_request = GateIORESTRequest(
                     method=RESTMethod.GET,
-                    endpoint=endpoint,
+                    endpoint=CONSTANTS.ORDER_STATUS_PATH_URL.format(id=exchange_order_id),
                     params=params,
                     is_auth_required=True,
                     throttler_limit_id=CONSTANTS.ORDER_STATUS_LIMIT_ID,
                 )
-                tasks.append(self._api_request(request))
-            self.logger().debug(f"Polling for order status updates of {len(tasks)} orders.")
-            responses = await safe_gather(*tasks, return_exceptions=True)
-            for response, tracked_order in zip(responses, tracked_orders):
-                client_order_id = tracked_order.client_order_id
-                if isinstance(response, GateIoAPIError):
-                    if response.error_label == 'ORDER_NOT_FOUND':
-                        self._order_not_found_records[client_order_id] = \
-                            self._order_not_found_records.get(client_order_id, 0) + 1
-                        if self._order_not_found_records[client_order_id] < self.ORDER_NOT_EXIST_CONFIRMATION_COUNT:
-                            # Wait until the order not found error have repeated a few times before actually treating
-                            # it as failed. See: https://github.com/CoinAlpha/hummingbot/issues/601
-                            continue
-                        self.trigger_event(MarketEvent.OrderFailure,
-                                           MarketOrderFailureEvent(
-                                               self.current_timestamp, client_order_id, tracked_order.order_type))
-                        self.stop_tracking_order(client_order_id)
-                    else:
-                        continue
-                elif "id" not in response:
-                    self.logger().info(f"_update_order_status id not in resp: {response}")
-                    continue
+                params = {
+                    "currency_pair": trading_pair,
+                    "order_id": exchange_order_id
+                }
+                order_trade_request = GateIORESTRequest(
+                    method=RESTMethod.GET,
+                    endpoint=CONSTANTS.MY_TRADES_PATH_URL,
+                    params=params,
+                    is_auth_required=True,
+                    throttler_limit_id=CONSTANTS.MY_TRADES_PATH_URL,
+                )
+                order_status_tasks.append(self._api_request(order_status_request))
+                order_trade_tasks.append(self._api_request(order_trade_request))
+            self.logger().debug(f"Polling for order status updates of {len(order_status_tasks)} orders.")
+
+            trade_responses = await safe_gather(*order_trade_tasks, return_exceptions=True)
+
+            for response, tracked_order in zip(trade_responses, tracked_orders):
+                if not isinstance(response, GateIoAPIError):
+                    if len(response) > 0:
+                        for trade_fills in response:
+                            self._process_trade_message(trade_fills)
                 else:
+                    self.logger().warning(f"Failed to fetch trade updates for order {tracked_order.client_order_id}. "
+                                          f"Response: {response}")
+                    if response.error_label == 'ORDER_NOT_FOUND':
+                        self.stop_tracking_order_exceed_not_found_limit(tracked_order=tracked_order)
+
+            status_responses = await safe_gather(*order_status_tasks, return_exceptions=True)
+            for response, tracked_order in zip(status_responses, tracked_orders):
+                if not isinstance(response, GateIoAPIError):
                     self._process_order_message(response)
+                else:
+                    self.logger().warning(f"Failed to fetch order status updates for order {tracked_order.client_order_id}. "
+                                          f"Response: {response}")
+                    if response.error_label == 'ORDER_NOT_FOUND':
+                        self.stop_tracking_order_exceed_not_found_limit(tracked_order=tracked_order)
 
     def _process_order_message(self, order_msg: Dict[str, Any]):
         """
@@ -722,17 +753,13 @@ class GateIoExchange(ExchangeBase):
         }
         """
 
-        exchange_order_id = str(order_msg["id"])
-        tracked_orders = list(self._in_flight_orders.values())
-        track_order = [o for o in tracked_orders if exchange_order_id == o.exchange_order_id]
-        if track_order:
-            tracked_order = track_order[0]
+        client_order_id = str(order_msg["text"])
+        tracked_order = self.in_flight_orders.get(client_order_id, None)
+        if tracked_order:
 
-            updated = tracked_order.update_with_order_update(order_msg)
+            tracked_order.last_state = order_msg.get("status", order_msg.get("event"))
 
-            if updated:
-                safe_ensure_future(self._trigger_order_fill(tracked_order, order_msg))
-            elif tracked_order.is_cancelled:
+            if tracked_order.is_cancelled:
                 self.logger().info(f"Successfully cancelled order {tracked_order.client_order_id}.")
                 self.stop_tracking_order(tracked_order.client_order_id)
                 self.trigger_event(MarketEvent.OrderCancelled,
@@ -745,7 +772,7 @@ class GateIoExchange(ExchangeBase):
                                        self.current_timestamp, tracked_order.client_order_id, tracked_order.order_type))
                 self.stop_tracking_order(tracked_order.client_order_id)
 
-    async def _process_trade_message(self, trade_msg: Dict[str, Any]):
+    def _process_trade_message(self, trade_msg: Dict[str, Any]):
         """
         Updates in-flight order and trigger order filled event for trade message received. Triggers order completed
         event if the total executed amount equals to the specified order amount.
@@ -772,11 +799,12 @@ class GateIoExchange(ExchangeBase):
         if tracked_order:
             updated = tracked_order.update_with_trade_update(trade_msg)
             if updated:
-                safe_ensure_future(self._trigger_order_fill(tracked_order, trade_msg))
+                self._trigger_order_fill(tracked_order=tracked_order,
+                                         update_msg=trade_msg)
 
-    async def _trigger_order_fill(self,
-                                  tracked_order: GateIoInFlightOrder,
-                                  update_msg: Dict[str, Any]):
+    def _trigger_order_fill(self,
+                            tracked_order: GateIoInFlightOrder,
+                            update_msg: Dict[str, Any]):
         self.trigger_event(
             MarketEvent.OrderFilled,
             OrderFilledEvent(
@@ -802,7 +830,6 @@ class GateIoExchange(ExchangeBase):
                 else MarketEvent.SellOrderCompleted
             event_class = BuyOrderCompletedEvent if tracked_order.trade_type is TradeType.BUY \
                 else SellOrderCompletedEvent
-            await asyncio.sleep(0.1)
             self.trigger_event(event_tag,
                                event_class(self.current_timestamp,
                                            tracked_order.client_order_id,
@@ -927,19 +954,19 @@ class GateIoExchange(ExchangeBase):
                 ]
 
                 channel: str = event_message.get("channel", None)
-                params: str = event_message.get("result", None)
+                results: str = event_message.get("result", None)
 
                 if channel not in user_channels:
                     self.logger().error(f"Unexpected message in user stream: {event_message}.", exc_info=True)
                     continue
                 if channel == CONSTANTS.USER_TRADES_ENDPOINT_NAME:
-                    for trade_msg in params:
-                        await self._process_trade_message(trade_msg)
+                    for trade_msg in results:
+                        self._process_trade_message(trade_msg)
                 elif channel == CONSTANTS.USER_ORDERS_ENDPOINT_NAME:
-                    for order_msg in params:
+                    for order_msg in results:
                         self._process_order_message(order_msg)
                 elif channel == CONSTANTS.USER_BALANCE_ENDPOINT_NAME:
-                    self._process_balance_message_ws(params)
+                    self._process_balance_message_ws(results)
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/hummingbot/connector/exchange/gate_io/gate_io_in_flight_order.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_in_flight_order.py
@@ -29,7 +29,6 @@ class GateIoInFlightOrder(InFlightOrderBase):
             initial_state,
         )
         self.trade_update_id_set = set()
-        self.order_update_id_set = set()
         self.cancelled_event = asyncio.Event()
 
     @property
@@ -58,7 +57,7 @@ class GateIoInFlightOrder(InFlightOrderBase):
             getattr(TradeType, data["trade_type"]),
             Decimal(data["price"]),
             Decimal(data["amount"]),
-            data["last_state"]
+            data["last_state"],
         )
         retval.executed_amount_base = Decimal(data["executed_amount_base"])
         retval.executed_amount_quote = Decimal(data["executed_amount_quote"])
@@ -73,25 +72,26 @@ class GateIoInFlightOrder(InFlightOrderBase):
         return: True if the order gets updated otherwise False
         Example Trade:
         {
-            "id": 5736713,
-            "user_id": 1000001,
-            "order_id": "30784428",
-            "currency_pair": "BTC_USDT",
-            "create_time": 1605176741,
-            "create_time_ms": "1605176741123.456",
-            "side": "sell",
-            "amount": "1.00000000",
-            "role": "taker",
-            "price": "10000.00000000",
-            "fee": "0.00200000000000",
+            "id": 1234567890,
+            "user_id": 1234567,
+            "order_id": "96780687179",
+            "currency_pair": "ETH_USDT",
+            "create_time": 1637764970,
+            "create_time_ms": "1637764970928.48",
+            "side": "buy",
+            "amount": "0.005",
+            "role": "maker",
+            "price": "4191.1",
+            "fee": "0.000009",
+            "fee_currency": "ETH",
             "point_fee": "0",
-            "gt_fee": "0"
+            "gt_fee": "0",
+            "text": "t-HBOT-B-EHUT1637764969004024",
         }
         """
-        # Using time as ID here to avoid conflicts with order updates - order updates will take priority.
-        trade_id_ms = str(str(trade_update["create_time_ms"]).split('.')[0])
+
         trade_id = str(trade_update["id"])
-        if trade_id in self.trade_update_id_set or trade_id_ms in self.order_update_id_set:
+        if trade_id in self.trade_update_id_set:
             # trade already recorded
             return False
 
@@ -104,71 +104,6 @@ class GateIoInFlightOrder(InFlightOrderBase):
             # No trades executed yet.
             return False
         self.fee_paid += Decimal(str(trade_update.get("fee", "0")))
-        self.executed_amount_quote += (Decimal(str(trade_update.get("price", "0"))) *
-                                       trade_executed_base)
-        if not self.fee_asset:
-            self.fee_asset = self.quote_asset
-        return True
-
-    def update_with_order_update(self, order_update: Dict[str, Any]) -> bool:
-        """
-        Updates the in flight order with order update (from private/get-order-detail end point)
-        return: True if the order gets updated otherwise False
-        Example Order:
-        {
-            "id": "52109248977",
-            "text": "3",
-            "create_time": "1622638707",
-            "update_time": "1622638807",
-            "currency_pair": "BTC_USDT",
-            "type": "limit",
-            "account": "spot",
-            "side": "buy",
-            "amount": "0.001",
-            "price": "1999.8",
-            "time_in_force": "gtc",
-            "left": "0.001",
-            "filled_total": "0",
-            "fee": "0",
-            "fee_currency": "BTC",
-            "point_fee": "0",
-            "gt_fee": "0",
-            "gt_discount": true,
-            "rebated_fee": "0",
-            "rebated_fee_currency": "BTC",
-            "create_time_ms": "1622638707326",
-            "update_time_ms": "1622638807635",
-            ... optional params
-            "status": "open",
-            "event": "finish"
-            "iceberg": "0",
-            "fill_price": "0",
-            "user": 5660412,
-        }
-        """
-        # Update order execution status
-        self.last_state = order_update.get("status", order_update.get("event"))
-
-        if 'filled_total' not in order_update:
-            return False
-
-        trade_id_ms = str(str(order_update["update_time_ms"]).split('.')[0])
-        if trade_id_ms in self.order_update_id_set:
-            # trade already recorded
-            return False
-
-        # Set executed amounts
-        executed_amount_quote = Decimal(str(order_update["filled_total"]))
-        executed_price = Decimal(str(order_update.get("fill_price", "0")))
-        if executed_amount_quote <= s_decimal_0 or executed_price <= s_decimal_0:
-            # Skip these.
-            return False
-
-        self.order_update_id_set.add(trade_id_ms)
-
-        self.executed_amount_quote = executed_amount_quote
-        self.executed_amount_base = self.executed_amount_quote / executed_price
-        self.fee_paid = Decimal(str(order_update.get("fee")))
-        if not self.fee_asset:
-            self.fee_asset = order_update.get("fee_currency", self.quote_asset)
+        self.executed_amount_quote += Decimal(str(trade_update.get("price", "0"))) * trade_executed_base
+        self.fee_asset = trade_update["fee_currency"]
         return True

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_user_stream_data_source.py
@@ -33,27 +33,28 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
 
     def get_user_trades_mock(self) -> Dict:
         user_trades = {
-            "time": 1605176741,
+            "time": 1637764970,
             "channel": "spot.usertrades",
             "event": "update",
             "result": [
                 {
-                    "id": 5736713,
-                    "user_id": 1000001,
-                    "order_id": "30784428",
-                    "currency_pair": f"{self.base_asset}_{self.quote_asset}",
-                    "create_time": 1605176741,
-                    "create_time_ms": "1605176741123.456",
-                    "side": "sell",
-                    "amount": "1.00000000",
-                    "role": "taker",
-                    "price": "10000.00000000",
-                    "fee": "0.00200000000000",
+                    "id": 2217816329,
+                    "user_id": 5774224,
+                    "order_id": "96780687179",
+                    "currency_pair": "ETH_USDT",
+                    "create_time": 1637764970,
+                    "create_time_ms": "1637764970928.48",
+                    "side": "buy",
+                    "amount": "0.005",
+                    "role": "maker",
+                    "price": "4191.1",
+                    "fee": "0.000009",
+                    "fee_currency": "ETH",
                     "point_fee": "0",
                     "gt_fee": "0",
-                    "text": "apiv4"
+                    "text": "t-HBOT-B-EHUT1637764969004024",
                 }
-            ]
+            ],
         }
         return user_trades
 
@@ -87,9 +88,9 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
                     "gt_fee": "0",
                     "gt_discount": True,
                     "rebated_fee": "0",
-                    "rebated_fee_currency": "USDT"
+                    "rebated_fee_currency": "USDT",
                 }
-            ]
+            ],
         }
         return user_orders
 
@@ -106,9 +107,9 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
                     "currency": self.base_asset,
                     "change": "100",
                     "total": "1032951.325075926",
-                    "available": "1022943.325075926"
+                    "available": "1022943.325075926",
                 }
-            ]
+            ],
         }
         return user_balance
 
@@ -119,25 +120,19 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
         self.ev_loop.create_task(self.data_source.listen_for_user_stream(self.ev_loop, output_queue))
 
         resp = self.get_user_trades_mock()
-        self.mocking_assistant.add_websocket_aiohttp_message(
-            ws_connect_mock.return_value, json.dumps(resp)
-        )
+        self.mocking_assistant.add_websocket_aiohttp_message(ws_connect_mock.return_value, json.dumps(resp))
         ret = self.async_run_with_timeout(coroutine=output_queue.get())
 
         self.assertEqual(ret, resp)
 
         resp = self.get_user_orders_mock()
-        self.mocking_assistant.add_websocket_aiohttp_message(
-            ws_connect_mock.return_value, json.dumps(resp)
-        )
+        self.mocking_assistant.add_websocket_aiohttp_message(ws_connect_mock.return_value, json.dumps(resp))
         ret = self.async_run_with_timeout(coroutine=output_queue.get())
 
         self.assertEqual(ret, resp)
 
         resp = self.get_user_balance_mock()
-        self.mocking_assistant.add_websocket_aiohttp_message(
-            ws_connect_mock.return_value, json.dumps(resp)
-        )
+        self.mocking_assistant.add_websocket_aiohttp_message(ws_connect_mock.return_value, json.dumps(resp))
         ret = self.async_run_with_timeout(coroutine=output_queue.get())
 
         self.assertEqual(ret, resp)
@@ -146,15 +141,14 @@ class TestGateIoAPIOrderBookDataSource(unittest.TestCase):
     def test_listen_for_user_stream_skips_subscribe_unsubscribe_messages_updates_last_recv_time(self, ws_connect_mock):
         ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
         resp = {"time": 1632223851, "channel": "spot.usertrades", "event": "subscribe", "result": {"status": "success"}}
-        self.mocking_assistant.add_websocket_aiohttp_message(
-            ws_connect_mock.return_value, json.dumps(resp)
-        )
+        self.mocking_assistant.add_websocket_aiohttp_message(ws_connect_mock.return_value, json.dumps(resp))
         resp = {
-            "time": 1632223851, "channel": "spot.usertrades", "event": "unsubscribe", "result": {"status": "success"}
+            "time": 1632223851,
+            "channel": "spot.usertrades",
+            "event": "unsubscribe",
+            "result": {"status": "success"},
         }
-        self.mocking_assistant.add_websocket_aiohttp_message(
-            ws_connect_mock.return_value, json.dumps(resp)
-        )
+        self.mocking_assistant.add_websocket_aiohttp_message(ws_connect_mock.return_value, json.dumps(resp))
 
         output_queue = asyncio.Queue()
         self.ev_loop.create_task(self.data_source.listen_for_user_stream(self.ev_loop, output_queue))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Closes #4223 
Refactor how GateIO processes order messages and trade messages from both REST and WS API

Note:
`_process_order_message()` should only update order status, while `_process_trade_message()` should update the `InFlightOrder` attributes(i.e. `executed_amount_base`) and trigger the `OrderFilledEvent` if necessary

**Tests performed by the developer**:
- Include usage of `spot/my_trades` in `_update_order_status()`
- Refactor `_process_order_message()` to only update order status.

**Tips for QA testing**:
Ensure that all trade fees, orders and trades are reported correctly.

