### PR TITLE
Fix/hitbtc trading pairs parsing

### DIFF
--- a/hummingbot/connector/exchange/hitbtc/hitbtc_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_api_order_book_data_source.py
@@ -1,29 +1,30 @@
-#!/usr/bin/env python
 import asyncio
 import logging
 import time
-import pandas as pd
+
 from decimal import Decimal
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+import pandas as pd
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.logger import HummingbotLogger
-from .hitbtc_constants import Constants
 from .hitbtc_active_order_tracker import HitbtcActiveOrderTracker
+from .hitbtc_constants import Constants
 from .hitbtc_order_book import HitbtcOrderBook
-from .hitbtc_websocket import HitbtcWebsocket
 from .hitbtc_utils import (
-    str_date_to_ts,
-    convert_to_exchange_trading_pair,
-    convert_from_exchange_trading_pair,
     api_call_with_retries,
     HitbtcAPIError,
+    str_date_to_ts,
 )
+from .hitbtc_websocket import HitbtcWebsocket
 
 
 class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
     _logger: Optional[HummingbotLogger] = None
+    _trading_pair_symbol_map: Dict[str, str] = {}
 
     @classmethod
     def logger(cls) -> HummingbotLogger:
@@ -37,12 +38,34 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
         self._snapshot_msg: Dict[str, any] = {}
 
     @classmethod
+    async def init_trading_pair_symbols(cls, shared_session: Optional[aiohttp.ClientSession] = None):
+        """Initialize _trading_pair_symbol_map class variable
+        """
+
+        symbols: List[Dict[str, Any]] = await api_call_with_retries(
+            "GET",
+            Constants.ENDPOINT["SYMBOL"],
+            shared_client=shared_session)
+        cls._trading_pair_symbol_map = {
+            symbol_data["id"]: f"{symbol_data['baseCurrency']}-{symbol_data['quoteCurrency']}"
+            for symbol_data in symbols
+            if "marginTrading" not in symbol_data
+        }
+
+    @classmethod
+    async def trading_pair_symbol_map(cls) -> Dict[str, str]:
+        if not cls._trading_pair_symbol_map:
+            await cls.init_trading_pair_symbols()
+
+        return cls._trading_pair_symbol_map
+
+    @classmethod
     async def get_last_traded_prices(cls, trading_pairs: List[str]) -> Dict[str, Decimal]:
         results = {}
         if len(trading_pairs) > 1:
             tickers: List[Dict[Any]] = await api_call_with_retries("GET", Constants.ENDPOINT["TICKER"])
         for trading_pair in trading_pairs:
-            ex_pair: str = convert_to_exchange_trading_pair(trading_pair)
+            ex_pair: str = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(trading_pair)
             if len(trading_pairs) > 1:
                 ticker: Dict[Any] = list([tic for tic in tickers if tic['symbol'] == ex_pair])[0]
             else:
@@ -52,16 +75,26 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
         return results
 
     @staticmethod
+    async def exchange_symbol_associated_to_pair(trading_pair: str) -> str:
+        symbol_map = await HitbtcAPIOrderBookDataSource.trading_pair_symbol_map()
+        symbols = [symbol for symbol, pair in symbol_map.items() if pair == trading_pair]
+
+        if symbols:
+            symbol = symbols[0]
+        else:
+            raise ValueError(f"There is no symbol mapping for trading pair {trading_pair}")
+
+        return symbol
+
+    @staticmethod
+    async def trading_pair_associated_to_exchange_symbol(symbol: str) -> str:
+        symbol_map = await HitbtcAPIOrderBookDataSource.trading_pair_symbol_map()
+        return symbol_map[symbol]
+
+    @staticmethod
     async def fetch_trading_pairs() -> List[str]:
-        try:
-            symbols: List[Dict[str, Any]] = await api_call_with_retries("GET", Constants.ENDPOINT["SYMBOL"])
-            trading_pairs: List[str] = list([convert_from_exchange_trading_pair(sym["id"]) for sym in symbols])
-            # Filter out unmatched pairs so nothing breaks
-            return [sym for sym in trading_pairs if sym is not None]
-        except Exception:
-            # Do nothing if the request fails -- there will be no autocomplete for HitBTC trading pairs
-            pass
-        return []
+        symbols_map = await HitbtcAPIOrderBookDataSource.trading_pair_symbol_map()
+        return list(symbols_map.values())
 
     @staticmethod
     async def get_order_book_data(trading_pair: str) -> Dict[str, any]:
@@ -69,7 +102,7 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
         Get whole orderbook
         """
         try:
-            ex_pair = convert_to_exchange_trading_pair(trading_pair)
+            ex_pair = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(trading_pair)
             orderbook_response: Dict[Any] = await api_call_with_retries("GET", Constants.ENDPOINT["ORDER_BOOK"],
                                                                         params={"limit": 150, "symbols": ex_pair})
             return orderbook_response[ex_pair]
@@ -102,7 +135,8 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 await ws.connect()
 
                 for pair in self._trading_pairs:
-                    await ws.subscribe(Constants.WS_SUB["TRADES"], convert_to_exchange_trading_pair(pair))
+                    symbol = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(pair)
+                    await ws.subscribe(Constants.WS_SUB["TRADES"], symbol)
 
                 async for response in ws.on_message():
                     method: str = response.get("method", None)
@@ -111,7 +145,7 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
                     if trades_data is None or method != Constants.WS_METHODS['TRADES_UPDATE']:
                         continue
 
-                    pair: str = convert_from_exchange_trading_pair(response["params"]["symbol"])
+                    pair: str = await self.self.trading_pair_associated_to_exchange_symbol(response["params"]["symbol"])
 
                     for trade in trades_data["data"]:
                         trade: Dict[Any] = trade
@@ -145,7 +179,8 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 ]
 
                 for pair in self._trading_pairs:
-                    await ws.subscribe(Constants.WS_SUB["ORDERS"], convert_to_exchange_trading_pair(pair))
+                    symbol = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(pair)
+                    await ws.subscribe(Constants.WS_SUB["ORDERS"], symbol)
 
                 async for response in ws.on_message():
                     method: str = response.get("method", None)
@@ -155,7 +190,7 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
                         continue
 
                     timestamp: int = str_date_to_ts(order_book_data["timestamp"])
-                    pair: str = convert_from_exchange_trading_pair(order_book_data["symbol"])
+                    pair: str = await self.trading_pair_associated_to_exchange_symbol(order_book_data["symbol"])
 
                     order_book_msg_cls = (HitbtcOrderBook.diff_message_from_exchange
                                           if method == Constants.WS_METHODS['ORDERS_UPDATE'] else

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
@@ -1,56 +1,58 @@
+import aiohttp
+import asyncio
+import math
+import time
 import logging
+
+from async_timeout import timeout
+from decimal import Decimal
 from typing import (
+    Any,
+    AsyncIterable,
     Dict,
     List,
     Optional,
-    Any,
-    AsyncIterable,
 )
-from decimal import Decimal
-import asyncio
-import aiohttp
-import math
-import time
-from async_timeout import timeout
 
-from hummingbot.core.network_iterator import NetworkStatus
-from hummingbot.logger import HummingbotLogger
-from hummingbot.core.clock import Clock
-from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
-from hummingbot.connector.trading_rule import TradingRule
-from hummingbot.core.data_type.cancellation_result import CancellationResult
-from hummingbot.core.data_type.order_book import OrderBook
-from hummingbot.core.data_type.limit_order import LimitOrder
-from hummingbot.core.event.events import (
-    MarketEvent,
-    BuyOrderCompletedEvent,
-    SellOrderCompletedEvent,
-    OrderFilledEvent,
-    OrderCancelledEvent,
-    BuyOrderCreatedEvent,
-    SellOrderCreatedEvent,
-    MarketOrderFailureEvent,
-    OrderType,
-    TradeType,
-    TradeFee
-)
 from hummingbot.connector.exchange_base import ExchangeBase
-from hummingbot.connector.exchange.hitbtc.hitbtc_order_book_tracker import HitbtcOrderBookTracker
-from hummingbot.connector.exchange.hitbtc.hitbtc_user_stream_tracker import HitbtcUserStreamTracker
+from hummingbot.connector.exchange.hitbtc.hitbtc_api_order_book_data_source import HitbtcAPIOrderBookDataSource
 from hummingbot.connector.exchange.hitbtc.hitbtc_auth import HitbtcAuth
+from hummingbot.connector.exchange.hitbtc.hitbtc_constants import Constants
 from hummingbot.connector.exchange.hitbtc.hitbtc_in_flight_order import HitbtcInFlightOrder
+from hummingbot.connector.exchange.hitbtc.hitbtc_order_book_tracker import HitbtcOrderBookTracker
 from hummingbot.connector.exchange.hitbtc.hitbtc_utils import (
-    convert_from_exchange_trading_pair,
-    convert_to_exchange_trading_pair,
-    translate_asset,
-    get_new_client_order_id,
     aiohttp_response_with_errors,
+    get_new_client_order_id,
+    HitbtcAPIError,
     retry_sleep_time,
     str_date_to_ts,
-    HitbtcAPIError,
+    translate_asset,
 )
-from hummingbot.connector.exchange.hitbtc.hitbtc_constants import Constants
+from hummingbot.connector.exchange.hitbtc.hitbtc_user_stream_tracker import HitbtcUserStreamTracker
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.common import OpenOrder
+from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
+    OrderFilledEvent,
+    OrderType,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+    TradeFee,
+    TradeType,
+)
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
+from hummingbot.logger import HummingbotLogger
+
+
 ctce_logger = None
 s_decimal_NaN = Decimal("nan")
 
@@ -289,7 +291,7 @@ class HitbtcExchange(ExchangeBase):
         result = {}
         for rule in symbols_info:
             try:
-                trading_pair = convert_from_exchange_trading_pair(rule["id"])
+                trading_pair = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(rule["id"])
                 price_step = Decimal(str(rule["tickSize"]))
                 size_step = Decimal(str(rule["quantityIncrement"]))
                 result[trading_pair] = TradingRule(trading_pair,
@@ -430,7 +432,8 @@ class HitbtcExchange(ExchangeBase):
             raise ValueError(f"Buy order amount {amount} is lower than the minimum order size "
                              f"{trading_rule.min_order_size}.")
         order_type_str = order_type.name.lower().split("_")[0]
-        api_params = {"symbol": convert_to_exchange_trading_pair(trading_pair),
+        symbol = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(trading_pair)
+        api_params = {"symbol": symbol,
                       "side": trade_type.name.lower(),
                       "type": order_type_str,
                       "price": f"{price:f}",
@@ -861,10 +864,12 @@ class HitbtcExchange(ExchangeBase):
             if order["type"] != OrderType.LIMIT.name.lower():
                 self.logger().info(f"Unsupported order type found: {order['type']}")
                 continue
+            trading_pair = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(
+                order["symbol"])
             ret_val.append(
                 OpenOrder(
                     client_order_id=order["clientOrderId"],
-                    trading_pair=convert_from_exchange_trading_pair(order["symbol"]),
+                    trading_pair=trading_pair,
                     price=Decimal(str(order["price"])),
                     amount=Decimal(str(order["quantity"])),
                     executed_amount=Decimal(str(order["cumQuantity"])),

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
@@ -265,9 +265,9 @@ class HitbtcExchange(ExchangeBase):
     async def _update_trading_rules(self):
         symbols_info = await self._api_request("GET", endpoint=Constants.ENDPOINT['SYMBOL'])
         self._trading_rules.clear()
-        self._trading_rules = self._format_trading_rules(symbols_info)
+        self._trading_rules = await self._format_trading_rules(symbols_info)
 
-    def _format_trading_rules(self, symbols_info: Dict[str, Any]) -> Dict[str, TradingRule]:
+    async def _format_trading_rules(self, symbols_info: Dict[str, Any]) -> Dict[str, TradingRule]:
         """
         Converts json API response into a dictionary of trading rules.
         :param symbols_info: The json API response

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
@@ -432,7 +432,7 @@ class HitbtcExchange(ExchangeBase):
             raise ValueError(f"Buy order amount {amount} is lower than the minimum order size "
                              f"{trading_rule.min_order_size}.")
         order_type_str = order_type.name.lower().split("_")[0]
-        symbol = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(trading_pair)
+        symbol = await HitbtcAPIOrderBookDataSource.exchange_symbol_associated_to_pair(trading_pair)
         api_params = {"symbol": symbol,
                       "side": trade_type.name.lower(),
                       "type": order_type_str,

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_order_book_message.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_order_book_message.py
@@ -1,20 +1,15 @@
-#!/usr/bin/env python
-
 from typing import (
     Dict,
     List,
     Optional,
 )
 
-from hummingbot.core.data_type.order_book_row import OrderBookRow
 from hummingbot.core.data_type.order_book_message import (
     OrderBookMessage,
     OrderBookMessageType,
 )
+from hummingbot.core.data_type.order_book_row import OrderBookRow
 from .hitbtc_constants import Constants
-from .hitbtc_utils import (
-    convert_from_exchange_trading_pair,
-)
 
 
 class HitbtcOrderBookMessage(OrderBookMessage):
@@ -50,10 +45,7 @@ class HitbtcOrderBookMessage(OrderBookMessage):
 
     @property
     def trading_pair(self) -> str:
-        if "trading_pair" in self.content:
-            return self.content["trading_pair"]
-        elif "symbol" in self.content:
-            return convert_from_exchange_trading_pair(self.content["symbol"])
+        return self.content["trading_pair"]
 
     # The `asks` and `bids` properties are only used in the methods below.
     # They are all replaced or unused in this connector:

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_utils.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_utils.py
@@ -72,18 +72,6 @@ def translate_asset(asset_name: str) -> str:
     return asset_name
 
 
-def translate_assets(hb_trading_pair: str) -> str:
-    skip_pairs = [
-        'USDT-GUSD'
-    ]
-    if hb_trading_pair in skip_pairs:
-        return hb_trading_pair
-    assets = hb_trading_pair.split('-')
-    for x in range(len(assets)):
-        assets[x] = translate_asset(assets[x])
-    return '-'.join(assets)
-
-
 def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
     side = "B" if is_buy else "S"
     symbols = trading_pair.split("-")

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_utils.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_utils.py
@@ -84,20 +84,6 @@ def translate_assets(hb_trading_pair: str) -> str:
     return '-'.join(assets)
 
 
-def convert_from_exchange_trading_pair(ex_trading_pair: str) -> Optional[str]:
-    regex_match = split_trading_pair(ex_trading_pair)
-    if regex_match is None:
-        return None
-    # HitBTC uses uppercase (BTCUSDT)
-    base_asset, quote_asset = split_trading_pair(ex_trading_pair)
-    return translate_assets(f"{base_asset.upper()}-{quote_asset.upper()}")
-
-
-def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
-    # HitBTC uses uppercase (BTCUSDT)
-    return translate_assets(hb_trading_pair).replace("-", "").upper()
-
-
 def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
     side = "B" if is_buy else "S"
     symbols = trading_pair.split("-")

--- a/test/connector/exchange/hitbtc/test_hitbtc_currencies.py
+++ b/test/connector/exchange/hitbtc/test_hitbtc_currencies.py
@@ -34,7 +34,8 @@ class TestAuth(unittest.TestCase):
         pairs = [i['id'] for i in result]
         unmatched_pairs = []
         for pair in pairs:
-            matched_pair = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(pair)
+            matched_pair = asyncio.get_event_loop().run_until_complete(
+                HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(pair))
             if matched_pair is None:
                 matched_pair_split = None
                 print(f"\nUnmatched pair: {pair}\n")

--- a/test/connector/exchange/hitbtc/test_hitbtc_currencies.py
+++ b/test/connector/exchange/hitbtc/test_hitbtc_currencies.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import sys
 import asyncio
 import unittest
@@ -6,10 +5,11 @@ import aiohttp
 import logging
 from os.path import join, realpath
 from typing import Dict, Any
+
+from hummingbot.connector.exchange.hitbtc.hitbtc_api_order_book_data_source import HitbtcAPIOrderBookDataSource
+from hummingbot.connector.exchange.hitbtc.hitbtc_constants import Constants
 from hummingbot.connector.exchange.hitbtc.hitbtc_utils import aiohttp_response_with_errors
 from hummingbot.logger.struct_logger import METRICS_LOG_LEVEL
-from hummingbot.connector.exchange.hitbtc.hitbtc_constants import Constants
-from hummingbot.connector.exchange.hitbtc.hitbtc_utils import convert_from_exchange_trading_pair
 
 sys.path.insert(0, realpath(join(__file__, "../../../../../")))
 logging.basicConfig(level=METRICS_LOG_LEVEL)
@@ -34,7 +34,7 @@ class TestAuth(unittest.TestCase):
         pairs = [i['id'] for i in result]
         unmatched_pairs = []
         for pair in pairs:
-            matched_pair = convert_from_exchange_trading_pair(pair)
+            matched_pair = await HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol(pair)
             if matched_pair is None:
                 matched_pair_split = None
                 print(f"\nUnmatched pair: {pair}\n")

--- a/test/hummingbot/connector/exchange/hitbtc/test_hitbtc_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/hitbtc/test_hitbtc_api_order_book_data_source.py
@@ -25,9 +25,9 @@ class HitbtcAPIOrderBookDataSourceTests(TestCase):
         url = f"{CONSTANTS.REST_URL}/{CONSTANTS.ENDPOINT['SYMBOL']}"
         resp = [
             {
-                "id": "BTCUSDT",
+                "id": "BTCUSD",
                 "baseCurrency": "BTC",
-                "quoteCurrency": "USDT",
+                "quoteCurrency": "USD",
                 "quantityIncrement": "0.001",
                 "tickSize": "0.000001",
                 "takeLiquidityRate": "0.001",
@@ -51,9 +51,10 @@ class HitbtcAPIOrderBookDataSourceTests(TestCase):
 
         map = self.async_run_with_timeout(HitbtcAPIOrderBookDataSource.trading_pair_symbol_map())
 
-        self.assertIn("BTCUSDT", map)
-        self.assertEqual("BTC-USDT", map["BTCUSDT"])
-        self.assertNotIn("ETHBTC", map)
+        self.assertIn("BTCUSD", map)
+        self.assertEqual("BTC-USDT", map["BTCUSD"])
+        self.assertIn("ETHBTC", map)
+        self.assertEqual("ETH-BTC", map["ETHBTC"])
 
     def test_fetch_trading_pairs(self):
         HitbtcAPIOrderBookDataSource._trading_pair_symbol_map = {"BTCUSDT": "BTC-USDT", "ETHUSDT": "ETH-USDT"}

--- a/test/hummingbot/connector/exchange/hitbtc/test_hitbtc_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/hitbtc/test_hitbtc_api_order_book_data_source.py
@@ -1,0 +1,80 @@
+import asyncio
+import json
+from typing import Awaitable
+
+from unittest import TestCase
+
+from aioresponses import aioresponses
+
+from hummingbot.connector.exchange.hitbtc.hitbtc_api_order_book_data_source import HitbtcAPIOrderBookDataSource
+from hummingbot.connector.exchange.hitbtc.hitbtc_constants import Constants as CONSTANTS
+
+
+class HitbtcAPIOrderBookDataSourceTests(TestCase):
+
+    def tearDown(self) -> None:
+        HitbtcAPIOrderBookDataSource._trading_pair_symbol_map = {}
+        super().tearDown()
+
+    def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
+        ret = asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+        return ret
+
+    @aioresponses()
+    def test_trading_pairs_initialization(self, mock_api):
+        url = f"{CONSTANTS.REST_URL}/{CONSTANTS.ENDPOINT['SYMBOL']}"
+        resp = [
+            {
+                "id": "BTCUSDT",
+                "baseCurrency": "BTC",
+                "quoteCurrency": "USDT",
+                "quantityIncrement": "0.001",
+                "tickSize": "0.000001",
+                "takeLiquidityRate": "0.001",
+                "provideLiquidityRate": "-0.0001",
+                "feeCurrency": "USDT"
+            },
+            {
+                "id": "ETHBTC",
+                "baseCurrency": "ETH",
+                "quoteCurrency": "BTC",
+                "quantityIncrement": "0.001",
+                "tickSize": "0.000001",
+                "takeLiquidityRate": "0.001",
+                "provideLiquidityRate": "-0.0001",
+                "feeCurrency": "BTC",
+                "marginTrading": True,
+                "maxInitialLeverage": "10.00"
+            }
+        ]
+        mock_api.get(url, body=json.dumps(resp))
+
+        map = self.async_run_with_timeout(HitbtcAPIOrderBookDataSource.trading_pair_symbol_map())
+
+        self.assertIn("BTCUSDT", map)
+        self.assertEqual("BTC-USDT", map["BTCUSDT"])
+        self.assertNotIn("ETHBTC", map)
+
+    def test_fetch_trading_pairs(self):
+        HitbtcAPIOrderBookDataSource._trading_pair_symbol_map = {"BTCUSDT": "BTC-USDT", "ETHUSDT": "ETH-USDT"}
+        trading_pairs = self.async_run_with_timeout(HitbtcAPIOrderBookDataSource.fetch_trading_pairs())
+        self.assertEqual(["BTC-USDT", "ETH-USDT"], trading_pairs)
+
+    def test_exchange_symbol_associated_to_pair(self):
+        HitbtcAPIOrderBookDataSource._trading_pair_symbol_map = {"BTCUSDT": "BTC-USDT", "ETHUSDT": "ETH-USDT"}
+        symbol = self.async_run_with_timeout(
+            HitbtcAPIOrderBookDataSource.exchange_symbol_associated_to_pair("BTC-USDT"))
+        self.assertEqual("BTCUSDT", symbol)
+
+    def test_exchange_symbol_associated_to_pair_raises_error_when_pair_not_found(self):
+        HitbtcAPIOrderBookDataSource._trading_pair_symbol_map = {"BTCUSDT": "BTC-USDT", "ETHUSDT": "ETH-USDT"}
+        with self.assertRaises(ValueError) as exception:
+            self.async_run_with_timeout(
+                HitbtcAPIOrderBookDataSource.exchange_symbol_associated_to_pair("NOT-VALID"))
+            self.assertEqual("There is no symbol mapping for trading pair NOT-VALID", str(exception))
+
+    def test_trading_pair_associated_to_exchange_symbol(self):
+        HitbtcAPIOrderBookDataSource._trading_pair_symbol_map = {"BTCUSDT": "BTC-USDT", "ETHUSDT": "ETH-USDT"}
+        symbol = self.async_run_with_timeout(
+            HitbtcAPIOrderBookDataSource.trading_pair_associated_to_exchange_symbol("BTCUSDT"))
+        self.assertEqual("BTC-USDT", symbol)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Change in HitBTC connector to keep a list of available tokens and use it to translate tokens from exchange format to client format back and forth. Since the connector is a spot connector the new logic excludes all perpetual tokens from the list.


**Tests performed by the developer**:
I have added unit tests for all the new functionality related to the population of the token list and the new functions to translate token formats.
I have not added tests for the connector functions that consume the translation methods because we need to send this fix to production with the next release. Also in the near future we will be working on replacing websockets library for aiohttp in HItBTC, and we will add all the required tests when tackling that task.


**Tips for QA testing**:
Please test the connector can create and cancel orders correctly, and the trade fills are processed without issues. I could not test the connector myself because the support HitBTC account has no founds.

Fixes #4750 
