### PR TITLE
Fix/trading pairs parsing

### DIFF
--- a/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
@@ -809,7 +809,9 @@ cdef class BeaxyExchange(ExchangeBase):
 
         for rule in market_dict:
             try:
-                trading_pair = rule.get('symbol')
+                trading_pair = split_trading_pair(rule.get('symbol'))
+                if trading_pair is None:
+                    raise ValueError
                 # Parsing from string doesn't mess up the precision
                 retval.append(TradingRule(trading_pair,
                                           min_price_increment=Decimal(str(rule.get('tickSize'))),

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_api_order_book_data_source.py
@@ -55,7 +55,11 @@ class HitbtcAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def fetch_trading_pairs() -> List[str]:
         try:
             symbols: List[Dict[str, Any]] = await api_call_with_retries("GET", Constants.ENDPOINT["SYMBOL"])
-            trading_pairs: List[str] = list([convert_from_exchange_trading_pair(sym["id"]) for sym in symbols])
+            trading_pairs = []
+            for sym in symbols:
+                trading_pair = convert_from_exchange_trading_pair(sym["id"])
+                if trading_pair is not None:
+                    trading_pairs.append(trading_pair)
             # Filter out unmatched pairs so nothing breaks
             return [sym for sym in trading_pairs if sym is not None]
         except Exception:

--- a/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
+++ b/hummingbot/connector/exchange/hitbtc/hitbtc_exchange.py
@@ -290,6 +290,8 @@ class HitbtcExchange(ExchangeBase):
         for rule in symbols_info:
             try:
                 trading_pair = convert_from_exchange_trading_pair(rule["id"])
+                if trading_pair is None:
+                    raise ValueError
                 price_step = Decimal(str(rule["tickSize"]))
                 size_step = Decimal(str(rule["quantityIncrement"]))
                 result[trading_pair] = TradingRule(trading_pair,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR adds a couple of fixes for Beaxy and HitBTC to **avoid** the parsing failures exposed by the PR #4678 . It does not fix the broken parsing, but simply makes it explicit in the logs and re-enables the connectors to use the correctly parsed pairs.


**Tests performed by the developer**:
Ran PMM on both exchanges successfully.


**Tips for QA testing**:
Simply checking that the connectors are usable in the client is sufficient.

