### PR TITLE
fix/ndax test async with timeout

### DIFF
--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -845,6 +845,9 @@ class NdaxExchange(ExchangeBase):
         for order_status in parsed_status_responses:
             self._process_order_event_message(order_status)
 
+    def _reset_poll_notifier(self):
+        self._poll_notifier = asyncio.Event()
+
     async def _status_polling_loop(self):
         """
         Periodically update user balances and order status via REST API. This serves as a fallback measure for web
@@ -852,7 +855,7 @@ class NdaxExchange(ExchangeBase):
         """
         while True:
             try:
-                self._poll_notifier = asyncio.Event()
+                self._reset_poll_notifier()
                 await self._poll_notifier.wait()
                 start_ts = self.current_timestamp
                 await safe_gather(

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_exchange.py
@@ -1,19 +1,22 @@
 import asyncio
 import json
 import time
-import pandas as pd
 import re
+
+import pandas as pd
 
 from aioresponses import aioresponses
 from decimal import Decimal
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Awaitable
 from unittest import TestCase
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 from hummingbot.connector.exchange.ndax import ndax_constants as CONSTANTS, ndax_utils
 from hummingbot.connector.exchange.ndax.ndax_exchange import NdaxExchange
 from hummingbot.connector.exchange.ndax.ndax_in_flight_order import (
-    NdaxInFlightOrder, WORKING_LOCAL_STATUS, NdaxInFlightOrderNotCreated
+    NdaxInFlightOrder,
+    NdaxInFlightOrderNotCreated,
+    WORKING_LOCAL_STATUS,
 )
 from hummingbot.connector.exchange.ndax.ndax_order_book import NdaxOrderBook
 from hummingbot.connector.trading_rule import TradingRule
@@ -89,6 +92,10 @@ class NdaxExchangeTests(TestCase):
     def _is_logged(self, log_level: str, message: str) -> bool:
         return any(record.levelname == log_level and record.getMessage() == message
                    for record in self.log_records)
+
+    def async_run_with_timeout(self, coroutine: Awaitable, timeout: int = 1):
+        ret = asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+        return ret
 
     def _authentication_response(self, authenticated: bool) -> str:
         user = {"UserId": 492,
@@ -170,12 +177,12 @@ class NdaxExchangeTests(TestCase):
 
         # Add a dummy message for the websocket to read and include in the "messages" queue
         self.mocking_assistant.add_websocket_text_message(ws_connect_mock, json.dumps('dummyMessage'))
-        asyncio.get_event_loop().run_until_complete(self.resume_test_event.wait())
+        self.async_run_with_timeout(self.resume_test_event.wait())
         self.resume_test_event.clear()
 
         try:
             self.exchange_task.cancel()
-            asyncio.get_event_loop().run_until_complete(self.exchange_task)
+            self.async_run_with_timeout(self.exchange_task)
         except asyncio.CancelledError:
             pass
         except Exception:
@@ -193,10 +200,10 @@ class NdaxExchangeTests(TestCase):
         self.exchange._user_stream_tracker._user_stream = dummy_user_stream
 
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         with self.assertRaises(asyncio.CancelledError):
-            asyncio.get_event_loop().run_until_complete(self.tracker_task)
+            self.async_run_with_timeout(self.tracker_task)
 
     def test_exchange_logs_unknown_event_message(self):
         payload = {}
@@ -211,7 +218,7 @@ class NdaxExchangeTests(TestCase):
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
 
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertTrue(self._is_logged('DEBUG', f"Unknown event received from the connector ({message})"))
 
@@ -236,7 +243,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertEqual(Decimal('10499.1'), self.exchange.get_balance('BTC'))
         self.assertEqual(Decimal('10499.1') - Decimal('2.1'), self.exchange.available_balances['BTC'])
@@ -278,7 +285,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertEqual("Canceled", inflight_order.last_state)
         self.assertTrue(inflight_order.is_cancelled)
@@ -326,7 +333,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertEqual("Rejected", inflight_order.last_state)
         self.assertTrue(inflight_order.is_failure)
@@ -377,7 +384,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertEqual("FullyExecuted", inflight_order.last_state)
         self.assertIn(payload["TradeId"], inflight_order.trade_id_set)
@@ -450,7 +457,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertEqual("FullyExecuted", inflight_order.last_state)
         self.assertIn(payload["TradeId"], inflight_order.trade_id_set)
@@ -597,7 +604,7 @@ class NdaxExchangeTests(TestCase):
         task = asyncio.get_event_loop().create_task(
             self.exchange._get_account_id()
         )
-        resp = asyncio.get_event_loop().run_until_complete(task)
+        resp = self.async_run_with_timeout(task)
         self.assertEqual(resp, account_id)
 
     @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
@@ -628,7 +635,7 @@ class NdaxExchangeTests(TestCase):
         task = asyncio.get_event_loop().create_task(
             self.exchange._get_account_id()
         )
-        resp = asyncio.get_event_loop().run_until_complete(task)
+        resp = self.async_run_with_timeout(task)
 
         self.assertTrue(self._is_logged('ERROR', f"There is no account named {self._account_name} "
                                                  f"associated with the current NDAX user"))
@@ -656,7 +663,7 @@ class NdaxExchangeTests(TestCase):
         self.exchange_task = asyncio.get_event_loop().create_task(
             self.exchange._update_balances()
         )
-        asyncio.get_event_loop().run_until_complete(self.exchange_task)
+        self.async_run_with_timeout(self.exchange_task)
 
         self.assertEqual(Decimal(str(10.0)), self.exchange.get_balance(self.base_asset))
 
@@ -785,7 +792,7 @@ class NdaxExchangeTests(TestCase):
         })
 
         self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._update_order_status())
-        asyncio.get_event_loop().run_until_complete(self.exchange_task)
+        self.async_run_with_timeout(self.exchange_task)
         self.assertEqual(0, len(self.exchange.in_flight_orders))
 
     @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
@@ -870,7 +877,7 @@ class NdaxExchangeTests(TestCase):
         })
 
         self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._update_order_status())
-        asyncio.get_event_loop().run_until_complete(self.exchange_task)
+        self.async_run_with_timeout(self.exchange_task)
         self.assertEqual(1, len(self.exchange.in_flight_orders))
 
         self.assertEqual(0, len(self.exchange.in_flight_orders[order.client_order_id].trade_id_set))
@@ -898,13 +905,13 @@ class NdaxExchangeTests(TestCase):
             self.trading_pair: 5
         })
         self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._update_order_status())
-        asyncio.get_event_loop().run_until_complete(self.exchange_task)
+        self.async_run_with_timeout(self.exchange_task)
 
         self.assertEqual(1, len(self.exchange._in_flight_orders))
         self.assertEqual(1, self.exchange._order_not_found_records[order.client_order_id])
 
         self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._update_order_status())
-        asyncio.get_event_loop().run_until_complete(self.exchange_task)
+        self.async_run_with_timeout(self.exchange_task)
 
         self.assertEqual(0, len(self.exchange._in_flight_orders))
         self.assertEqual(2, self.exchange._order_not_found_records[order.client_order_id])
@@ -927,10 +934,10 @@ class NdaxExchangeTests(TestCase):
             )
 
             # Add small delay to ensure an API request is "called"
-            asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.5))
+            self.async_run_with_timeout(asyncio.sleep(0.5))
             self.exchange._poll_notifier.set()
 
-            asyncio.get_event_loop().run_until_complete(asyncio.wait_for(self.exchange_task, 2.0))
+            self.async_run_with_timeout(asyncio.wait_for(self.exchange_task, 2.0))
 
         self.assertEqual(ts, self.exchange._last_poll_timestamp)
 
@@ -948,10 +955,10 @@ class NdaxExchangeTests(TestCase):
                 self.exchange._status_polling_loop()
             )
             # Add small delay to ensure _poll_notifier is set
-            asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.5))
+            self.async_run_with_timeout(asyncio.sleep(0.5))
             self.exchange._poll_notifier.set()
 
-            asyncio.get_event_loop().run_until_complete(self.exchange_task)
+            self.async_run_with_timeout(self.exchange_task)
 
         self.assertEqual(0, self.exchange._last_poll_timestamp)
 
@@ -973,10 +980,10 @@ class NdaxExchangeTests(TestCase):
         )
 
         # Add small delay to ensure an API request is "called"
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.5))
+        self.async_run_with_timeout(asyncio.sleep(0.5))
         self.exchange._poll_notifier.set()
 
-        asyncio.get_event_loop().run_until_complete(self.resume_test_event.wait())
+        self.async_run_with_timeout(self.resume_test_event.wait())
 
         self.assertEqual(0, self.exchange._last_poll_timestamp)
         self._is_logged("ERROR", "Unexpected error while in status polling loop. Error: ")
@@ -1022,7 +1029,7 @@ class NdaxExchangeTests(TestCase):
         task = asyncio.get_event_loop().create_task(
             self.exchange._update_trading_rules()
         )
-        asyncio.get_event_loop().run_until_complete(task)
+        self.async_run_with_timeout(task)
 
         self.assertTrue(self.trading_pair in self.exchange.trading_rules)
 
@@ -1039,7 +1046,7 @@ class NdaxExchangeTests(TestCase):
         with self.assertRaises(asyncio.TimeoutError):
             self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._trading_rules_polling_loop())
 
-            asyncio.get_event_loop().run_until_complete(
+            self.async_run_with_timeout(
                 asyncio.wait_for(self.exchange_task, 1.0)
             )
 
@@ -1053,7 +1060,7 @@ class NdaxExchangeTests(TestCase):
                 self.exchange._trading_rules_polling_loop()
             )
 
-            asyncio.get_event_loop().run_until_complete(self.exchange_task)
+            self.async_run_with_timeout(self.exchange_task)
 
         self.assertEqual(0, self.exchange._last_poll_timestamp)
 
@@ -1067,7 +1074,7 @@ class NdaxExchangeTests(TestCase):
             self.exchange._trading_rules_polling_loop()
         )
 
-        asyncio.get_event_loop().run_until_complete(self.resume_test_event.wait())
+        self.async_run_with_timeout(self.resume_test_event.wait())
 
         self._is_logged("ERROR", "Unexpected error while fetching trading rules. Error: ")
 
@@ -1077,7 +1084,7 @@ class NdaxExchangeTests(TestCase):
         self.mocking_assistant.configure_http_request_mock(mock_api)
         self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
 
-        result = asyncio.get_event_loop().run_until_complete(self.exchange.check_network())
+        result = self.async_run_with_timeout(self.exchange.check_network())
 
         self.assertEqual(NetworkStatus.CONNECTED, result)
 
@@ -1087,13 +1094,13 @@ class NdaxExchangeTests(TestCase):
         self.mocking_assistant.configure_http_request_mock(mock_api)
         self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
 
-        result = asyncio.get_event_loop().run_until_complete(self.exchange.check_network())
+        result = self.async_run_with_timeout(self.exchange.check_network())
         self.assertEqual(NetworkStatus.NOT_CONNECTED, result)
 
         mock_response = {}
         self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
 
-        result = asyncio.get_event_loop().run_until_complete(self.exchange.check_network())
+        result = self.async_run_with_timeout(self.exchange.check_network())
         self.assertEqual(NetworkStatus.NOT_CONNECTED, result)
 
     @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
@@ -1102,7 +1109,7 @@ class NdaxExchangeTests(TestCase):
         self.mocking_assistant.configure_http_request_mock(mock_api)
         self.mocking_assistant.add_http_response(mock_api, 404, mock_response, "")
 
-        result = asyncio.get_event_loop().run_until_complete(self.exchange.check_network())
+        result = self.async_run_with_timeout(self.exchange.check_network())
 
         self.assertEqual(NetworkStatus.NOT_CONNECTED, result)
 
@@ -1178,7 +1185,7 @@ class NdaxExchangeTests(TestCase):
 
         self.assertEqual(0, len(self.exchange.in_flight_orders))
         future = self._simulate_create_order(*order_details)
-        asyncio.get_event_loop().run_until_complete(future)
+        self.async_run_with_timeout(future)
 
         self.assertEqual(1, len(self.exchange.in_flight_orders))
         self._is_logged("INFO",
@@ -1224,7 +1231,7 @@ class NdaxExchangeTests(TestCase):
 
         self.assertEqual(0, len(self.exchange.in_flight_orders))
         future = self._simulate_create_order(*order_details)
-        asyncio.get_event_loop().run_until_complete(future)
+        self.async_run_with_timeout(future)
 
         self.assertEqual(1, len(self.exchange.in_flight_orders))
         self._is_logged("INFO",
@@ -1275,7 +1282,7 @@ class NdaxExchangeTests(TestCase):
 
         self.exchange._user_stream_tracker.user_stream.put_nowait(message)
         # Yield processor for the exchange to process the new message
-        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.3))
+        self.async_run_with_timeout(asyncio.sleep(0.3))
 
         self.assertEqual(1, len(self.exchange.in_flight_orders))
         tracked_order: NdaxInFlightOrder = self.exchange.in_flight_orders["3"]
@@ -1306,7 +1313,7 @@ class NdaxExchangeTests(TestCase):
         self.assertEqual(0, len(self.exchange.in_flight_orders))
         future = self._simulate_create_order(*order_details)
         with self.assertRaises(asyncio.CancelledError):
-            asyncio.get_event_loop().run_until_complete(future)
+            self.async_run_with_timeout(future)
 
         # InFlightOrder is still 1 since we do not know exactly where did the Cancel occur.
         self.assertEqual(1, len(self.exchange.in_flight_orders))
@@ -1337,7 +1344,7 @@ class NdaxExchangeTests(TestCase):
             self.exchange._create_order(*order_details)
         )
 
-        asyncio.get_event_loop().run_until_complete(self.exchange_task)
+        self.async_run_with_timeout(self.exchange_task)
 
         self.assertEqual(0, len(self.exchange.in_flight_orders))
         self._is_logged("NETWORK", f"Error submitting {TradeType.BUY.name} {OrderType.LIMIT.name} order to NDAX")
@@ -1373,7 +1380,7 @@ class NdaxExchangeTests(TestCase):
         ]
 
         self.assertEqual(0, len(self.exchange.in_flight_orders))
-        asyncio.get_event_loop().run_until_complete(
+        self.async_run_with_timeout(
             self.exchange._create_order(*order_details)
         )
 

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_order_book_tracker.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_order_book_tracker.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import asyncio
 from decimal import Decimal


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Added a timeout to all async executions done by NDAX tests to avoid the unit tests runs from hanging git validation workflow.


**Tests performed by the developer**:
Run all unit tests


**Tips for QA testing**:
No test required. Changes only impact unit tests.

