### PR TITLE
Fix/No printing in the output pane after status --live is terminated

### DIFF
--- a/hummingbot/client/command/status_command.py
+++ b/hummingbot/client/command/status_command.py
@@ -133,6 +133,7 @@ class StatusCommand:
                     await self.cls_display_delay(
                         await self.strategy_status(live=True) + script_status + "\n\n Press escape key to stop update.", 1
                     )
+                self.app.live_updates = False
                 self._notify("Stopped live status display update.")
             else:
                 self._notify(await self.strategy_status())


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

"status --live"  to hand over control over output pane after being terminated with "stop", as it does when terminated with ESC

**Tests performed by the developer**:

Basic test in the client according to the bug description
