### PR TITLE
fix/fees beaxy

### DIFF
--- a/hummingbot/connector/exchange/beaxy/beaxy_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/beaxy/beaxy_api_user_stream_data_source.py
@@ -63,6 +63,7 @@ class BeaxyAPIUserStreamDataSource(UserStreamTrackerDataSource):
 
     async def _listen_for_orders(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
         async for msg in self.__listen_ws(BeaxyConstants.TradingApi.WS_ORDERS_ENDPOINT):
+            self.logger().info(f"\n***\n{msg}\n***")
             output.put_nowait([BeaxyConstants.UserStream.ORDER_MESSAGE, msg])
 
     async def listen_for_user_stream(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):

--- a/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
@@ -41,7 +41,7 @@ from hummingbot.core.event.events import (
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.utils.estimate_fee import estimate_fee
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonceß
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.logger import HummingbotLogger
 
 s_logger = None
@@ -868,7 +868,7 @@ cdef class BeaxyExchange(ExchangeBase):
                     tracked_order = self._in_flight_orders.get(client_order_id)
 
                     if tracked_order is None:
-                        self.logger().debug(f'Didn`rt find order with id {client_order_id}')
+                        self.logger().debug(f'Didn\'t find order with id {client_order_id}')
                         continue
 
                     if not tracked_order.exchange_order_id:
@@ -881,7 +881,7 @@ cdef class BeaxyExchange(ExchangeBase):
 
                     if updated:
                         fee_asset = tracked_order.fee_asset or tracked_order.quote_asset
-                        fee_amount = Decimal(order['commission']) or Decimal(0)
+                        fee_amount = order['commission'] or "0"
 
                         self.logger().info(f'Filled {Decimal(order["trade_size"])} out of {tracked_order.amount} of the '
                                            f'{tracked_order.order_type_description} order {tracked_order.client_order_id}')
@@ -897,7 +897,7 @@ cdef class BeaxyExchange(ExchangeBase):
                                                  Decimal(order["trade_size"]),
                                                  TradeFee(
                                                      percent=Decimal(0.0),
-                                                     flat_fees=[(fee_asset, fee_amount)]),
+                                                     flat_fees=[(fee_asset, Decimal(fee_amount))]),
                                                  exchange_trade_id=exchange_order_id
                                              ))
 

--- a/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pxd
+++ b/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pxd
@@ -3,3 +3,4 @@ from hummingbot.connector.in_flight_order_base cimport InFlightOrderBase
 cdef class BeaxyInFlightOrder(InFlightOrderBase):
     cdef:
         public object created_at
+        object trade_id_set

--- a/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pyx
@@ -1,12 +1,25 @@
+import logging
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
 from hummingbot.connector.in_flight_order_base import InFlightOrderBase
 from hummingbot.core.event.events import OrderType, TradeType
+from hummingbot.logger import HummingbotLogger
+
+s_logger = None
 
 
 cdef class BeaxyInFlightOrder(InFlightOrderBase):
+    _logger = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        global s_logger
+        if s_logger is None:
+            s_logger = logging.getLogger(__name__)
+        return s_logger
+
     def __init__(
         self,
         client_order_id: str,
@@ -98,6 +111,7 @@ cdef class BeaxyInFlightOrder(InFlightOrderBase):
                 or trade_update["trade_size"] is None
                 or trade_update["trade_price"] is None
                 or Decimal(trade_update["filled_size"]) <= self.executed_amount_base):
+            self.logger().info(f"\n*** Will not update inflight order\ntrade_id={trade_id} - trade_size={trade_update['trade_size']} - trade_price={trade_update['trade_price']} - filled_size={trade_update['filled_size']}\n{self.trade_id_set}")
             return False
 
         self.trade_id_set.add(trade_id)

--- a/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pyx
@@ -1,24 +1,12 @@
-import logging
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
 from hummingbot.connector.in_flight_order_base import InFlightOrderBase
 from hummingbot.core.event.events import OrderType, TradeType
-from hummingbot.logger import HummingbotLogger
-
-s_logger = None
 
 
 cdef class BeaxyInFlightOrder(InFlightOrderBase):
-    _logger = None
-
-    @classmethod
-    def logger(cls) -> HummingbotLogger:
-        global s_logger
-        if s_logger is None:
-            s_logger = logging.getLogger(__name__)
-        return s_logger
 
     def __init__(
         self,

--- a/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_in_flight_order.pyx
@@ -111,7 +111,6 @@ cdef class BeaxyInFlightOrder(InFlightOrderBase):
                 or trade_update["trade_size"] is None
                 or trade_update["trade_price"] is None
                 or Decimal(trade_update["filled_size"]) <= self.executed_amount_base):
-            self.logger().info(f"\n*** Will not update inflight order\ntrade_id={trade_id} - trade_size={trade_update['trade_size']} - trade_price={trade_update['trade_price']} - filled_size={trade_update['filled_size']}\n{self.trade_id_set}")
             return False
 
         self.trade_id_set.add(trade_id)

--- a/test/hummingbot/connector/exchange/beaxy/test_beaxy_exchange.py
+++ b/test/hummingbot/connector/exchange/beaxy/test_beaxy_exchange.py
@@ -1,0 +1,201 @@
+import asyncio
+import functools
+from decimal import Decimal
+from typing import Awaitable, Callable, Optional
+from unittest import TestCase
+from unittest.mock import AsyncMock
+
+from hummingbot.connector.exchange.beaxy.beaxy_constants import BeaxyConstants
+from hummingbot.connector.exchange.beaxy.beaxy_exchange import BeaxyExchange
+from hummingbot.core.event.event_logger import EventLogger
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    MarketEvent,
+    OrderFilledEvent,
+    OrderType,
+    TradeType,
+)
+
+
+class BeaxyExchangeTests(TestCase):
+    # the level is required to receive logs from the data source logger
+    level = 0
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.base_asset = "COINALPHA"
+        cls.quote_asset = "HBOT"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.symbol = f"{cls.base_asset}{cls.quote_asset}"
+        cls.listen_key = "TEST_LISTEN_KEY"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.log_records = []
+        self.test_task: Optional[asyncio.Task] = None
+        self.resume_test_event = asyncio.Event()
+
+        self.exchange = BeaxyExchange(
+            beaxy_api_key="testAPIKey",
+            beaxy_secret_key="testSecret",
+            trading_pairs=[self.trading_pair],
+        )
+
+        self.exchange.logger().setLevel(1)
+        self.exchange.logger().addHandler(self)
+
+        self._initialize_event_loggers()
+
+    def tearDown(self) -> None:
+        self.test_task and self.test_task.cancel()
+        super().tearDown()
+
+    def _initialize_event_loggers(self):
+        self.buy_order_completed_logger = EventLogger()
+        self.sell_order_completed_logger = EventLogger()
+        self.order_filled_logger = EventLogger()
+
+        events_and_loggers = [
+            (MarketEvent.BuyOrderCompleted, self.buy_order_completed_logger),
+            (MarketEvent.SellOrderCompleted, self.sell_order_completed_logger),
+            (MarketEvent.OrderFilled, self.order_filled_logger)]
+
+        for event, logger in events_and_loggers:
+            self.exchange.add_listener(event, logger)
+
+    def handle(self, record):
+        self.log_records.append(record)
+
+    def _is_logged(self, log_level: str, message: str) -> bool:
+        return any(record.levelname == log_level and record.getMessage() == message for record in self.log_records)
+
+    def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
+        ret = asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+        return ret
+
+    def _return_calculation_and_set_done_event(self, calculation: Callable, *args, **kwargs):
+        if self.resume_test_event.is_set():
+            raise asyncio.CancelledError
+        self.resume_test_event.set()
+        return calculation(*args, **kwargs)
+
+    def test_order_fill_event_takes_fee_from_update_event(self):
+        self.exchange.start_tracking_order(
+            order_id="OID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal("10000"),
+            amount=Decimal("1"),
+        )
+
+        order = self.exchange.in_flight_orders.get("OID1")
+        order.update_exchange_order_id("EOID1")
+
+        partial_fill = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "OID1",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "partially_filled",
+            "size": "1.0",
+            "trade_size": "0.1",
+            "trade_price": "10050.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "0.1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "10.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.785Z"
+        }
+
+        message = [BeaxyConstants.UserStream.ORDER_MESSAGE,
+                   {
+                       "stream": "order",
+                       "data": partial_fill,
+                       "type": "update",
+                   }]
+
+        mock_user_stream = AsyncMock()
+        mock_user_stream.get.side_effect = functools.partial(self._return_calculation_and_set_done_event,
+                                                             lambda: message)
+
+        self.exchange.user_stream_tracker._user_stream = mock_user_stream
+
+        self.test_task = asyncio.get_event_loop().create_task(self.exchange._user_stream_event_listener())
+        self.async_run_with_timeout(self.resume_test_event.wait())
+
+        self.assertEqual(Decimal("10"), order.fee_paid)
+        self.assertEqual(1, len(self.order_filled_logger.event_log))
+        fill_event: OrderFilledEvent = self.order_filled_logger.event_log[0]
+        self.assertEqual(0.0, fill_event.trade_fee.percent)
+        self.assertEqual([(partial_fill["commission_currency"], Decimal(partial_fill["commission"]))],
+                         fill_event.trade_fee.flat_fees)
+        self.assertTrue(self._is_logged(
+            "INFO",
+            f"Filled {Decimal(partial_fill['trade_size'])} out of {order.amount} of the "
+            f"{order.order_type_description} order {order.client_order_id}"
+        ))
+
+        self.assertEqual(0, len(self.buy_order_completed_logger.event_log))
+
+        complete_fill = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "OID1",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "completely_filled",
+            "size": "1.0",
+            "trade_size": "0.9",
+            "trade_price": "10060.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "1.0",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "30.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.786Z"
+        }
+
+        message[1]["data"] = complete_fill
+
+        self.resume_test_event = asyncio.Event()
+        mock_user_stream = AsyncMock()
+        mock_user_stream.get.side_effect = functools.partial(self._return_calculation_and_set_done_event,
+                                                             lambda: message)
+
+        self.exchange.user_stream_tracker._user_stream = mock_user_stream
+
+        self.test_task = asyncio.get_event_loop().create_task(self.exchange._user_stream_event_listener())
+        self.async_run_with_timeout(self.resume_test_event.wait())
+
+        self.assertEqual(Decimal("40"), order.fee_paid)
+
+        self.assertEqual(2, len(self.order_filled_logger.event_log))
+        fill_event: OrderFilledEvent = self.order_filled_logger.event_log[1]
+        self.assertEqual(0.0, fill_event.trade_fee.percent)
+        self.assertEqual([(complete_fill["commission_currency"], Decimal(complete_fill["commission"]))],
+                         fill_event.trade_fee.flat_fees)
+
+        self.assertTrue(self._is_logged(
+            "INFO",
+            f"The market buy order {order.client_order_id} has completed according to Beaxy user stream."
+        ))
+
+        self.assertEqual(1, len(self.buy_order_completed_logger.event_log))
+        buy_complete_event: BuyOrderCompletedEvent = self.buy_order_completed_logger.event_log[0]
+        self.assertEqual(Decimal(40), buy_complete_event.fee_amount)
+        self.assertEqual(complete_fill["commission_currency"], buy_complete_event.fee_asset)

--- a/test/hummingbot/connector/exchange/beaxy/test_beaxy_in_flight_order.py
+++ b/test/hummingbot/connector/exchange/beaxy/test_beaxy_in_flight_order.py
@@ -1,0 +1,270 @@
+from datetime import datetime
+from decimal import Decimal
+from unittest import TestCase
+
+from hummingbot.connector.exchange.beaxy.beaxy_in_flight_order import BeaxyInFlightOrder
+from hummingbot.core.event.events import OrderType, TradeType
+
+
+class BeaxyInFlightOrderTests(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.base_token = "BTC"
+        self.quote_token = "USDT"
+        self.trading_pair = f"{self.base_token}-{self.quote_token}"
+
+    def test_update_with_partial_trade_event(self):
+        order = BeaxyInFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal(10000),
+            amount=Decimal(1),
+            created_at=datetime.now()
+        )
+
+        trade_event_info = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "HBOT-buy-ETH-USDT-1638969314002553",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "partially_filled",
+            "size": "1.0",
+            "trade_size": "0.1",
+            "trade_price": "10050.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "0.1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "10.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.785Z"
+        }
+
+        update_result = order.update_with_trade_update(trade_event_info)
+
+        self.assertTrue(update_result)
+        self.assertFalse(order.is_done)
+        self.assertEqual("new", order.last_state)
+        self.assertEqual(Decimal(str(trade_event_info["trade_size"])), order.executed_amount_base)
+        expected_executed_quote_amount = Decimal(str(trade_event_info["trade_size"])) * Decimal(
+            str(trade_event_info["trade_price"]))
+        self.assertEqual(expected_executed_quote_amount, order.executed_amount_quote)
+        self.assertEqual(Decimal(trade_event_info["commission"]), order.fee_paid)
+        self.assertEqual(trade_event_info["commission_currency"], order.fee_asset)
+
+    def test_update_with_full_fill_trade_event(self):
+        order = BeaxyInFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal(10000),
+            amount=Decimal(1),
+            created_at=datetime.now()
+        )
+
+        trade_event_info = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "HBOT-buy-ETH-USDT-1638969314002553",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "partially_filled",
+            "size": "1.0",
+            "trade_size": "0.1",
+            "trade_price": "10050.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "0.1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "10.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.785Z"
+        }
+
+        update_result = order.update_with_trade_update(trade_event_info)
+
+        self.assertTrue(update_result)
+        self.assertFalse(order.is_done)
+        self.assertEqual("new", order.last_state)
+        self.assertEqual(Decimal(str(trade_event_info["trade_size"])), order.executed_amount_base)
+        expected_executed_quote_amount = Decimal(str(trade_event_info["trade_size"])) * Decimal(
+            str(trade_event_info["trade_price"]))
+        self.assertEqual(expected_executed_quote_amount, order.executed_amount_quote)
+        self.assertEqual(Decimal(trade_event_info["commission"]), order.fee_paid)
+        self.assertEqual(trade_event_info["commission_currency"], order.fee_asset)
+
+        complete_event_info = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "HBOT-buy-ETH-USDT-1638969314002553",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "completely_filled",
+            "size": "1.0",
+            "trade_size": "0.9",
+            "trade_price": "10060.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "50.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.786Z"
+        }
+
+        update_result = order.update_with_trade_update(complete_event_info)
+
+        self.assertTrue(update_result)
+        self.assertFalse(order.is_done)
+        self.assertEqual("new", order.last_state)
+        self.assertEqual(order.amount, order.executed_amount_base)
+        expected_executed_quote_amount += Decimal(str(complete_event_info["trade_size"])) * Decimal(
+            str(complete_event_info["trade_price"]))
+        self.assertEqual(expected_executed_quote_amount, order.executed_amount_quote)
+        self.assertEqual(Decimal(trade_event_info["commission"]) + Decimal(complete_event_info["commission"]),
+                         order.fee_paid)
+        self.assertEqual(trade_event_info["commission_currency"], order.fee_asset)
+
+    def test_update_with_repeated_timestamp_is_ignored(self):
+        order = BeaxyInFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal(10000),
+            amount=Decimal(1),
+            created_at=datetime.now()
+        )
+
+        trade_event_info = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "HBOT-buy-ETH-USDT-1638969314002553",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "partially_filled",
+            "size": "1.0",
+            "trade_size": "0.1",
+            "trade_price": "10050.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "0.1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "10.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.785Z"
+        }
+
+        update_result = order.update_with_trade_update(trade_event_info)
+
+        self.assertTrue(update_result)
+        self.assertFalse(order.is_done)
+        self.assertEqual("new", order.last_state)
+        self.assertEqual(Decimal(str(trade_event_info["trade_size"])), order.executed_amount_base)
+        expected_executed_quote_amount = Decimal(str(trade_event_info["trade_size"])) * Decimal(
+            str(trade_event_info["trade_price"]))
+        self.assertEqual(expected_executed_quote_amount, order.executed_amount_quote)
+        self.assertEqual(Decimal(trade_event_info["commission"]), order.fee_paid)
+        self.assertEqual(trade_event_info["commission_currency"], order.fee_asset)
+
+        complete_event_info = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "HBOT-buy-ETH-USDT-1638969314002553",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "completely_filled",
+            "size": "1.0",
+            "trade_size": "0.9",
+            "trade_price": "10060.0",
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "0.1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "50.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.785Z"
+        }
+
+        update_result = order.update_with_trade_update(complete_event_info)
+
+        self.assertFalse(update_result)
+        self.assertFalse(order.is_done)
+        self.assertEqual("new", order.last_state)
+        self.assertEqual(Decimal(str(trade_event_info["trade_size"])), order.executed_amount_base)
+        self.assertEqual(expected_executed_quote_amount, order.executed_amount_quote)
+        self.assertEqual(Decimal(trade_event_info["commission"]), order.fee_paid)
+        self.assertEqual(trade_event_info["commission_currency"], order.fee_asset)
+
+    def test_update_without_trade_info_is_ignored(self):
+        order = BeaxyInFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal(10000),
+            amount=Decimal(1),
+            created_at=datetime.now()
+        )
+
+        trade_event_info = {
+            "order_id": "EOID1",
+            "symbol": "BTCUSDT",
+            "wallet_id": "8576DAF5-E033-46C6-8EFD-385F8A4662F7",
+            "comment": "HBOT-buy-ETH-USDT-1638969314002553",
+            "time_in_force": "good_till_cancel",
+            "order_type": "limit",
+            "side": "buy",
+            "order_status": "partially_filled",
+            "size": "1.0",
+            "trade_size": None,
+            "trade_price": None,
+            "limit_price": "10000",
+            "stop_price": "None",
+            "filled_size": "0.1",
+            "average_price": "10000.0",
+            "open_time": "2021-12-08T13:15:14.779Z",
+            "close_time": "2021-12-08T13:15:14.787Z",
+            "commission": "10.0",
+            "commission_currency": "USDT",
+            "timestamp": "2021-12-08T13:15:14.785Z"
+        }
+
+        update_result = order.update_with_trade_update(trade_event_info)
+
+        self.assertFalse(update_result)
+        self.assertFalse(order.is_done)
+        self.assertEqual("new", order.last_state)
+        self.assertEqual(Decimal(0), order.executed_amount_base)
+        self.assertEqual(Decimal(0), order.executed_amount_quote)
+        self.assertEqual(Decimal(0), order.fee_paid)
+        self.assertIsNone(order.fee_asset)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The PR include the required changes to consider the fees informed by the exchange when a trade takes place, instead of estimating them.
This is more a proof of concept than a final change. Since Beaxy does not provide an event for trades (or order fills), this PR changes the fill logic to take fees from the order update event. The only problem is that in my tests the fee was always informed as being 0 (or None). But I could not validate that in the exchange because I don't have 2FA code to connect. QA please validate the fees registered by the client are in line with the fees in the exchange.
Partially closes #2084


**Tests performed by the developer**:
Added new unit tests for the order fill process and the fees registration


**Tips for QA testing**:
Please check that partial and complete fills are working correctly in Beaxy connector. Also verify if the fees are now being registered correctly.
Verify if the fees registered by the client are the same fees registered by the exchange (I could not validate this because I don't have Beaxy 2FA code)
