### PR TITLE
Fix/Avellaneda MM - Randomly appearing RunTimeWarning on the log pane

### DIFF
--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -120,7 +120,12 @@ cdef class TradingIntensityIndicator():
 
         # Fit the probability density function; reuse previously calculated parameters as initial values
         try:
-            params = curve_fit(lambda t, a, b: a*np.exp(-b*t), price_levels, lambdas_adj, p0=(self._alpha, self._kappa), method='dogbox')
+            params = curve_fit(lambda t, a, b: a*np.exp(-b*t),
+                               price_levels,
+                               lambdas_adj,
+                               p0=(self._alpha, self._kappa),
+                               method='dogbox',
+                               bounds=([0, 0], [np.inf, np.inf]))
 
             self._kappa = Decimal(str(params[0][1]))
             self._alpha = Decimal(str(params[0][0]))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- bounds specified for the scipy curve_fit parameters

**Tests performed by the developer**:

- ran the strategy with binance paper and the AXS-USDT - I wasn't able to reproduce the problem, but this change should be a fix for it
- ran unit tests

**Tips for QA testing**:

- as I was not able to reproduce the problem I couldn't verify whether the fix really changes anything in this case. However it's a fix regardless as the bounds need to be defined and based on the error messages this should be the reason. Please verify if it really solves the warning problem.
