### PR TITLE
add hook to detect wallet private keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ repos:
         files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
         types: [file]
 -   repo: https://github.com/CoinAlpha/git-hooks
-    rev: main
+    rev: ee15a9ed8b82be2b072fa347798eb0ff186ce1d4
     hooks:
     -   id: detect-wallet-private-key
         types: [file]
+        exclude: .json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,8 @@ repos:
     -   id: eslint
         files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
         types: [file]
+-   repo: https://github.com/CoinAlpha/git-hooks
+    rev: main
+    hooks:
+    -   id: detect-wallet-private-key
+        types: [file]

--- a/gateway/test/chains/ethereum/ethereum.controllers.test.ts
+++ b/gateway/test/chains/ethereum/ethereum.controllers.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
 afterEach(() => unpatch());
 
 const zeroAddress =
-  '0000000000000000000000000000000000000000000000000000000000000000';
+  '0000000000000000000000000000000000000000000000000000000000000000'; // noqa: mock
 
 describe('nonce', () => {
   it('return a nonce for a wallet', async () => {


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

[ch21177]

Created hook in new repo - https://github.com/CoinAlpha/git-hooks

**Note:**
Wallet private keys already exist in the project. That implies that there's going to be issues when those files are modified.
![hooks](https://user-images.githubusercontent.com/31972210/149223311-95119a0d-4cb4-4683-bd48-202303f9da0a.png)