### PR TITLE
fix/binance paper trade exchange name error

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_order_book_tracker.py
+++ b/hummingbot/connector/exchange/binance/binance_order_book_tracker.py
@@ -50,6 +50,13 @@ class BinanceOrderBookTracker(OrderBookTracker):
             cls._logger = logging.getLogger(__name__)
         return cls._logger
 
+    @property
+    def exchange_name(self) -> str:
+        if self._domain == "com":
+            return "binance"
+        else:
+            return f"binance_{self._domain}"
+
     def start(self):
         """
         Starts the background task that connects to the exchange and listens to order book updates and trade events.

--- a/test/hummingbot/connector/exchange/binance/test_binance_order_book_tracker.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_order_book_tracker.py
@@ -51,6 +51,15 @@ class BinanceOrderBookTrackerUnitTests(unittest.TestCase):
         else:
             raise NotImplementedError
 
+    def test_exchange_name(self):
+        self.assertEqual("binance", self.tracker.exchange_name)
+
+        us_tracker = BinanceOrderBookTracker(trading_pairs=[self.trading_pair],
+                                             domain="us",
+                                             throttler=self.throttler)
+
+        self.assertEqual("binance_us", us_tracker.exchange_name)
+
     def test_order_book_diff_router_trading_pair_not_found_append_to_saved_message_queue(self):
         expected_msg: OrderBookMessage = OrderBookMessage(
             message_type=OrderBookMessageType.DIFF,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix problem in Binance paper trade introduced with the Binance spot connector update.


**Tests performed by the developer**:
Added unit tests for the failing functionality.
Executed a pure market making strategy with the connector.


**Tips for QA testing**:
Try to reproduce the error as described in https://github.com/hummingbot/hummingbot/issues/5017


[ch22040]

