### PR TITLE
Fix/Avellaneda MM - fix reserved price calculation for the infinite time horizon

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -737,25 +737,20 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
             if self._execution_state.time_left is not None and self._execution_state.closing_time is not None:
                 # Avellaneda-Stoikov for a fixed timespan
                 time_left_fraction = Decimal(str(self._execution_state.time_left / self._execution_state.closing_time))
-
-                self._reserved_price = price - (q * self._gamma * mid_price_variance * time_left_fraction)
-
-                self._optimal_spread = self._gamma * mid_price_variance * time_left_fraction
-                self._optimal_spread += 2 * Decimal(1 + self._gamma / self._kappa).ln() / self._gamma
             else:
                 # Avellaneda-Stoikov for an infinite timespan
-                # gamma reversed to achieve unit consistency as for finite timeframe
-                q_max = 1
-                omega = Decimal(1 / 2) * ((1 / self._gamma) ** 2) * (vol ** 2) * Decimal((q_max + 1) ** 2)
-                offset_ask = Decimal(self._gamma) * Decimal(1 + ((1 - 2 * q) * ((1 / self._gamma) ** 2) * (vol ** 2)) / (2 * omega - (((1 / self._gamma) ** 2) * (q ** 2) * (vol ** 2)))).ln()
-                offset_bid = Decimal(self._gamma) * Decimal(1 + ((-1 - 2 * q) * ((1 / self._gamma) ** 2) * (vol ** 2)) / (2 * omega - (((1 / self._gamma) ** 2) * (q ** 2) * (vol ** 2)))).ln()
-                reserved_price_ask = price + offset_ask
-                reserved_price_bid = price + offset_bid
-                self._reserved_price = (reserved_price_ask + reserved_price_bid) / 2
+                # The equations in the paper for this contain a few mistakes
+                # - the units don't align with the rest of the paper
+                # - volatility cancells itself out completely
+                # - the risk factor gets partially cancelled
+                # The proposed solution is to use the same equation as for the constrained timespan but with
+                # a fixed time left
+                time_left_fraction = 1
 
-                # Derived from the asymptotic expansion in q for finite timeframe
-                self._optimal_spread = -(offset_ask + offset_bid) / (2 * q)
-                self._optimal_spread += 2 * Decimal(1 + self._gamma / self._kappa).ln() / self._gamma
+            self._reserved_price = price - (q * self._gamma * mid_price_variance * time_left_fraction)
+
+            self._optimal_spread = self._gamma * mid_price_variance * time_left_fraction
+            self._optimal_spread += 2 * Decimal(1 + self._gamma / self._kappa).ln() / self._gamma
 
             min_spread = price / 100 * Decimal(str(self._min_spread))
 

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -643,10 +643,10 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Check reserved_price, optimal_ask and optimal_bid
-        self.assertAlmostEqual(Decimal("100.0412277645493864745650970"), self.strategy.reserved_price, 2)
-        self.assertAlmostEqual(Decimal("8.364589434178470691479022122"), self.strategy.optimal_spread, 2)
-        self.assertAlmostEqual(Decimal("104.2235224816386218203046081"), self.strategy.optimal_ask, 2)
-        self.assertAlmostEqual(Decimal("95.85893304746015112882558594"), self.strategy.optimal_bid, 2)
+        self.assertAlmostEqual(Decimal("99.93581983304362835415781320"), self.strategy.reserved_price, 2)
+        self.assertAlmostEqual(Decimal("8.048452121090869051292856409"), self.strategy.optimal_spread, 2)
+        self.assertAlmostEqual(Decimal("103.9600458935890628798042414"), self.strategy.optimal_ask, 2)
+        self.assertAlmostEqual(Decimal("95.91159377249819382851138500"), self.strategy.optimal_bid, 2)
 
     def test_calculate_reserved_price_and_optimal_spread_timeframe_infinite(self):
         # Init params
@@ -664,10 +664,10 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
         # Check reserved_price, optimal_ask and optimal_bid
-        self.assertAlmostEqual(Decimal("100.0679427754527770932063714"), self.strategy.reserved_price, 2)
-        self.assertAlmostEqual(Decimal("7.266095956433297082007557171"), self.strategy.optimal_spread, 2)
-        self.assertAlmostEqual(Decimal("103.7009907536694256342101500"), self.strategy.optimal_ask, 2)
-        self.assertAlmostEqual(Decimal("96.43489479723612855220259281"), self.strategy.optimal_bid, 2)
+        self.assertAlmostEqual(Decimal("99.93618286107057944269726650"), self.strategy.reserved_price, 2)
+        self.assertAlmostEqual(Decimal("6.870924306831992724076648358"), self.strategy.optimal_spread, 2)
+        self.assertAlmostEqual(Decimal("103.3716450144865758047355907"), self.strategy.optimal_ask, 2)
+        self.assertAlmostEqual(Decimal("96.50072070765458308065894232"), self.strategy.optimal_bid, 2)
 
     def test_create_proposal_based_on_order_override(self):
         # Initial check for empty order_override
@@ -744,8 +744,8 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.strategy.measure_order_book_liquidity()
         self.strategy.calculate_reserved_price_and_optimal_spread()
 
-        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.08959064919181206598124149685'), Decimal('0.1791812983836241319624829937'), Decimal('0.2687719476906450244239016419')]
-        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.08959064919181206598124149685'), Decimal('0.1791812983836241319624829937'), Decimal('0.2687719476906450244239016419')]
+        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.3716424871860017289514480476'), Decimal('0.7432849743720034579028960952'), Decimal('1.114927461558005186854344143')]
+        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.3716424871860017289514480476'), Decimal('0.7432849743720034579028960952'), Decimal('1.114927461558005186854344143')]
 
         bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Replacement of the equations for the infinite timeframe. The solution described in the paper seems to contain mistakes, and therefore is unusable. It has been replaced with the equations for constrained timeframes, but with dependency on time neutralized.

**Tests performed by the developer**:

- Ran the unit tests
- Ran the strategy with binance paper and ETH-USDT to see if the strategy is able to achieve it's target portfolio allocation

**Tips for QA testing**:

- The arbitrary values in the Avellaneda unit tests come from a measurement and estimation of a stochastic process. They have to be taken as they are without further explanation.
