### PR TITLE
fix/incorrect trade id in order filled event

### DIFF
--- a/hummingbot/connector/connector_base.pyx
+++ b/hummingbot/connector/connector_base.pyx
@@ -1,3 +1,4 @@
+import time
 from decimal import Decimal
 from typing import (
     Dict,
@@ -14,7 +15,7 @@ from hummingbot.core.event.events import (
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.network_iterator import NetworkIterator
 from hummingbot.connector.in_flight_order_base import InFlightOrderBase
-from hummingbot.connector.utils import TradeFillOrderDetails, split_hb_trading_pair
+from hummingbot.connector.utils import split_hb_trading_pair, TradeFillOrderDetails
 from hummingbot.core.event.events import OrderFilledEvent
 from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.core.utils.estimate_fee import estimate_fee
@@ -444,3 +445,10 @@ cdef class ConnectorBase(NetworkIterator):
         # Assume (market, exchange_trade_id, trading_pair) are unique. Also order has to be recorded in Order table
         return (not TradeFillOrderDetails(self.display_name, exchange_trade_id, trading_pair) in self._current_trade_fills) and \
                (exchange_order_id in set(self._exchange_order_ids.keys()))
+
+    def _time(self) -> float:
+        """
+        Method created to enable tests to mock the machine time
+        :return: The machine time (time.time())
+        """
+        return time.time()

--- a/hummingbot/connector/derivative/dydx_perpetual/dydx_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/dydx_perpetual/dydx_perpetual_derivative.py
@@ -8,8 +8,8 @@ from decimal import Decimal
 from typing import Any, AsyncIterable, Dict, List, Optional
 
 from dateutil.parser import parse as dateparse
-
 from dydx3.errors import DydxApiError
+
 from hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_auth import DydxPerpetualAuth
 from hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_client_wrapper import DydxPerpetualClientWrapper
 from hummingbot.connector.derivative.dydx_perpetual.dydx_perpetual_fill_report import DydxPerpetualFillReport
@@ -28,14 +28,27 @@ from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.transaction_tracker import TransactionTracker
 from hummingbot.core.event.event_listener import EventListener
-from hummingbot.core.event.events import (BuyOrderCompletedEvent, BuyOrderCreatedEvent, FundingInfo,
-                                          FundingPaymentCompletedEvent, MarketEvent, MarketOrderFailureEvent,
-                                          OrderCancelledEvent, OrderExpiredEvent, OrderFilledEvent, OrderType,
-                                          PositionAction, PositionMode, PositionSide, SellOrderCompletedEvent,
-                                          SellOrderCreatedEvent, TradeType)
-from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    FundingInfo,
+    FundingPaymentCompletedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
+    OrderExpiredEvent,
+    OrderFilledEvent,
+    OrderType,
+    PositionAction,
+    PositionMode,
+    PositionSide,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+    TradeType,
+)
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
@@ -718,7 +731,7 @@ class DydxPerpetualDerivative(ExchangeBase, PerpetualTrading):
                         new_price,
                         new_amount,
                         AddedToCostTradeFee(flat_fees=[TokenAmount(tracked_order.fee_asset, new_fee)]),
-                        tracked_order.client_order_id,
+                        str(int(self._time() * 1e6)),
                         self._leverage[tracked_order.trading_pair],
                         tracked_order.position,
                     ),

--- a/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
@@ -381,7 +381,7 @@ cdef class BeaxyExchange(ExchangeBase):
                             execute_price,
                             execute_amount_diff,
                         ),
-                        exchange_trade_id=exchange_order_id,
+                        exchange_trade_id=str(int(self._time() * 1e6)),
                     )
                     self.logger().info(f'Filled {execute_amount_diff} out of {tracked_order.amount} of the '
                                        f'{order_type_description} order {client_order_id}.')
@@ -417,7 +417,7 @@ cdef class BeaxyExchange(ExchangeBase):
                                 execute_price,
                                 execute_amount_diff,
                             ),
-                            exchange_trade_id=exchange_order_id,
+                            exchange_trade_id=str(int(self._time() * 1e6)),
                         )
                         self.logger().info(f'Filled {execute_amount_diff} out of {tracked_order.amount} of the '
                                            f'{order_type_description} order {client_order_id}.')
@@ -905,7 +905,7 @@ cdef class BeaxyExchange(ExchangeBase):
                                                          execute_price,
                                                          execute_amount_diff,
                                                      ),
-                                                     exchange_trade_id=exchange_order_id
+                                                     exchange_trade_id=str(int(self._time() * 1e6)),
                                                  ))
 
                     elif order_status == 'completely_filled':
@@ -937,7 +937,7 @@ cdef class BeaxyExchange(ExchangeBase):
                                     execute_price,
                                     execute_amount_diff,
                                 ),
-                                exchange_trade_id=exchange_order_id,
+                                exchange_trade_id=str(int(self._time() * 1e6)),
                             )
                             self.logger().info(f'Filled {execute_amount_diff} out of {tracked_order.amount} of the '
                                                f'{order_type_description} order {client_order_id}.')

--- a/hummingbot/connector/exchange/bittrex/bittrex_exchange.pyx
+++ b/hummingbot/connector/exchange/bittrex/bittrex_exchange.pyx
@@ -402,7 +402,8 @@ cdef class BittrexExchange(ExchangeBase):
                                                  tracked_order.trade_type,
                                                  executed_price,
                                                  executed_amount_diff
-                                             )
+                                             ),
+                                             exchange_trade_id=str(int(self._time() * 1e6))
                                          ))
 
                 if order_state == "CLOSED":

--- a/hummingbot/connector/exchange/blocktane/blocktane_exchange.pyx
+++ b/hummingbot/connector/exchange/blocktane/blocktane_exchange.pyx
@@ -1,47 +1,50 @@
-import re
-import time
 import asyncio
-import aiohttp
-import copy
 import json
 import logging
-import pandas as pd
-import traceback
+import time
 from decimal import Decimal
-from libc.stdint cimport int64_t
-from threading import Lock
+from typing import Any, AsyncIterable, Dict, List, Optional, Tuple
+
+import aiohttp
 from async_timeout import timeout
-from typing import Optional, List, Dict, Any, AsyncIterable, Tuple
+from libc.stdint cimport int64_t
 
-
-from hummingbot.core.clock cimport Clock
-from hummingbot.connector.exchange_base cimport ExchangeBase
-from hummingbot.connector.exchange_base import s_decimal_NaN
-from hummingbot.core.utils.estimate_fee import build_trade_fee
-from hummingbot.logger import HummingbotLogger
-from hummingbot.connector.trading_rule cimport TradingRule
-from hummingbot.core.network_iterator import NetworkStatus
-from hummingbot.core.data_type.order_book cimport OrderBook
-from hummingbot.core.data_type.limit_order import LimitOrder
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.connector.exchange.blocktane.blocktane_auth import BlocktaneAuth
-from hummingbot.core.data_type.transaction_tracker import TransactionTracker
-from hummingbot.core.data_type.cancellation_result import CancellationResult
-from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
-from hummingbot.core.event.events import (
-    MarketEvent,
-    OrderType,
-    OrderFilledEvent,
-    TradeType,
-    BuyOrderCompletedEvent,
-    SellOrderCompletedEvent, OrderCancelledEvent, MarketTransactionFailureEvent,
-    MarketOrderFailureEvent, SellOrderCreatedEvent, BuyOrderCreatedEvent
-)
-from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
 from hummingbot.connector.exchange.blocktane.blocktane_in_flight_order import BlocktaneInFlightOrder
 from hummingbot.connector.exchange.blocktane.blocktane_order_book_tracker import BlocktaneOrderBookTracker
 from hummingbot.connector.exchange.blocktane.blocktane_user_stream_tracker import BlocktaneUserStreamTracker
-from hummingbot.connector.exchange.blocktane.blocktane_utils import convert_from_exchange_trading_pair, convert_to_exchange_trading_pair, split_trading_pair
+from hummingbot.connector.exchange.blocktane.blocktane_utils import (
+    convert_from_exchange_trading_pair,
+    convert_to_exchange_trading_pair,
+    split_trading_pair,
+)
+from hummingbot.connector.exchange_base cimport ExchangeBase
+from hummingbot.connector.exchange_base import s_decimal_NaN
+from hummingbot.connector.trading_rule cimport TradingRule
+from hummingbot.core.clock cimport Clock
+from hummingbot.core.data_type.cancellation_result import CancellationResult
+from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
+from hummingbot.core.data_type.transaction_tracker import TransactionTracker
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
+    MarketTransactionFailureEvent,
+    OrderCancelledEvent,
+    OrderFilledEvent,
+    OrderType,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+    TradeType,
+)
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
+from hummingbot.logger import HummingbotLogger
 
 bm_logger = None
 s_decimal_0 = Decimal(0)
@@ -401,7 +404,8 @@ cdef class BlocktaneExchange(ExchangeBase):
                                                      tracked_order.trade_type,
                                                      executed_price,
                                                      executed_amount_base_diff
-                                                 )
+                                                 ),
+                                                 exchange_trade_id=str(int(self._time() * 1e6))
                                              ))
 
                     if order_state == "done":
@@ -533,7 +537,8 @@ cdef class BlocktaneExchange(ExchangeBase):
                                                      tracked_order.trade_type,
                                                      executed_price,
                                                      executed_amount_base_diff
-                                                 )
+                                                 ),
+                                                 exchange_trade_id=str(int(self._time() * 1e6))
                                              ))
 
                     if order_status == "done":  # FILL(COMPLETE)

--- a/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
+++ b/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
@@ -14,8 +14,8 @@ from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_in_flight_order imp
 from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_order_book_tracker import CoinbaseProOrderBookTracker
 from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_user_stream_tracker import CoinbaseProUserStreamTracker
 from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_utils import (
+    build_coinbase_pro_web_assistant_factory,
     CoinbaseProRESTRequest,
-    build_coinbase_pro_web_assistant_factory
 )
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.trading_rule cimport TradingRule
@@ -480,7 +480,7 @@ cdef class CoinbaseProExchange(ExchangeBase):
                     ),
                     # Coinbase Pro's websocket stream tags events with order_id rather than trade_id
                     # Using order_id here for easier data validation
-                    exchange_trade_id=exchange_order_id,
+                    exchange_trade_id=str(int(self._time() * 1e6)),
                 )
                 self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of the "
                                    f"{order_type_description} order {client_order_id}.")

--- a/hummingbot/connector/exchange/crypto_com/crypto_com_exchange.py
+++ b/hummingbot/connector/exchange/crypto_com/crypto_com_exchange.py
@@ -675,7 +675,7 @@ class CryptoComExchange(ExchangeBase):
                 AddedToCostTradeFee(
                     flat_fees=[TokenAmount(trade_msg["fee_currency"], Decimal(str(trade_msg["fee"])))]
                 ),
-                exchange_trade_id=trade_msg["order_id"]
+                exchange_trade_id=str(trade_msg.get("trade_id", int(self._time() * 1e6)))
             )
         )
         if math.isclose(tracked_order.executed_amount_base, tracked_order.amount) or \

--- a/hummingbot/connector/exchange/digifinex/digifinex_exchange.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_exchange.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-# import json
-# import aiohttp
 import math
 import time
 from decimal import Decimal
@@ -9,7 +7,6 @@ from typing import Any, AsyncIterable, Dict, List, Optional
 
 from hummingbot.connector.exchange.digifinex import digifinex_utils
 from hummingbot.connector.exchange.digifinex.digifinex_global import DigifinexGlobal
-# from hummingbot.connector.exchange.digifinex.digifinex_auth import DigifinexAuth
 from hummingbot.connector.exchange.digifinex.digifinex_in_flight_order import DigifinexInFlightOrder
 from hummingbot.connector.exchange.digifinex.digifinex_order_book_tracker import DigifinexOrderBookTracker
 from hummingbot.connector.exchange.digifinex.digifinex_user_stream_tracker import DigifinexUserStreamTracker
@@ -17,7 +14,6 @@ from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
-# from hummingbot.connector.exchange.digifinex import digifinex_constants as Constants
 from hummingbot.core.data_type.common import OpenOrder
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
@@ -656,7 +652,7 @@ class DigifinexExchange(ExchangeBase):
                 delta_trade_amount,
                 estimate_fee(self.name, tracked_order.order_type in [OrderType.LIMIT, OrderType.LIMIT_MAKER]),
                 # TradeFee(0.0, [(trade_msg["fee_currency"], Decimal(str(trade_msg["fee"])))]),
-                exchange_trade_id='N/A'
+                exchange_trade_id=str(int(self._time() * 1e6))
             )
         )
         if math.isclose(tracked_order.executed_amount_base, tracked_order.amount) or \

--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import time
-
 from decimal import Decimal
 from typing import (
     Any,
@@ -12,23 +11,25 @@ from typing import (
 )
 
 import ujson
-
 from libc.stdint cimport int64_t
 
 import hummingbot.connector.exchange.huobi.huobi_constants as CONSTANTS
-
 from hummingbot.connector.exchange.huobi.huobi_auth import HuobiAuth
 from hummingbot.connector.exchange.huobi.huobi_in_flight_order import HuobiInFlightOrder
 from hummingbot.connector.exchange.huobi.huobi_order_book_tracker import HuobiOrderBookTracker
+from hummingbot.connector.exchange.huobi.huobi_user_stream_tracker import HuobiUserStreamTracker
 from hummingbot.connector.exchange.huobi.huobi_utils import (
     build_api_factory,
     convert_to_exchange_trading_pair,
     get_new_client_order_id,
 )
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.connector.trading_rule cimport TradingRule
 from hummingbot.core.clock cimport Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.transaction_tracker import TransactionTracker
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
@@ -43,10 +44,6 @@ from hummingbot.core.event.events import (
     SellOrderCreatedEvent,
     TradeType,
 )
-from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
-from hummingbot.connector.exchange_base import ExchangeBase
-from hummingbot.connector.exchange.huobi.huobi_user_stream_tracker import HuobiUserStreamTracker
-from hummingbot.connector.trading_rule cimport TradingRule
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_call_scheduler import AsyncCallScheduler
 from hummingbot.core.utils.async_utils import (
@@ -470,7 +467,7 @@ cdef class HuobiExchange(ExchangeBase):
                         # Unique exchange trade ID not available in client order status
                         # But can use validate an order using exchange order ID:
                         # https://huobiapi.github.io/docs/spot/v1/en/#query-order-by-order-id
-                        exchange_trade_id=exchange_order_id
+                        exchange_trade_id=str(int(self._time() * 1e6))
                     )
                     self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of the "
                                        f"order {tracked_order.client_order_id}.")
@@ -689,7 +686,7 @@ cdef class HuobiExchange(ExchangeBase):
                                              TokenAmount(tracked_order.fee_asset, Decimal(trade_event["transactFee"]))
                                          ]
                                      ),
-                                     exchange_trade_id=order_id
+                                     exchange_trade_id=str(trade_event["tradeId"])
                                  ))
 
     @property

--- a/hummingbot/connector/exchange/k2/k2_exchange.py
+++ b/hummingbot/connector/exchange/k2/k2_exchange.py
@@ -685,7 +685,7 @@ class K2Exchange(ExchangeBase):
                 Decimal(str(trade_msg["price"])),
                 current_executed_amount,
                 AddedToCostTradeFee(flat_fees=[TokenAmount(fee_currency, Decimal(str(trade_msg["fee"])))]),
-                exchange_trade_id=trade_msg["orderid"]
+                exchange_trade_id=str(int(self._time() * 1e6))
             )
         )
         if math.isclose(tracked_order.executed_amount_base, tracked_order.amount) or \

--- a/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
+++ b/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
@@ -1,12 +1,9 @@
-import aiohttp
 import asyncio
 import copy
 import json
 import logging
 import math
 import sys
-
-from async_timeout import timeout
 from decimal import Decimal
 from typing import (
     Any,
@@ -16,6 +13,8 @@ from typing import (
     Optional,
 )
 
+import aiohttp
+from async_timeout import timeout
 from libc.stdint cimport int64_t
 
 from hummingbot.connector.exchange.liquid.constants import Constants
@@ -31,6 +30,7 @@ from hummingbot.core.clock cimport Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book cimport OrderBook
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.transaction_tracker import TransactionTracker
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
@@ -45,7 +45,6 @@ from hummingbot.core.event.events import (
     SellOrderCreatedEvent,
     TradeType,
 )
-from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import (
     safe_ensure_future,
@@ -623,7 +622,7 @@ cdef class LiquidExchange(ExchangeBase):
                         execute_price,
                         execute_amount_diff,
                     ),
-                    exchange_trade_id=exchange_order_id,
+                    exchange_trade_id=str(int(self._time() * 1e6)),
                 )
                 self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of the "
                                    f"{order_type_description} order {client_order_id}.")
@@ -750,6 +749,7 @@ cdef class LiquidExchange(ExchangeBase):
                 updated = tracked_order.update_with_trade_update(content)
 
                 if updated:
+                    trade_id = content.get("trade_id", None)
                     self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of the "
                                        f"{tracked_order.order_type_description} order {tracked_order.client_order_id} "
                                        f"according to Liquid user stream.")
@@ -765,7 +765,9 @@ cdef class LiquidExchange(ExchangeBase):
                                              AddedToCostTradeFee(
                                                  flat_fees=[TokenAmount(tracked_order.fee_asset, fee_diff)]
                                              ),
-                                             exchange_trade_id=tracked_order.exchange_order_id
+                                             exchange_trade_id=(str(trade_id)
+                                                                if trade_id
+                                                                else str(int(self._time() * 1e6)))
                                          ))
 
                 if event_status == "filled":

--- a/hummingbot/connector/exchange/loopring/loopring_exchange.pyx
+++ b/hummingbot/connector/exchange/loopring/loopring_exchange.pyx
@@ -1,59 +1,54 @@
-import aiohttp
 import asyncio
-import binascii
-import json
-import time
-import uuid
-import traceback
-import urllib
 import hashlib
+import json
+import logging
+import time
+import urllib
+from decimal import *
 from typing import (
     Any,
     Dict,
     List,
     Optional
 )
-import math
-import logging
-from decimal import *
+
+import aiohttp
+from ethsnarks_loopring import FQ, SNARK_SCALAR_FIELD
+from ethsnarks_loopring import PoseidonEdDSA
+from ethsnarks_loopring import poseidon_params, poseidon
 from libc.stdint cimport int64_t
+
+from hummingbot.connector.exchange.loopring.loopring_api_token_configuration_data_source import \
+    LoopringAPITokenConfigurationDataSource
+from hummingbot.connector.exchange.loopring.loopring_auth import LoopringAuth
+from hummingbot.connector.exchange.loopring.loopring_in_flight_order cimport LoopringInFlightOrder
+from hummingbot.connector.exchange.loopring.loopring_order_book_tracker import LoopringOrderBookTracker
+from hummingbot.connector.exchange.loopring.loopring_user_stream_tracker import LoopringUserStreamTracker
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.connector.trading_rule cimport TradingRule
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book cimport OrderBook
-from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.event.event_listener cimport EventListener
-from hummingbot.connector.exchange_base import ExchangeBase
-from hummingbot.connector.exchange.loopring.loopring_auth import LoopringAuth
-from hummingbot.connector.exchange.loopring.loopring_order_book_tracker import LoopringOrderBookTracker
-from hummingbot.connector.exchange.loopring.loopring_api_order_book_data_source import LoopringAPIOrderBookDataSource
-from hummingbot.connector.exchange.loopring.loopring_api_token_configuration_data_source import LoopringAPITokenConfigurationDataSource
-from hummingbot.connector.exchange.loopring.loopring_user_stream_tracker import LoopringUserStreamTracker
-from hummingbot.core.utils.async_utils import (
-    safe_ensure_future,
-)
 from hummingbot.core.event.events import (
-    MarketEvent,
     BuyOrderCompletedEvent,
-    SellOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
     OrderCancelledEvent,
     OrderExpiredEvent,
     OrderFilledEvent,
-    MarketOrderFailureEvent,
-    BuyOrderCreatedEvent,
+    OrderType,
+    SellOrderCompletedEvent,
     SellOrderCreatedEvent,
     TradeType,
-    OrderType,
 )
-from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
-from hummingbot.logger import HummingbotLogger
-from hummingbot.connector.exchange.loopring.loopring_in_flight_order cimport LoopringInFlightOrder
-from hummingbot.connector.trading_rule cimport TradingRule
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import estimate_fee
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
-
-from ethsnarks_loopring import PoseidonEdDSA
-from ethsnarks_loopring import FQ, SNARK_SCALAR_FIELD
-from ethsnarks_loopring import poseidon_params, poseidon
+from hummingbot.logger import HummingbotLogger
 
 s_logger = None
 s_decimal_0 = Decimal(0)
@@ -621,7 +616,7 @@ cdef class LoopringExchange(ExchangeBase):
                                                       AddedToCostTradeFee(
                                                           flat_fees=[TokenAmount(tracked_order.fee_asset, new_fee)]
                                                       ),
-                                                      tracked_order.client_order_id))
+                                                      str(int(self._time() * 1e6))))
             elif market_event == MarketEvent.OrderExpired:
                 self.c_trigger_event(ORDER_EXPIRED_EVENT,
                                      OrderExpiredEvent(self._current_timestamp,

--- a/hummingbot/connector/exchange/mexc/mexc_exchange.py
+++ b/hummingbot/connector/exchange/mexc/mexc_exchange.py
@@ -395,7 +395,7 @@ class MexcExchange(ExchangeBase):
                                 execute_amount_diff,
                                 execute_price,
                             ),
-                            exchange_trade_id=exchange_order_id
+                            exchange_trade_id=str(int(self._time() * 1e6))
                         )
                         self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of the "
                                            f"order {tracked_order.client_order_id}.")
@@ -546,7 +546,7 @@ class MexcExchange(ExchangeBase):
                                                     execute_price,
                                                     execute_amount_diff,
                                                     current_fee,
-                                                    exchange_trade_id=tracked_order.exchange_order_id))
+                                                    exchange_trade_id=str(int(self._time() * 1e6))))
         if order_status == "FILLED":
             fee_paid, fee_currency = await self.get_deal_detail_fee(tracked_order.exchange_order_id)
             tracked_order.fee_paid = fee_paid

--- a/hummingbot/connector/exchange/okex/okex_exchange.pyx
+++ b/hummingbot/connector/exchange/okex/okex_exchange.pyx
@@ -1,10 +1,7 @@
-import aiohttp
 import asyncio
-from decimal import Decimal
-from libc.stdint cimport int64_t
 import logging
-import pandas as pd
 import time
+from decimal import Decimal
 from typing import (
     Any,
     AsyncIterable,
@@ -12,49 +9,49 @@ from typing import (
     List,
     Optional,
 )
-import ujson
 
+import aiohttp
+import ujson
+from libc.stdint cimport int64_t
+
+from hummingbot.connector.exchange.okex.constants import *
+from hummingbot.connector.exchange.okex.okex_auth import OKExAuth
+from hummingbot.connector.exchange.okex.okex_in_flight_order import OkexInFlightOrder
+from hummingbot.connector.exchange.okex.okex_order_book_tracker import OkexOrderBookTracker
+from hummingbot.connector.exchange.okex.okex_user_stream_tracker import OkexUserStreamTracker
+from hummingbot.connector.exchange_base import (
+    ExchangeBase,
+    s_decimal_NaN)
+from hummingbot.connector.trading_rule cimport TradingRule
 from hummingbot.core.clock cimport Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book cimport OrderBook
 from hummingbot.core.data_type.order_book_tracker import OrderBookTrackerDataSourceType
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
 from hummingbot.core.data_type.transaction_tracker import TransactionTracker
 from hummingbot.core.event.events import (
-    MarketEvent,
     BuyOrderCompletedEvent,
-    SellOrderCompletedEvent,
-    OrderFilledEvent,
-    OrderCancelledEvent,
     BuyOrderCreatedEvent,
-    SellOrderCreatedEvent,
-    MarketTransactionFailureEvent,
+    MarketEvent,
     MarketOrderFailureEvent,
+    MarketTransactionFailureEvent,
+    OrderCancelledEvent,
+    OrderFilledEvent,
     OrderType,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
     TradeType
 )
-from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_call_scheduler import AsyncCallScheduler
 from hummingbot.core.utils.async_utils import (
     safe_ensure_future,
     safe_gather,
 )
-from hummingbot.logger import HummingbotLogger
-from hummingbot.connector.exchange.okex.okex_api_order_book_data_source import OkexAPIOrderBookDataSource
-from hummingbot.connector.exchange.okex.okex_auth import OKExAuth
-from hummingbot.connector.exchange.okex.okex_in_flight_order import OkexInFlightOrder
-from hummingbot.connector.exchange.okex.okex_order_book_tracker import OkexOrderBookTracker
-from hummingbot.connector.trading_rule cimport TradingRule
-from hummingbot.connector.exchange_base import (
-    ExchangeBase,
-    s_decimal_NaN)
-from hummingbot.connector.exchange.okex.okex_user_stream_tracker import OkexUserStreamTracker
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.core.utils.estimate_fee import estimate_fee
-
-from hummingbot.connector.exchange.okex.constants import *
-
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
+from hummingbot.logger import HummingbotLogger
 
 hm_logger = None
 s_decimal_0 = Decimal(0)
@@ -425,7 +422,7 @@ cdef class OkexExchange(ExchangeBase):
                         execute_amount_diff,
                         execute_price,
                     ),
-                    exchange_trade_id=exchange_order_id
+                    exchange_trade_id=str(int(self._time() * 1e6))
                 )
                 self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of the "
                                    f"order {tracked_order.client_order_id}.")
@@ -580,7 +577,9 @@ cdef class OkexExchange(ExchangeBase):
                                                                   execute_price,
                                                                   execute_amount_diff,
                                                                   current_fee,
-                                                                  exchange_trade_id=order_id))
+                                                                  exchange_trade_id=str(data.get("tradeId",
+                                                                                                 int(self._time() * 1e6))
+                                                                                        )))
 
                         if order_status == "filled":
                             tracked_order.last_state = order_status

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -1,70 +1,54 @@
 # distutils: sources=['hummingbot/core/cpp/Utils.cpp', 'hummingbot/core/cpp/LimitOrder.cpp', 'hummingbot/core/cpp/OrderExpirationEntry.cpp']
 
 import asyncio
-from collections import (
-    deque, defaultdict
-)
-from cpython cimport PyObject
-from decimal import Decimal
-from libcpp cimport bool as cppbool
-from libcpp.vector cimport vector
 import math
-import pandas as pd
 import random
+from collections import defaultdict, deque
+from decimal import Decimal
 from typing import (
     Dict,
     List,
     Optional,
     Tuple,
 )
-from cython.operator cimport(
-    postincrement as inc,
-    dereference as deref,
-    address
-)
-from hummingbot.core.Utils cimport(
-    getIteratorFromReverseIterator,
-    reverse_iterator
-)
-from hummingbot.core.utils.async_utils import (
-    safe_ensure_future,
-)
+
+from cpython cimport PyObject
+from cython.operator cimport address, dereference as deref, postincrement as inc
+from libcpp cimport bool as cppbool
+from libcpp.vector cimport vector
+
+from hummingbot.connector.budget_checker import BudgetChecker
+from hummingbot.connector.exchange.paper_trade.market_config import AssetType, MarketConfig
+from hummingbot.connector.exchange.paper_trade.trading_pair import TradingPair
+from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.core.clock cimport Clock
-from hummingbot.core.clock import (
-    Clock
-)
+from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.composite_order_book import CompositeOrderBook
 from hummingbot.core.data_type.composite_order_book cimport CompositeOrderBook
-from hummingbot.core.data_type.limit_order cimport c_create_limit_order_from_cpp_limit_order
 from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.data_type.limit_order cimport c_create_limit_order_from_cpp_limit_order
 from hummingbot.core.data_type.order_book cimport OrderBook
 from hummingbot.core.data_type.order_book_tracker import OrderBookTracker
-from hummingbot.core.event.events import (
-    MarketEvent,
-    OrderType,
-    TradeType,
-    BuyOrderCompletedEvent,
-    OrderFilledEvent,
-    SellOrderCompletedEvent,
-    MarketOrderFailureEvent,
-    OrderBookEvent,
-    BuyOrderCreatedEvent,
-    SellOrderCreatedEvent,
-    OrderBookTradeEvent,
-    OrderCancelledEvent
-)
 from hummingbot.core.event.event_listener cimport EventListener
-from hummingbot.core.network_iterator import NetworkStatus
-from hummingbot.connector.exchange_base import ExchangeBase
-from hummingbot.connector.exchange.paper_trade.trading_pair import TradingPair
-from hummingbot.core.utils.estimate_fee import estimate_fee, build_trade_fee
-
-from .market_config import (
-    MarketConfig,
-    AssetType
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketEvent,
+    MarketOrderFailureEvent,
+    OrderFilledEvent,
+    OrderBookEvent,
+    OrderBookTradeEvent,
+    OrderCancelledEvent,
+    OrderType,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+    TradeType,
 )
-from ...budget_checker import BudgetChecker
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.Utils cimport getIteratorFromReverseIterator, reverse_iterator
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.utils.estimate_fee import estimate_fee, build_trade_fee
 
 ptm_logger = None
 s_decimal_0 = Decimal(0)
@@ -629,7 +613,8 @@ cdef class PaperTradeExchange(ExchangeBase):
                 OrderType.LIMIT,
                 <object> cpp_limit_order_ptr.getPrice(),
                 <object> cpp_limit_order_ptr.getQuantity(),
-                fees
+                fees,
+                exchange_trade_id=str(int(self._time() * 1e6))
             ))
 
         self.c_trigger_event(
@@ -693,7 +678,8 @@ cdef class PaperTradeExchange(ExchangeBase):
                 OrderType.LIMIT,
                 <object> cpp_limit_order_ptr.getPrice(),
                 <object> cpp_limit_order_ptr.getQuantity(),
-                fees
+                fees,
+                exchange_trade_id=str(int(self._time() * 1e6))
             ))
 
         self.c_trigger_event(

--- a/hummingbot/core/event/events.py
+++ b/hummingbot/core/event/events.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
@@ -175,11 +174,21 @@ class OrderFilledEvent(NamedTuple):
                                                  order_type: OrderType,
                                                  trade_fee: TradeFeeBase,
                                                  order_book_rows: List[OrderBookRow],
-                                                 exchange_trade_id: str = "") -> List["OrderFilledEvent"]:
+                                                 exchange_trade_id: Optional[str] = None) -> List["OrderFilledEvent"]:
+        if exchange_trade_id is None:
+            exchange_trade_id = order_id
         return [
-            OrderFilledEvent(timestamp, order_id, trading_pair, trade_type, order_type,
-                             Decimal(r.price), Decimal(r.amount), trade_fee, exchange_trade_id=exchange_trade_id)
-            for r in order_book_rows
+            OrderFilledEvent(
+                timestamp,
+                order_id,
+                trading_pair,
+                trade_type,
+                order_type,
+                Decimal(row.price),
+                Decimal(row.amount),
+                trade_fee,
+                exchange_trade_id=f"{exchange_trade_id}_{index}")
+            for index, row in enumerate(order_book_rows)
         ]
 
     @classmethod

--- a/test/hummingbot/connector/test_markets_recorder.py
+++ b/test/hummingbot/connector/test_markets_recorder.py
@@ -155,7 +155,7 @@ class MarketsRecorderTests(TestCase):
             price=Decimal(1010),
             amount=create_event.amount,
             trade_fee=AddedToCostTradeFee(),
-            exchange_trade_id=create_event.exchange_order_id
+            exchange_trade_id="TradeId1"
         )
 
         recorder._did_fill_order(MarketEvent.OrderFilled.value, self, fill_event)

--- a/test/hummingbot/core/test_events.py
+++ b/test/hummingbot/core/test_events.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+from unittest import TestCase
+
+from hummingbot.core.data_type.order_book_row import OrderBookRow
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
+from hummingbot.core.event.events import OrderFilledEvent, OrderType, TradeType
+
+
+class OrderFilledEventTests(TestCase):
+
+    def test_fill_events_created_from_order_book_rows_have_unique_trade_ids(self):
+        rows = [OrderBookRow(Decimal(1000), Decimal(1), 1), OrderBookRow(Decimal(1001), Decimal(2), 2)]
+        fill_events = OrderFilledEvent.order_filled_events_from_order_book_rows(
+            timestamp=1640001112.223,
+            order_id="OID1",
+            trading_pair="COINALPHA-HBOT",
+            trade_type=TradeType.BUY,
+            order_type=OrderType.LIMIT,
+            trade_fee=AddedToCostTradeFee(),
+            order_book_rows=rows
+        )
+
+        self.assertEqual("OID1_0", fill_events[0].exchange_trade_id)
+        self.assertEqual("OID1_1", fill_events[1].exchange_trade_id)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR fixes the issue https://github.com/hummingbot/hummingbot/issues/5037
It updates the creation of OrderFilledEvent instances in all the connectors that were doing that without specifying the trade id, or using the order id as trade id.
Impacted connectors:
- DyDx perpetual
- Beaxy
- Bitfinex
- Bittrex
- Blocktane
- Coinbase Pro
- Crypto com
- Digifinex
- Huobi
- K2
- Kucoin
- Liquid
- Loopring
- Mexc
- Okex

It also impacts the paper trade logic.

**Tests performed by the developer**:
Added new test for the changes in the paper trade logic.
All existing unit tests running in green.


**Tips for QA testing**:
The scenario for which the error was happening was when any of the mentioned connections received more than one fill for the same order (ie.: at least one partial fill before the full fill)


[ch22310]