### PR TITLE
Feat/Avellaneda - A multiplier to normalize the risk factor for all assets

### DIFF
--- a/hummingbot/strategy/__utils__/trailing_indicators/instant_volatility.py
+++ b/hummingbot/strategy/__utils__/trailing_indicators/instant_volatility.py
@@ -7,7 +7,7 @@ class InstantVolatilityIndicator(BaseTrailingIndicator):
         super().__init__(sampling_length, processing_length)
 
     def _indicator_calculation(self) -> float:
-        # The variance should be calculated between ticks and not with a mean of the whole buffer
+        # The standard deviation should be calculated between ticks and not with a mean of the whole buffer
         # Otherwise if the asset is trending, changing the length of the buffer would result in a greater volatility as more ticks would be further away from the mean
         # which is a nonsense result. If volatility of the underlying doesn't change in fact, changing the length of the buffer shouldn't change the result.
         np_sampling_buffer = self._sampling_buffer.get_as_numpy_array()

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -110,10 +110,7 @@ cdef class TradingIntensityIndicator():
         price_levels = sorted(price_levels, reverse=True)
 
         for price_level in price_levels:
-            if len(lambdas) == 0:
-                lambdas += [trades_consolidated[price_level]]
-            else:
-                lambdas += [trades_consolidated[price_level]]
+            lambdas += [trades_consolidated[price_level]]
 
         # Adjust to be able to calculate log
         lambdas_adj = [10**-10 if x==0 else x for x in lambdas]

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -48,7 +48,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _end_time
         double _min_spread
         object _q_adjustment_factor
-        object _reserved_price
+        object _reservation_price
         object _optimal_spread
         object _optimal_bid
         object _optimal_ask
@@ -82,7 +82,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
     cdef bint c_is_algorithm_ready(self)
     cdef bint c_is_algorithm_changed(self)
     cdef c_measure_order_book_liquidity(self)
-    cdef c_calculate_reserved_price_and_optimal_spread(self)
+    cdef c_calculate_reservation_price_and_optimal_spread(self)
     cdef object c_calculate_target_inventory(self)
     cdef object c_calculate_inventory(self)
     cdef c_did_complete_order(self, object order_completed_event)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -138,7 +138,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._end_time = end_time
         self._min_spread = min_spread
         self._latest_parameter_calculation_vol = s_decimal_zero
-        self._reserved_price = s_decimal_zero
+        self._reservation_price = s_decimal_zero
         self._optimal_spread = s_decimal_zero
         self._optimal_ask = s_decimal_zero
         self._optimal_bid = s_decimal_zero
@@ -323,12 +323,12 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._eta = value
 
     @property
-    def reserved_price(self):
-        return self._reserved_price
+    def reservation_price(self):
+        return self._reservation_price
 
-    @reserved_price.setter
-    def reserved_price(self, value):
-        self._reserved_price = value
+    @reservation_price.setter
+    def reservation_price(self, value):
+        self._reservation_price = value
 
     @property
     def optimal_spread(self):
@@ -494,7 +494,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
     def market_status_data_frame(self, market_trading_pair_tuples: List[MarketTradingPairTuple]) -> pd.DataFrame:
         markets_data = []
         markets_columns = ["Exchange", "Market", "Best Bid", "Best Ask", f"MidPrice"]
-        markets_columns.append('Reserved Price')
+        markets_columns.append('Reservation Price')
         markets_columns.append('Optimal Spread')
         market_books = [(self._market_info.market, self._market_info.trading_pair)]
         for market, trading_pair in market_books:
@@ -507,7 +507,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                 float(bid_price),
                 float(ask_price),
                 float(ref_price),
-                round(self._reserved_price, 5),
+                round(self._reservation_price, 5),
                 round(self._optimal_spread, 5),
             ])
         return pd.DataFrame(data=markets_data, columns=markets_columns).replace(np.nan, '', regex=True)
@@ -636,8 +636,8 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         proposal = None
         # Trading is allowed
         if self._create_timestamp <= self._current_timestamp:
-            # 1. Calculate reserved price and optimal spread from gamma, alpha, kappa and volatility
-            self.c_calculate_reserved_price_and_optimal_spread()
+            # 1. Calculate reservation price and optimal spread from gamma, alpha, kappa and volatility
+            self.c_calculate_reservation_price_and_optimal_spread()
             # 2. Check if calculated prices make sense
             if self._optimal_bid > 0 and self._optimal_ask > 0:
                 # 3. Create base order proposals
@@ -707,15 +707,15 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
     def measure_order_book_liquidity(self):
         return self.c_measure_order_book_liquidity()
 
-    cdef c_calculate_reserved_price_and_optimal_spread(self):
+    cdef c_calculate_reservation_price_and_optimal_spread(self):
         cdef:
             ExchangeBase market = self._market_info.market
 
         # Current mid price
         price = self.get_price()
 
-        # The amount of stocks owned - q - has to be in relative units, not absolute, because changing the portfolio size shouldn't change the reserved price
-        # The reserved price should concern itself only with the strategy performance, i.e. amount of stocks relative to the target
+        # The amount of stocks owned - q - has to be in relative units, not absolute, because changing the portfolio size shouldn't change the reservation price
+        # The reservation price should concern itself only with the strategy performance, i.e. amount of stocks relative to the target
         inventory = Decimal(str(self.c_calculate_inventory()))
 
         if inventory == 0:
@@ -723,13 +723,12 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
         q_target = Decimal(str(self.c_calculate_target_inventory()))
         q = (market.get_balance(self.base_asset) - q_target) / (inventory)
-        # Volatility has to be in absolute values (prices) because in calculation of reserved price it's not multiplied by the current price, therefore
+        # Volatility has to be in absolute values (prices) because in calculation of reservation price it's not multiplied by the current price, therefore
         # it can't be a percentage. The result of the multiplication has to be an absolute price value because it's being subtracted from the current price
         vol = self.get_volatility()
-        mid_price_variance = vol ** 2
 
         # order book liquidity - kappa and alpha have to represent absolute values because the second member of the optimal spread equation has to be an absolute price
-        # and from the reserved price calculation we know that gamma's unit is not absolute price
+        # and from the reservation price calculation we know that gamma's unit is not absolute price
         if all((self._gamma, self._kappa)) and self._alpha != 0 and self._kappa > 0 and vol != 0:
             if self._execution_state.time_left is not None and self._execution_state.closing_time is not None:
                 # Avellaneda-Stoikov for a fixed timespan
@@ -744,9 +743,16 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                 # a fixed time left
                 time_left_fraction = 1
 
-            self._reserved_price = price - (q * self._gamma * mid_price_variance * time_left_fraction)
+            # Here seems to be another mistake in the paper
+            # It doesn't make sense to use mid_price_variance because its units would be absolute price units ^2, yet that side of the equation is subtracted
+            # from the actual mid price of the asset in absolute price units
+            # gamma / risk_factor gains a meaning of a fraction (percentage) of the volatility (standard deviation between ticks) to be subtraced from the
+            # current mid price
+            # This leads to normalization of the risk_factor and will guaranetee consistent behavior on all price ranges of the asset, and across assets
 
-            self._optimal_spread = self._gamma * mid_price_variance * time_left_fraction
+            self._reservation_price = price - (q * self._gamma * vol * time_left_fraction)
+
+            self._optimal_spread = self._gamma * vol * time_left_fraction
             self._optimal_spread += 2 * Decimal(1 + self._gamma / self._kappa).ln() / self._gamma
 
             min_spread = price / 100 * Decimal(str(self._min_spread))
@@ -754,8 +760,8 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
             max_limit_bid = price - min_spread / 2
             min_limit_ask = price + min_spread / 2
 
-            self._optimal_ask = max(self._reserved_price + self._optimal_spread / 2, min_limit_ask)
-            self._optimal_bid = min(self._reserved_price - self._optimal_spread / 2, max_limit_bid)
+            self._optimal_ask = max(self._reservation_price + self._optimal_spread / 2, min_limit_ask)
+            self._optimal_bid = min(self._reservation_price - self._optimal_spread / 2, max_limit_bid)
 
             # This is not what the algorithm will use as proposed bid and ask. This is just the raw output.
             # Optimal bid and optimal ask prices will be used
@@ -763,13 +769,13 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                 self.logger().info(f"q={q:.4f} | "
                                    f"vol={vol:.10f}")
                 self.logger().info(f"mid_price={price:.10f} | "
-                                   f"reserved_price={self._reserved_price:.10f} | "
+                                   f"reservation_price={self._reservation_price:.10f} | "
                                    f"optimal_spread={self._optimal_spread:.10f}")
-                self.logger().info(f"optimal_bid={(price-(self._reserved_price - self._optimal_spread / 2)) / price * 100:.4f}% | "
-                                   f"optimal_ask={((self._reserved_price + self._optimal_spread / 2) - price) / price * 100:.4f}%")
+                self.logger().info(f"optimal_bid={(price-(self._reservation_price - self._optimal_spread / 2)) / price * 100:.4f}% | "
+                                   f"optimal_ask={((self._reservation_price + self._optimal_spread / 2) - price) / price * 100:.4f}%")
 
-    def calculate_reserved_price_and_optimal_spread(self):
-        return self.c_calculate_reserved_price_and_optimal_spread()
+    def calculate_reservation_price_and_optimal_spread(self):
+        return self.c_calculate_reservation_price_and_optimal_spread()
 
     cdef object c_calculate_target_inventory(self):
         cdef:
@@ -1337,9 +1343,9 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         spread = Decimal(str(self.c_get_spread()))
 
         best_ask = mid_price + spread / 2
-        new_ask = self._reserved_price + self._optimal_spread / 2
+        new_ask = self._reservation_price + self._optimal_spread / 2
         best_bid = mid_price - spread / 2
-        new_bid = self._reserved_price - self._optimal_spread / 2
+        new_bid = self._reservation_price - self._optimal_spread / 2
 
         vol = self.get_volatility()
         mid_price_variance = vol ** 2
@@ -1348,7 +1354,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
             df_header = pd.DataFrame([('mid_price',
                                        'best_bid',
                                        'best_ask',
-                                       'reserved_price',
+                                       'reservation_price',
                                        'optimal_spread',
                                        'optimal_bid',
                                        'optimal_ask',
@@ -1358,6 +1364,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
                                        'target_inv',
                                        'time_left_fraction',
                                        'mid_price std_dev',
+                                       'risk_factor',
                                        'gamma',
                                        'alpha',
                                        'kappa',
@@ -1375,12 +1382,12 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         df = pd.DataFrame([(mid_price,
                             best_bid,
                             best_ask,
-                            self._reserved_price,
+                            self._reservation_price,
                             self._optimal_spread,
                             self._optimal_bid,
                             self._optimal_ask,
-                            (mid_price - (self._reserved_price - self._optimal_spread / 2)) / mid_price,
-                            ((self._reserved_price + self._optimal_spread / 2) - mid_price) / mid_price,
+                            (mid_price - (self._reservation_price - self._optimal_spread / 2)) / mid_price,
+                            ((self._reservation_price + self._optimal_spread / 2) - mid_price) / mid_price,
                             market.get_balance(self.base_asset),
                             self.c_calculate_target_inventory(),
                             time_left_fraction,

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making.py
@@ -626,7 +626,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
         self.assertAlmostEqual(1.0028041271598158, alpha, 5)
         self.assertAlmostEqual(0.00038015903945779595, kappa, 5)
 
-    def test_calculate_reserved_price_and_optimal_spread_timeframe_constrained(self):
+    def test_calculate_reservation_price_and_optimal_spread_timeframe_constrained(self):
         # Init params
         self.strategy.execution_timeframe = "daily_between_times"
         self.strategy.start_time = (datetime.datetime.fromtimestamp(self.strategy.current_timestamp) - datetime.timedelta(minutes=30)).time()
@@ -640,15 +640,15 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Execute measurements and calculations
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
-        # Check reserved_price, optimal_ask and optimal_bid
-        self.assertAlmostEqual(Decimal("99.93581983304362835415781320"), self.strategy.reserved_price, 2)
-        self.assertAlmostEqual(Decimal("8.048452121090869051292856409"), self.strategy.optimal_spread, 2)
-        self.assertAlmostEqual(Decimal("103.9600458935890628798042414"), self.strategy.optimal_ask, 2)
-        self.assertAlmostEqual(Decimal("95.91159377249819382851138500"), self.strategy.optimal_bid, 2)
+        # Check reservation_price, optimal_ask and optimal_bid
+        self.assertAlmostEqual(Decimal("99.95404856954350080330559626"), self.strategy.reservation_price, 2)
+        self.assertAlmostEqual(Decimal("8.10312337812488556961420323"), self.strategy.optimal_spread, 2)
+        self.assertAlmostEqual(Decimal("104.0056102586059435881126979"), self.strategy.optimal_ask, 2)
+        self.assertAlmostEqual(Decimal("95.90248688048105801849849464"), self.strategy.optimal_bid, 2)
 
-    def test_calculate_reserved_price_and_optimal_spread_timeframe_infinite(self):
+    def test_calculate_reservation_price_and_optimal_spread_timeframe_infinite(self):
         # Init params
         self.strategy.execution_timeframe = "infinite"
         self.strategy.gamma = self.risk_factor_infinite
@@ -661,13 +661,13 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Execute measurements and calculations
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
-        # Check reserved_price, optimal_ask and optimal_bid
-        self.assertAlmostEqual(Decimal("99.93618286107057944269726650"), self.strategy.reserved_price, 2)
-        self.assertAlmostEqual(Decimal("6.870924306831992724076648358"), self.strategy.optimal_spread, 2)
-        self.assertAlmostEqual(Decimal("103.3716450144865758047355907"), self.strategy.optimal_ask, 2)
-        self.assertAlmostEqual(Decimal("96.50072070765458308065894232"), self.strategy.optimal_bid, 2)
+        # Check reservation_price, optimal_ask and optimal_bid
+        self.assertAlmostEqual(Decimal("99.95896878169542000413199532"), self.strategy.reservation_price, 2)
+        self.assertAlmostEqual(Decimal("6.939263378124513371978331884"), self.strategy.optimal_spread, 2)
+        self.assertAlmostEqual(Decimal("103.4286004707576766901211613"), self.strategy.optimal_ask, 2)
+        self.assertAlmostEqual(Decimal("96.48933709263316331814282938"), self.strategy.optimal_bid, 2)
 
     def test_create_proposal_based_on_order_override(self):
         # Initial check for empty order_override
@@ -720,10 +720,10 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Execute measurements and calculations
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
-        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.03710408601585762674091538545'), Decimal('0.07420817203171525348183077090'), Decimal('0.1113122580475728802227461564')]
-        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.03710408601585762674091538545'), Decimal('0.07420817203171525348183077090'), Decimal('0.1113122580475728802227461564')]
+        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.03471008344015021195989165942'), Decimal('0.07420817203171525348183077090'), Decimal('0.1113122580475728802227461564')]
+        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.03471008344015021195989165942'), Decimal('0.07420817203171525348183077090'), Decimal('0.1113122580475728802227461564')]
 
         bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
 
@@ -742,10 +742,10 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Execute measurements and calculations
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
-        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.3716424871860017289514480476'), Decimal('0.7432849743720034579028960952'), Decimal('1.114927461558005186854344143')]
-        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.3716424871860017289514480476'), Decimal('0.7432849743720034579028960952'), Decimal('1.114927461558005186854344143')]
+        expected_bid_spreads = [Decimal('0E-28'), Decimal('0.1170211083866360679794947748'), Decimal('0.2340422167732721359589895496'), Decimal('0.3510633251599082039384843244')]
+        expected_ask_spreads = [Decimal('0E-28'), Decimal('0.1170211083866360679794947748'), Decimal('0.2340422167732721359589895496'), Decimal('0.3510633251599082039384843244')]
 
         bid_level_spreads, ask_level_spreads = self.strategy._get_level_spreads()
 
@@ -764,7 +764,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # Test(1) Check order_levels default = 0
         empty_proposal = ([], [])
@@ -801,7 +801,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         expected_order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair,
                                                                            self.order_amount)
@@ -825,7 +825,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # (1) Default
         expected_order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair,
@@ -918,7 +918,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # Create a basic proposal.
         order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair, self.order_amount)
@@ -946,7 +946,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # Create a basic proposal.
         order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair, self.order_amount)
@@ -975,7 +975,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # Create a basic proposal.
         order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair, self.order_amount)
@@ -1028,7 +1028,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # Create a basic proposal.
         order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair, self.order_amount)
@@ -1086,7 +1086,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         # Create a basic proposal.
         order_amount: Decimal = self.market.quantize_order_amount(self.trading_pair, self.order_amount)
@@ -1314,7 +1314,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
 
@@ -1381,7 +1381,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
 
@@ -1433,7 +1433,7 @@ class AvellanedaMarketMakingUnitTests(unittest.TestCase):
 
         # Prepare market variables and parameters for calculation
         self.strategy.measure_order_book_liquidity()
-        self.strategy.calculate_reserved_price_and_optimal_spread()
+        self.strategy.calculate_reservation_price_and_optimal_spread()
 
         self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

The paper seems to contain another mistake. Fixing this will by itself lead to normalization of the risk_factor for all price ranges and across all assets. There was therefore in fact no need to implement any special feature. The risk_factor now is a fraction / percentage / multiplier of the asset's volatility (defined as a standard deviation), its typical value range is now between 0 and 100 for all assets, although it still remains unrestricted and it's possible to set it to even 1000000 if desired.

**Tests performed by the developer**:

- Ran tests with binance paper for multiple assets with various price ranges and equal settings, including risk_factors. In all cases the strategy was able to reach its target portfolio. I also plotted the important variables and visually verified the strategy behavior for all the tested assets.
- Ran unit tests

**Tips for QA testing**:

- As before with this strategy, the values in tests have to be taken as they are because they come from an estimation and measurement of a stochastic process.
