### PR TITLE
Fix/RingBuffer's c_get_as_numpy_array() doesn't return the correct array

### DIFF
--- a/hummingbot/strategy/__utils__/ring_buffer.pxd
+++ b/hummingbot/strategy/__utils__/ring_buffer.pxd
@@ -5,13 +5,12 @@ cimport numpy as np
 cdef class RingBuffer:
     cdef:
         np.float64_t[:] _buffer
-        int64_t _start_index
-        int64_t _stop_index
+        int64_t _delimiter
         int64_t _length
         bint _is_full
 
     cdef void c_add_value(self, float val)
-    cdef void c_increment_index(self)
+    cdef void c_increment_delimiter(self)
     cdef double c_get_last_value(self)
     cdef bint c_is_full(self)
     cdef bint c_is_empty(self)

--- a/hummingbot/strategy/__utils__/ring_buffer.pyx
+++ b/hummingbot/strategy/__utils__/ring_buffer.pyx
@@ -68,7 +68,8 @@ cdef class RingBuffer:
         if not self._is_full:
             indexes = np.arange(self._start_index, stop=self._stop_index, dtype=np.int16)
         else:
-            indexes = np.arange(self._start_index, stop=self._start_index + self._length,
+            indexes = np.arange((self._start_index - 1) % self._length,
+                                stop=(self._start_index - 1) % self._length + self._length,
                                 dtype=np.int16) % self._length
         return np.asarray(self._buffer)[indexes]
 

--- a/hummingbot/strategy/__utils__/ring_buffer.pyx
+++ b/hummingbot/strategy/__utils__/ring_buffer.pyx
@@ -16,30 +16,28 @@ cdef class RingBuffer:
     def __cinit__(self, int length):
         self._length = length
         self._buffer = np.zeros(length, dtype=np.float64)
-        self._start_index = 0
-        self._stop_index = 0
+        self._delimiter = 0
         self._is_full = False
 
     def __dealloc__(self):
         self._buffer = None
 
     cdef void c_add_value(self, float val):
-        self._buffer[self._stop_index] = val
-        self.c_increment_index()
+        self._buffer[self._delimiter] = val
+        self.c_increment_delimiter()
 
-    cdef void c_increment_index(self):
-        self._stop_index = (self._stop_index + 1) % self._length
-        if(self._start_index == self._stop_index):
+    cdef void c_increment_delimiter(self):
+        self._delimiter = (self._delimiter + 1) % self._length
+        if not self._is_full and self._delimiter == 0:
             self._is_full = True
-            self._start_index = (self._start_index + 1) % self._length
 
     cdef bint c_is_empty(self):
-        return (not self._is_full) and (self._start_index==self._stop_index)
+        return (not self._is_full) and (0==self._delimiter)
 
     cdef double c_get_last_value(self):
         if self.c_is_empty():
             return np.nan
-        return self._buffer[self._stop_index-1]
+        return self._buffer[self._delimiter-1]
 
     cdef bint c_is_full(self):
         return self._is_full
@@ -66,18 +64,16 @@ cdef class RingBuffer:
         cdef np.ndarray[np.int16_t, ndim=1] indexes
 
         if not self._is_full:
-            indexes = np.arange(self._start_index, stop=self._stop_index, dtype=np.int16)
+            indexes = np.arange(0, stop=self._delimiter, dtype=np.int16)
         else:
-            indexes = np.arange((self._start_index - 1) % self._length,
-                                stop=(self._start_index - 1) % self._length + self._length,
+            indexes = np.arange(self._delimiter, stop=self._delimiter + self._length,
                                 dtype=np.int16) % self._length
         return np.asarray(self._buffer)[indexes]
 
     def __init__(self, length):
         self._length = length
         self._buffer = np.zeros(length, dtype=np.double)
-        self._start_index = 0
-        self._stop_index = 0
+        self._delimiter = 0
         self._is_full = False
 
     def add_value(self, val):

--- a/test/hummingbot/strategy/utils/test_ring_buffer.py
+++ b/test/hummingbot/strategy/utils/test_ring_buffer.py
@@ -95,3 +95,15 @@ class RingBufferTest(unittest.TestCase):
         value = Decimal(3.141592653)
         self.buffer.add_value(value)
         self.assertAlmostEqual(float(value), self.buffer.get_last_value(), 6)
+
+    def test_numpy_array(self):
+        buffer = RingBuffer(4)
+
+        for i in range(3):
+            buffer.add_value(i)
+
+        self.assertTrue(np.array_equal(buffer.get_as_numpy_array(), np.array([0, 1, 2])))
+        buffer.add_value(3)
+        self.assertTrue(np.array_equal(buffer.get_as_numpy_array(), np.array([0, 1, 2, 3])))
+        buffer.add_value(4)
+        self.assertTrue(np.array_equal(buffer.get_as_numpy_array(), np.array([1, 2, 3, 4])))

--- a/test/hummingbot/strategy/utils/trailing_indicators/test_instant_volatility.py
+++ b/test/hummingbot/strategy/utils/trailing_indicators/test_instant_volatility.py
@@ -19,4 +19,4 @@ class InstantVolatilityTest(unittest.TestCase):
         for sample in samples:
             self.indicator.add_sample(sample)
 
-        self.assertAlmostEqual(self.indicator.current_value, 14.06933307647705, 4)
+        self.assertAlmostEqual(self.indicator.current_value, 14.068197250366211, 4)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

After adding a sample to the RingBuffer, start and stop indexes are updated. When calling the c_get_as_numpy_array() afterwards, the method doesn't account for the shifted indexes (in case the buffer is already filled). 
As a result it returns an array with wrong data.

**Tests performed by the developer**:

* Printed c_get_as_numpy_array()'s output and compared it to the actual content of the buffer and the start and stop indices
* Ran unit tests

