### PR TITLE
fix / quickstart with password

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -16,13 +16,13 @@ from hummingbot.client.config.config_helpers import (
     create_yml_files,
     read_system_configs_from_yml
 )
+from hummingbot.core.event.event_listener import EventListener
 from hummingbot import (
     init_logging,
     check_dev_mode,
     chdir_to_data_directory
 )
 from hummingbot.client.ui import login_prompt
-from hummingbot.client.ui.stdout_redirection import patch_stdout
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.core.utils.async_utils import safe_gather
 
@@ -53,23 +53,28 @@ async def main():
 
     hb = HummingbotApplication.main_application()
 
-    with patch_stdout(log_field=hb.app.log_field):
-        dev_mode = check_dev_mode()
-        if dev_mode:
-            hb.app.log("Running from dev branches. Full remote logging will be enabled.")
-        init_logging("hummingbot_logs.yml",
-                     override_log_level=global_config_map.get("log_level").value,
-                     dev_mode=dev_mode)
-        tasks: List[Coroutine] = [hb.run()]
-        if global_config_map.get("debug_console").value:
-            if not hasattr(__builtins__, "help"):
-                import _sitebuiltins
-                __builtins__.help = _sitebuiltins._Helper()
+    class UIStartListener(EventListener):
+        def __call__(self, _):
+            asyncio.create_task(self.ui_start_handler())
 
-            from hummingbot.core.management.console import start_management_console
-            management_port: int = detect_available_port(8211)
-            tasks.append(start_management_console(locals(), host="localhost", port=management_port))
-        await safe_gather(*tasks)
+        @staticmethod
+        async def ui_start_handler():
+            dev_mode = check_dev_mode()
+            if dev_mode:
+                hb.app.log("Running from dev branches. Full remote logging will be enabled.")
+
+    hb.app.add_listener(hb.app.Event.START, UIStartListener())
+
+    tasks: List[Coroutine] = [hb.run()]
+    if global_config_map.get("debug_console").value:
+        if not hasattr(__builtins__, "help"):
+            import _sitebuiltins
+            __builtins__.help = _sitebuiltins._Helper()
+
+        from hummingbot.core.management.console import start_management_console
+        management_port: int = detect_available_port(8211)
+        tasks.append(start_management_console(locals(), host="localhost", port=management_port))
+    await safe_gather(*tasks)
 
 
 if __name__ == "__main__":

--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -63,7 +63,10 @@ async def main():
             if dev_mode:
                 hb.app.log("Running from dev branches. Full remote logging will be enabled.")
 
-    hb.app.add_listener(hb.app.Event.START, UIStartListener())
+    # The listener needs to have a named variable for keeping reference, since the event listener system
+    # uses weak references to remove unneeded listeners.
+    start_listener: UIStartListener = UIStartListener()
+    hb.app.add_listener(hb.app.Event.START, start_listener)
 
     tasks: List[Coroutine] = [hb.run()]
     if global_config_map.get("debug_console").value:

--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -112,12 +112,16 @@ async def quick_start(args):
                 await write_config_to_yml(hb.strategy_name, hb.strategy_file_name)
                 hb.start(global_config_map.get("log_level").value)
 
-    hb.app.add_listener(hb.app.Event.START, UIStartListener())
+    # The listener needs to have a named variable for keeping reference, since the event listener system
+    # uses weak references to remove unneeded listeners.
+    start_listener: UIStartListener = UIStartListener()
+    hb.app.add_listener(hb.app.Event.START, start_listener)
 
     tasks: List[Coroutine] = [hb.run()]
     if global_config_map.get("debug_console").value:
         management_port: int = detect_available_port(8211)
         tasks.append(start_management_console(locals(), host="localhost", port=management_port))
+
     await safe_gather(*tasks)
 
 

--- a/hummingbot/client/ui/hummingbot_cli.py
+++ b/hummingbot/client/ui/hummingbot_cli.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import asyncio
+from contextlib import ExitStack
+from enum import Enum
 import logging
 import threading
 from prompt_toolkit.application import Application
@@ -11,6 +13,7 @@ from prompt_toolkit.layout.processors import BeforeInput, PasswordProcessor
 from prompt_toolkit.key_binding import KeyBindings
 from typing import Callable, Optional, Dict, Any, TYPE_CHECKING
 
+from hummingbot import init_logging, check_dev_mode
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
 from hummingbot.client.ui.layout import (
@@ -26,9 +29,12 @@ from hummingbot.client.ui.layout import (
     create_live_field,
     create_tab_button,
 )
+from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.tab.data_types import CommandTab
 from hummingbot.client.ui.interface_utils import start_timer, start_process_monitor, start_trade_monitor
+from hummingbot.client.ui.stdout_redirection import patch_stdout
 from hummingbot.client.ui.style import load_style
+from hummingbot.core.pubsub import PubSub
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
 
@@ -42,12 +48,16 @@ def _handle_exception_patch(self, loop, context):
 Application._handle_exception = _handle_exception_patch
 
 
-class HummingbotCLI:
+class HummingbotCLI(PubSub):
+    class Event(Enum):
+        START = 1
+
     def __init__(self,
                  input_handler: Callable,
                  bindings: KeyBindings,
                  completer: Completer,
                  command_tabs: Dict[str, CommandTab]):
+        super().__init__()
         self.command_tabs = command_tabs
         self.search_field = create_search_field()
         self.input_field = create_input_field(completer=completer)
@@ -79,16 +89,31 @@ class HummingbotCLI:
         self.input_event = None
         self.hide_input = False
 
+        # stdout redirection stack
+        self._stdout_redirect_context: ExitStack = ExitStack()
+
         # start ui tasks
         loop = asyncio.get_event_loop()
         loop.create_task(start_timer(self.timer))
         loop.create_task(start_process_monitor(self.process_usage))
         loop.create_task(start_trade_monitor(self.trade_monitor))
 
+    def did_start_ui(self):
+        self._stdout_redirect_context.enter_context(patch_stdout(log_field=self.log_field))
+
+        log_level = global_config_map.get("log_level").value
+        dev_mode = check_dev_mode()
+        init_logging("hummingbot_logs.yml",
+                     override_log_level=log_level,
+                     dev_mode=dev_mode)
+
+        self.trigger_event(HummingbotCLI.Event.START, None)
+
     async def run(self):
         self.app = Application(layout=self.layout, full_screen=True, key_bindings=self.bindings, style=load_style(),
                                mouse_support=True, clipboard=PyperclipClipboard())
-        await self.app.run_async()
+        await self.app.run_async(pre_run=self.did_start_ui)
+        self._stdout_redirect_context.close()
 
     def accept(self, buff):
         self.pending_input = self.input_field.text.strip()

--- a/hummingbot/client/ui/hummingbot_cli.py
+++ b/hummingbot/client/ui/hummingbot_cli.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from contextlib import ExitStack
-from enum import Enum
 import logging
 import threading
 from prompt_toolkit.application import Application
@@ -34,6 +33,7 @@ from hummingbot.client.tab.data_types import CommandTab
 from hummingbot.client.ui.interface_utils import start_timer, start_process_monitor, start_trade_monitor
 from hummingbot.client.ui.stdout_redirection import patch_stdout
 from hummingbot.client.ui.style import load_style
+from hummingbot.core.event.events import HummingbotUIEvent
 from hummingbot.core.pubsub import PubSub
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
@@ -49,9 +49,6 @@ Application._handle_exception = _handle_exception_patch
 
 
 class HummingbotCLI(PubSub):
-    class Event(Enum):
-        START = 1
-
     def __init__(self,
                  input_handler: Callable,
                  bindings: KeyBindings,
@@ -107,7 +104,7 @@ class HummingbotCLI(PubSub):
                      override_log_level=log_level,
                      dev_mode=dev_mode)
 
-        self.trigger_event(HummingbotCLI.Event.START, None)
+        self.trigger_event(HummingbotUIEvent.Start, self)
 
     async def run(self):
         self.app = Application(layout=self.layout, full_screen=True, key_bindings=self.bindings, style=load_style(),

--- a/hummingbot/core/event/events.py
+++ b/hummingbot/core/event/events.py
@@ -33,6 +33,10 @@ class OrderBookEvent(Enum):
     TradeEvent = 901
 
 
+class HummingbotUIEvent(Enum):
+    Start = 1
+
+
 class TradeType(Enum):
     BUY = 1
     SELL = 2

--- a/test/hummingbot/client/ui/test_hummingbot_cli.py
+++ b/test/hummingbot/client/ui/test_hummingbot_cli.py
@@ -6,6 +6,7 @@ from hummingbot.client.tab.data_types import CommandTab
 from hummingbot.client.ui.hummingbot_cli import HummingbotCLI
 from hummingbot.client.ui.custom_widgets import CustomTextArea
 from hummingbot.core.event.event_listener import EventListener
+from hummingbot.core.event.events import HummingbotUIEvent
 
 
 class HummingbotCLITest(unittest.TestCase):
@@ -113,7 +114,7 @@ class HummingbotCLITest(unittest.TestCase):
                 self.mock()
 
         handler: UIStartHandler = UIStartHandler()
-        self.app.add_listener(self.app.Event.START, handler)
+        self.app.add_listener(HummingbotUIEvent.Start, handler)
         self.app.did_start_ui()
 
         mock_config_map.get.assert_called()

--- a/test/hummingbot/client/ui/test_hummingbot_cli.py
+++ b/test/hummingbot/client/ui/test_hummingbot_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 from hummingbot.client.tab.data_types import CommandTab
 from hummingbot.client.ui.hummingbot_cli import HummingbotCLI
 from hummingbot.client.ui.custom_widgets import CustomTextArea
+from hummingbot.core.event.event_listener import EventListener
 
 
 class HummingbotCLITest(unittest.TestCase):
@@ -98,3 +99,24 @@ class HummingbotCLITest(unittest.TestCase):
         self.app.tab_navigate_right()
         self.assertFalse(tab1.is_selected)
         self.assertTrue(tab2.is_selected)
+
+    @patch("hummingbot.client.ui.hummingbot_cli.global_config_map")
+    @patch("hummingbot.client.ui.hummingbot_cli.check_dev_mode")
+    @patch("hummingbot.client.ui.hummingbot_cli.init_logging")
+    def test_did_start_ui(self, mock_init_logging: MagicMock, mock_dev_mode: MagicMock, mock_config_map: MagicMock):
+        class UIStartHandler(EventListener):
+            def __init__(self):
+                super().__init__()
+                self.mock = MagicMock()
+
+            def __call__(self, _):
+                self.mock()
+
+        handler: UIStartHandler = UIStartHandler()
+        self.app.add_listener(self.app.Event.START, handler)
+        self.app.did_start_ui()
+
+        mock_config_map.get.assert_called()
+        mock_dev_mode.assert_called()
+        mock_init_logging.assert_called()
+        handler.mock.assert_called()


### PR DESCRIPTION
Fixed crash-at-start issue when using hummingbot_quickstart.py with password.

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This patch moves the stdout redirection logic to after the prompt_toolkit UI initiation, which guarantees the stdout redirection wouldn't redirect the UI rendering.


**Tests performed by the developer**:
* Tested with `hummingbot_quickstart.py` with password.
* Tested with `hummingbot.py`.


**Tips for QA testing**:
* Make sure to test `hummingbot_quickstart.py` with an autostart strategy and password as well.

[ch22722]