### PR TITLE
Fix/TWAP - default values don't make sense

### DIFF
--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -46,7 +46,7 @@ class TwapTradeStrategy(StrategyPyBase):
                  is_buy: bool = True,
                  target_asset_amount: Decimal = Decimal("1.0"),
                  order_step_size: Decimal = Decimal("1.0"),
-                 order_price: Optional[Decimal] = None,
+                 order_price: Decimal = None,
                  order_delay_time: float = 10.0,
                  execution_state: ConditionalExecutionState = RunAlwaysExecutionState(),
                  cancel_order_wait_time: Optional[float] = 60.0,
@@ -83,11 +83,9 @@ class TwapTradeStrategy(StrategyPyBase):
         self._first_order = True
         self._previous_timestamp = 0
         self._last_timestamp = 0
-        self._order_price = Decimal("NaN")
+        self._order_price = order_price
         self._execution_state = execution_state
 
-        if order_price is not None:
-            self._order_price = order_price
         if cancel_order_wait_time is not None:
             self._cancel_order_wait_time = cancel_order_wait_time
 

--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -43,10 +43,10 @@ class TwapTradeStrategy(StrategyPyBase):
 
     def __init__(self,
                  market_infos: List[MarketTradingPairTuple],
+                 is_buy: bool,
+                 target_asset_amount: Decimal,
+                 order_step_size: Decimal,
                  order_price: Decimal,
-                 is_buy: bool = True,
-                 target_asset_amount: Decimal = Decimal("1.0"),
-                 order_step_size: Decimal = Decimal("1.0"),
                  order_delay_time: float = 10.0,
                  execution_state: ConditionalExecutionState = RunAlwaysExecutionState(),
                  cancel_order_wait_time: Optional[float] = 60.0,

--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -46,7 +46,7 @@ class TwapTradeStrategy(StrategyPyBase):
                  is_buy: bool = True,
                  target_asset_amount: Decimal = Decimal("1.0"),
                  order_step_size: Decimal = Decimal("1.0"),
-                 order_price: Decimal = None,
+                 order_price: Decimal = Decimal("1.0"),
                  order_delay_time: float = 10.0,
                  execution_state: ConditionalExecutionState = RunAlwaysExecutionState(),
                  cancel_order_wait_time: Optional[float] = 60.0,

--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -43,10 +43,10 @@ class TwapTradeStrategy(StrategyPyBase):
 
     def __init__(self,
                  market_infos: List[MarketTradingPairTuple],
+                 order_price: Decimal,
                  is_buy: bool = True,
                  target_asset_amount: Decimal = Decimal("1.0"),
                  order_step_size: Decimal = Decimal("1.0"),
-                 order_price: Decimal = Decimal("1.0"),
                  order_delay_time: float = 10.0,
                  execution_state: ConditionalExecutionState = RunAlwaysExecutionState(),
                  cancel_order_wait_time: Optional[float] = 60.0,

--- a/test/hummingbot/strategy/twap/test_twap_trade_strategy.py
+++ b/test/hummingbot/strategy/twap/test_twap_trade_strategy.py
@@ -32,14 +32,22 @@ class TwapTradeStrategyTest(TestCase):
 
     def test_creation_without_market_info_fails(self):
         with self.assertRaises(ValueError) as ex_context:
-            TwapTradeStrategy([])
+            TwapTradeStrategy(market_infos=[],
+                              is_buy=True,
+                              target_asset_amount=1,
+                              order_step_size=1,
+                              order_price=1)
 
         self.assertEqual(str(ex_context.exception), "market_infos must not be empty.")
 
     def test_start(self):
         exchange = MockExchange()
         marketTuple = MarketTradingPairTuple(exchange, "ETH-USDT", "ETH", "USDT")
-        strategy = TwapTradeStrategy(market_infos=[marketTuple])
+        strategy = TwapTradeStrategy(market_infos=[marketTuple],
+                                     is_buy=True,
+                                     target_asset_amount=1,
+                                     order_step_size=1,
+                                     order_price=1)
         strategy.logger().setLevel(1)
         strategy.logger().addHandler(self)
 
@@ -52,7 +60,11 @@ class TwapTradeStrategyTest(TestCase):
         exchange = MockExchange()
         exchange.ready = False
         marketTuple = MarketTradingPairTuple(exchange, "ETH-USDT", "ETH", "USDT")
-        strategy = TwapTradeStrategy(market_infos=[marketTuple])
+        strategy = TwapTradeStrategy(market_infos=[marketTuple],
+                                     is_buy=True,
+                                     target_asset_amount=1,
+                                     order_step_size=1,
+                                     order_price=1)
         strategy.logger().setLevel(1)
         strategy.logger().addHandler(self)
 
@@ -66,7 +78,11 @@ class TwapTradeStrategyTest(TestCase):
         exchange = MockExchange()
         exchange.ready = True
         marketTuple = MarketTradingPairTuple(exchange, "ETH-USDT", "ETH", "USDT")
-        strategy = TwapTradeStrategy(market_infos=[marketTuple])
+        strategy = TwapTradeStrategy(market_infos=[marketTuple],
+                                     is_buy=True,
+                                     target_asset_amount=1,
+                                     order_step_size=1,
+                                     order_price=1)
         strategy.logger().setLevel(1)
         strategy.logger().addHandler(self)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

A fix of following issue:
- order price optional in strategy parameters
- default values of `is_buy`, `target_asset_amount`, `order_step_size`, `order_price` are not justified, and the parameters always have to be provided by the user

**Tests performed by the developer**:

- ran the strategy, printed actual order price being sent
- ran the unit tests

**Tips for QA testing**:

- verify that the actual submitted order price corresponds to the configuration order_price
