### PR TITLE
Fix/Config variable set to None after CTRL+X

### DIFF
--- a/hummingbot/client/command/create_command.py
+++ b/hummingbot/client/command/create_command.py
@@ -118,14 +118,13 @@ class CreateCommand:
 
         if self.app.to_stop_config:
             return
-        config.value = parse_cvar_value(config, input_value)
+        value = parse_cvar_value(config, input_value)
         err_msg = await config.validate(input_value)
         if err_msg is not None:
             self._notify(err_msg)
-            config.value = None
             await self.prompt_a_config(config)
         else:
-            config.value = parse_cvar_value(config, input_value)
+            config.value = value
 
     async def prompt_new_file_name(self,  # type: HummingbotApplication
                                    strategy):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Fixes a bug where config variable is set to None when an invalid value is provided and CTRL+X is entered afterwards

**Tests performed by the developer**:

- Tried to reproduce the error with target_asset_amount in TWAP
- Ran unit tests

**Tips for QA testing**:

- Try to reproduce the problem with different kinds of variables. The result should always be the previously set value, not None.
