### PR TITLE
Fix/Handle no balance for paper connectors in global config

### DIFF
--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -248,8 +248,9 @@ class HummingbotApplication(*commands):
             if connector_name.endswith("paper_trade") and conn_setting.type == ConnectorType.Exchange:
                 connector = create_paper_trade_market(conn_setting.parent_name, trading_pairs)
                 paper_trade_account_balance = global_config_map.get("paper_trade_account_balance").value
-                for asset, balance in paper_trade_account_balance.items():
-                    connector.set_balance(asset, balance)
+                if paper_trade_account_balance is not None:
+                    for asset, balance in paper_trade_account_balance.items():
+                        connector.set_balance(asset, balance)
             else:
                 Security.update_config_map(global_config_map)
                 keys = {key: config.value for key, config in global_config_map.items()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Checks if paper trade balances exist in the global config before trying to assign them.

**Tests performed by the developer**:

- Ran the unit tests
- Ran a TWAP Plus strategy

**Tips for QA testing**:

Remove all items in the `paper_trade_account_balance` in global config file. Before you should get an exception on start, after the strategy should start (and balances should be empty).
