### PR TITLE
(fix) fix out-of-bound array exception on running hedge strategy

### DIFF
--- a/hummingbot/strategy/hedge/start.py
+++ b/hummingbot/strategy/hedge/start.py
@@ -17,7 +17,7 @@ def start(self):
     max_order_age = c_map.get("max_order_age").value
     minimum_trade = c_map.get("minimum_trade").value
     hedge_interval = c_map.get("hedge_interval").value
-    self._initialize_markets([(maker_exchange, []), (taker_exchange, taker_markets)])
+    self._initialize_markets([(maker_exchange, taker_markets), (taker_exchange, taker_markets)])
     exchanges = ExchangePairTuple(maker=self.markets[maker_exchange], taker=self.markets[taker_exchange])
 
     market_infos = {}


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [Yes] Your code builds clean without any errors or warnings
- [Yes] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When you run hedge strategy in kucoin spot with binance perpetual, It will occur an index out-of-bound error on load spot market. because it's set an empty array for it. It should same as taker market. I fixed it and it now works fine on kucoin and gate.io.


**Tests performed by the developer**:



**Tips for QA testing**:


