### PR TITLE
Fix/Avellaneda - remove _latest_parameter_calculation_vol

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -52,8 +52,6 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _optimal_spread
         object _optimal_bid
         object _optimal_ask
-        object _latest_parameter_calculation_vol
-        object _latest_parameter_calculation_trading_intensity
         str _debug_csv_path
         object _avg_vol
         object _trading_intensity

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -137,7 +137,6 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         self._start_time = start_time
         self._end_time = end_time
         self._min_spread = min_spread
-        self._latest_parameter_calculation_vol = s_decimal_zero
         self._reservation_price = s_decimal_zero
         self._optimal_spread = s_decimal_zero
         self._optimal_ask = s_decimal_zero
@@ -153,14 +152,6 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
     def all_markets_ready(self):
         return all([market.ready for market in self._sb_markets])
-
-    @property
-    def latest_parameter_calculation_vol(self):
-        return self._latest_parameter_calculation_vol
-
-    @latest_parameter_calculation_vol.setter
-    def latest_parameter_calculation_vol(self, value):
-        self._latest_parameter_calculation_vol = value
 
     @property
     def min_spread(self):
@@ -685,12 +676,6 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
     def get_volatility(self):
         vol = Decimal(str(self._avg_vol.current_value))
-        if vol == s_decimal_zero:
-            if self._latest_parameter_calculation_vol != s_decimal_zero:
-                vol = Decimal(str(self._latest_parameter_calculation_vol))
-            else:
-                # Default value at start time if price has no activity
-                vol = Decimal(str(self.c_get_spread() / 2))
         return vol
 
     cdef c_measure_order_book_liquidity(self):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

_latest_parameter_calculation_vol parameter needs to be removed. It's a leftover of a previous implementation, it's use corrupts volatility measurement.

**Tests performed by the developer**:

- ran the strategy with ascend_ex paper
- ran unit test