### PR TITLE
refactor/ amm_arb strategy to use `RateOracle` as default price source

### DIFF
--- a/hummingbot/strategy/amm_arb/amm_arb.py
+++ b/hummingbot/strategy/amm_arb/amm_arb.py
@@ -10,6 +10,7 @@ from hummingbot.connector.connector.uniswap.uniswap_connector import UniswapConn
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.market_order import MarketOrder
+from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.fixed_rate_source import FixedRateSource
 from hummingbot.logger import HummingbotLogger
@@ -62,7 +63,6 @@ class AmmArbStrategy(StrategyPyBase):
         :param concurrent_orders_submission: whether to submit both arbitrage taker orders (buy and sell) simultaneously
         If false, the bot will wait for first exchange order filled before submitting the other order.
         :param status_report_interval: Amount of seconds to wait to refresh the status report
-        :param rate_source: Provider of conversion rates between tokens
         """
         self._market_info_1 = market_info_1
         self._market_info_2 = market_info_2
@@ -89,7 +89,7 @@ class AmmArbStrategy(StrategyPyBase):
         self._market_1_quote_eth_rate = None
         self._market_2_quote_eth_rate = None
 
-        self._rate_source = rate_source
+        self._rate_source = RateOracle.get_instance()
 
     @property
     def min_profitability(self) -> Decimal:

--- a/hummingbot/strategy/amm_arb/amm_arb.py
+++ b/hummingbot/strategy/amm_arb/amm_arb.py
@@ -335,10 +335,10 @@ class AmmArbStrategy(StrategyPyBase):
         return self._sb_order_tracker.tracked_market_orders
 
     def start(self, clock: Clock, timestamp: float):
-        super.start(clock, timestamp)
+        super().start(clock, timestamp)
 
     def stop(self, clock: Clock):
         if self._main_task is not None:
             self._main_task.cancel()
             self._main_task = None
-        super.stop(clock)
+        super().stop(clock)

--- a/hummingbot/strategy/amm_arb/amm_arb_config_map.py
+++ b/hummingbot/strategy/amm_arb/amm_arb_config_map.py
@@ -1,5 +1,3 @@
-from hummingbot.client import settings
-from hummingbot.client.config.config_helpers import parse_cvar_value
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_validators import (
     validate_market_trading_pair,
@@ -55,27 +53,6 @@ def order_amount_prompt() -> str:
     trading_pair = amm_arb_config_map["market_1"].value
     base_asset, quote_asset = trading_pair.split("-")
     return f"What is the amount of {base_asset} per order? >>> "
-
-
-def update_oracle_settings(value: str):
-    c_map = amm_arb_config_map
-    if not (c_map["use_oracle_conversion_rate"].value is not None and
-            c_map["market_1"].value is not None and
-            c_map["market_2"].value is not None):
-        return
-    use_oracle = parse_cvar_value(c_map["use_oracle_conversion_rate"], c_map["use_oracle_conversion_rate"].value)
-    first_base, first_quote = c_map["market_1"].value.split("-")
-    second_base, second_quote = c_map["market_2"].value.split("-")
-    if use_oracle and (first_base != second_base or first_quote != second_quote):
-        settings.required_rate_oracle = True
-        settings.rate_oracle_pairs = []
-        if first_base != second_base:
-            settings.rate_oracle_pairs.append(f"{second_base}-{first_base}")
-        if first_quote != second_quote:
-            settings.rate_oracle_pairs.append(f"{second_quote}-{first_quote}")
-    else:
-        settings.required_rate_oracle = False
-        settings.rate_oracle_pairs = []
 
 
 amm_arb_config_map = {
@@ -143,22 +120,5 @@ amm_arb_config_map = {
         prompt_on_new=True,
         default=False,
         validator=validate_bool,
-        type_str="bool"),
-    "use_oracle_conversion_rate": ConfigVar(
-        key="use_oracle_conversion_rate",
-        type_str="bool",
-        prompt="Do you want to use rate oracle on unmatched trading pairs? (Yes/No) >>> ",
-        prompt_on_new=True,
-        validator=validate_bool,
-        on_validated=update_oracle_settings,
-    ),
-    "secondary_to_primary_quote_conversion_rate": ConfigVar(
-        key="secondary_to_primary_quote_conversion_rate",
-        prompt="Enter conversion rate for secondary quote asset value to primary quote asset value, e.g. "
-               "if primary quote asset is USD and the secondary is DAI and 1 DAI is valued at 1.25 USD, "
-               "the conversion rate is 1.25 >>> ",
-        default=Decimal("1"),
-        validator=lambda v: validate_decimal(v, Decimal(0), inclusive=False),
-        type_str="decimal",
-    ),
+        type_str="bool")
 }

--- a/hummingbot/strategy/amm_arb/data_types.py
+++ b/hummingbot/strategy/amm_arb/data_types.py
@@ -1,9 +1,9 @@
-from decimal import Decimal
 import logging
-from typing import Any
+
+from decimal import Decimal
+from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 
 from hummingbot.core.utils.estimate_fee import estimate_fee
-from hummingbot.core.utils.fixed_rate_source import FixedRateSource
 from hummingbot.logger import HummingbotLogger
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 
@@ -61,13 +61,16 @@ class ArbProposal:
         self.second_side: ArbProposalSide = second_side
 
     def profit_pct(self, account_for_fee: bool = False,
-                   rate_source: Any = FixedRateSource(),
+                   rate_source: RateOracle = None,
                    first_side_quote_eth_rate: Decimal = None,
                    second_side_quote_eth_rate: Decimal = None) -> Decimal:
         """
         Returns a profit in percentage value (e.g. 0.01 for 1% profitability)
         Assumes the base token is the same in both arbitrage sides
         """
+        if not rate_source:
+            rate_source = RateOracle.get_instance()
+
         buy = self.first_side if self.first_side.is_buy else self.second_side
         sell = self.first_side if not self.first_side.is_buy else self.second_side
         base_conversion_pair = f"{sell.market_info.base_asset}-{buy.market_info.base_asset}"

--- a/hummingbot/strategy/amm_arb/start.py
+++ b/hummingbot/strategy/amm_arb/start.py
@@ -1,7 +1,5 @@
 from decimal import Decimal
 
-from hummingbot.core.rate_oracle.rate_oracle import RateOracle
-from hummingbot.core.utils.fixed_rate_source import FixedRateSource
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.amm_arb.amm_arb import AmmArbStrategy
 from hummingbot.strategy.amm_arb.amm_arb_config_map import amm_arb_config_map
@@ -17,8 +15,6 @@ def start(self):
     market_1_slippage_buffer = amm_arb_config_map.get("market_1_slippage_buffer").value / Decimal("100")
     market_2_slippage_buffer = amm_arb_config_map.get("market_2_slippage_buffer").value / Decimal("100")
     concurrent_orders_submission = amm_arb_config_map.get("concurrent_orders_submission").value
-    use_oracle_conversion_rate = amm_arb_config_map.get("use_oracle_conversion_rate").value
-    secondary_to_primary_quote_conversion_rate = amm_arb_config_map.get("secondary_to_primary_quote_conversion_rate").value
 
     self._initialize_markets([(connector_1, [market_1]), (connector_2, [market_2])])
     base_1, quote_1 = market_1.split("-")
@@ -28,12 +24,6 @@ def start(self):
     market_info_2 = MarketTradingPairTuple(self.markets[connector_2], market_2, base_2, quote_2)
     self.market_trading_pair_tuples = [market_info_1, market_info_2]
 
-    if use_oracle_conversion_rate:
-        rate_source = RateOracle.get_instance()
-    else:
-        rate_source = FixedRateSource()
-        rate_source.add_rate(f"{quote_2}-{quote_1}", secondary_to_primary_quote_conversion_rate)
-
     self.strategy = AmmArbStrategy()
     self.strategy.init_params(market_info_1=market_info_1,
                               market_info_2=market_info_2,
@@ -42,4 +32,4 @@ def start(self):
                               market_1_slippage_buffer=market_1_slippage_buffer,
                               market_2_slippage_buffer=market_2_slippage_buffer,
                               concurrent_orders_submission=concurrent_orders_submission,
-                              rate_source=rate_source)
+                              )

--- a/hummingbot/templates/conf_amm_arb_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_amm_arb_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###   AMM Arbitrage strategy config   ###
 ##########################################
 
-template_version: 2
+template_version: 3
 strategy: null
 
 # The following configuations are only required for the AMM arbitrage trading strategy
@@ -32,12 +32,3 @@ market_2_slippage_buffer: null
 # A flag (true/false), if true the bot submits both arbitrage taker orders (buy and sell) simultaneously
 # If false, the bot will wait for first exchange order filled before submitting the other order
 concurrent_orders_submission: null
-
-# Whether to use rate oracle on unmatched trading pairs
-# Set this to either True or False
-use_oracle_conversion_rate: null
-
-# The conversion rate for secondary quote asset value to primary quote asset value.
-# e.g. if primary quote asset is USD, secondary is DAI and 1 USD is worth 1.25 DAI, "
-# the conversion rate is 0.8 (1 / 1.25)
-secondary_to_primary_quote_conversion_rate: null

--- a/test/hummingbot/strategy/amm_arb/test_amm_arb.py
+++ b/test/hummingbot/strategy/amm_arb/test_amm_arb.py
@@ -310,7 +310,7 @@ class AmmArbUnitTest(unittest.TestCase):
                            "    3   garlic  USDT            500                500\n\n"
                            "  Profitability:\n"
                            "    buy at onion, sell at garlic: 3.96%\n\n"
-                           "  Quotes Rates (fixed rates)\n"
+                           "  Quotes Rates (Binance rate oracle)\n"
                            "      Quotes pair Rate\n"
                            "    0   USDT-USDT    1")
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Refactor amm-arb strategy to use `RateOracle` as its default price source.

[sc-23390]


**Tests performed by the developer**:
Made changes to amm-arb to ensure that `RateOracle` is the only price source for all price calculations/usages.
Modified unit tests accordingly.

**Tips for QA testing**:
Ensure that amm_arb strategy works with Gateway connector v2.

