### PR TITLE
fix / cli handler format string

### DIFF
--- a/hummingbot/logger/cli_handler.py
+++ b/hummingbot/logger/cli_handler.py
@@ -14,7 +14,7 @@ class CLIHandler(StreamHandler):
         if record.exc_info is not None:
             record.exc_info = None
         retval = f'{datetime.fromtimestamp(record.created).strftime("%H:%M:%S")} - {record.name.split(".")[-1]} - ' \
-                 f'{record.msg}'
+                 f'{record.getMessage()}'
         if exc_info:
             retval += " (See log file for stack trace dump)"
         record.exc_info = exc_info


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Fixed format string log messages not being handled in CLIHandler. This fixes the issue where format string placeholders would sometimes appear in the Hummingbot log pane. e.g. "asyncssh - %s %s" when starting Hummingbot with debug mode on, in gateway v2 branch.

[ch23895]