### PR TITLE
fix/ fix gateway connectors not showing up in autocomplete

### DIFF
--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -268,7 +268,7 @@ class AllConnectorSettings:
 
     @classmethod
     def get_gateway_evm_amm_connector_names(cls) -> Set[str]:
-        return {cs.name for cs in cls.all_connector_settings.values if cs.type == ConnectorType.EVM_AMM}
+        return {cs.name for cs in cls.all_connector_settings.values() if cs.type == ConnectorType.EVM_AMM}
 
     @classmethod
     def get_example_pairs(cls) -> Dict[str, str]:

--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -267,6 +267,10 @@ class AllConnectorSettings:
         return {cs.name for cs in cls.all_connector_settings.values() if cs.use_ethereum_wallet}
 
     @classmethod
+    def get_gateway_evm_amm_connector_names(cls) -> Set[str]:
+        return {cs.name for cs in cls.all_connector_settings.values if cs.type == ConnectorType.EVM_AMM}
+
+    @classmethod
     def get_example_pairs(cls) -> Dict[str, str]:
         return {name: cs.example_pair for name, cs in cls.get_connector_settings().items()}
 

--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -37,7 +37,7 @@ class HummingbotCompleter(Completer):
         self._command_completer = WordCompleter(self.parser.commands, ignore_case=True)
         self._exchange_completer = WordCompleter(sorted(AllConnectorSettings.get_connector_settings().keys()), ignore_case=True)
         self._spot_exchange_completer = WordCompleter(sorted(AllConnectorSettings.get_exchange_names()), ignore_case=True)
-        self._spot_amm_completer = WordCompleter(sorted(AllConnectorSettings.get_exchange_names().union(AllConnectorSettings.get_gateway_evm_amm_connector_names())), ignore_case=True)
+        self._exchange_amm_completer = WordCompleter(sorted(AllConnectorSettings.get_exchange_names().union(AllConnectorSettings.get_gateway_evm_amm_connector_names())), ignore_case=True)
         self._trading_timeframe_completer = WordCompleter(["infinite", "from_date_to_date", "daily_between_times"], ignore_case=True)
         self._derivative_completer = WordCompleter(AllConnectorSettings.get_derivative_names(), ignore_case=True)
         self._derivative_exchange_completer = WordCompleter(AllConnectorSettings.get_derivative_names().difference(AllConnectorSettings.get_derivative_dex_names()), ignore_case=True)
@@ -134,7 +134,7 @@ class HummingbotCompleter(Completer):
         text_before_cursor: str = document.text_before_cursor
         return text_before_cursor.startswith("connect ")
 
-    def _complete_spot_amm_connectors(self, document: Document) -> bool:
+    def _complete_exchange_amm_connectors(self, document: Document) -> bool:
         return "(Exchange/AMM)" in self.prompt_text
 
     def _complete_spot_exchanges(self, document: Document) -> bool:
@@ -232,7 +232,7 @@ class HummingbotCompleter(Completer):
             for c in self._gateway_wallet_address_completer.get_completions(document, complete_event):
                 yield c
 
-        elif self._complete_spot_amm_connectors(document):
+        elif self._complete_exchange_amm_connectors(document):
             if self._complete_spot_exchanges(document):
                 for c in self._spot_exchange_completer.get_completions(document, complete_event):
                     yield c
@@ -240,7 +240,7 @@ class HummingbotCompleter(Completer):
                 for c in self._derivative_exchange_completer.get_completions(document, complete_event):
                     yield c
             else:
-                for c in self._spot_amm_completer.get_completions(document, complete_event):
+                for c in self._exchange_amm_completer.get_completions(document, complete_event):
                     yield c
 
         elif self._complete_spot_exchanges(document):

--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -36,12 +36,11 @@ class HummingbotCompleter(Completer):
         self._path_completer = WordCompleter(file_name_list(CONF_FILE_PATH, "yml"))
         self._command_completer = WordCompleter(self.parser.commands, ignore_case=True)
         self._exchange_completer = WordCompleter(sorted(AllConnectorSettings.get_connector_settings().keys()), ignore_case=True)
-        self._spot_completer = WordCompleter(sorted(AllConnectorSettings.get_exchange_names().union(AllConnectorSettings.get_other_connector_names())), ignore_case=True)
         self._spot_exchange_completer = WordCompleter(sorted(AllConnectorSettings.get_exchange_names()), ignore_case=True)
+        self._spot_amm_completer = WordCompleter(sorted(AllConnectorSettings.get_exchange_names().union(AllConnectorSettings.get_gateway_evm_amm_connector_names())), ignore_case=True)
         self._trading_timeframe_completer = WordCompleter(["infinite", "from_date_to_date", "daily_between_times"], ignore_case=True)
         self._derivative_completer = WordCompleter(AllConnectorSettings.get_derivative_names(), ignore_case=True)
         self._derivative_exchange_completer = WordCompleter(AllConnectorSettings.get_derivative_names().difference(AllConnectorSettings.get_derivative_dex_names()), ignore_case=True)
-        self._amm_arb_connector_completer = WordCompleter(set(AllConnectorSettings.get_connector_settings().keys()).difference(AllConnectorSettings.get_derivative_names()), ignore_case=True)
         self._connect_option_completer = WordCompleter(CONNECT_OPTIONS, ignore_case=True)
         self._export_completer = WordCompleter(["keys", "trades"], ignore_case=True)
         self._balance_completer = WordCompleter(["limit", "paper"], ignore_case=True)
@@ -135,7 +134,10 @@ class HummingbotCompleter(Completer):
         text_before_cursor: str = document.text_before_cursor
         return text_before_cursor.startswith("connect ")
 
-    def _complete_spot_connectors(self, document: Document) -> bool:
+    def _complete_spot_amm_connectors(self, document: Document) -> bool:
+        return "(Exchange/AMM)" in self.prompt_text
+
+    def _complete_spot_exchanges(self, document: Document) -> bool:
         return "spot" in self.prompt_text
 
     def _complete_trading_timeframe(self, document: Document) -> bool:
@@ -200,9 +202,6 @@ class HummingbotCompleter(Completer):
     def _complete_rate_oracle_source(self, document: Document):
         return all(x in self.prompt_text for x in ("source", "rate oracle"))
 
-    def _complete_amm_arb_connectors(self, document: Document):
-        return "(Exchange/AMM)" in self.prompt_text
-
     def get_completions(self, document: Document, complete_event: CompleteEvent):
         """
         Get completions for the current scope. This is the defining function for the completer
@@ -233,17 +232,24 @@ class HummingbotCompleter(Completer):
             for c in self._gateway_wallet_address_completer.get_completions(document, complete_event):
                 yield c
 
-        elif self._complete_amm_arb_connectors(document):
-            for c in self._amm_arb_connector_completer.get_completions(document, complete_event):
-                yield c
-
-        elif self._complete_spot_connectors(document):
-            if "(Exchange/AMM)" in self.prompt_text:
-                for c in self._spot_completer.get_completions(document, complete_event):
-                    yield c
-            else:
+        elif self._complete_spot_amm_connectors(document):
+            if self._complete_spot_exchanges(document):
                 for c in self._spot_exchange_completer.get_completions(document, complete_event):
                     yield c
+            elif self._complete_derivatives(document):
+                for c in self._derivative_exchange_completer.get_completions(document, complete_event):
+                    yield c
+            else:
+                for c in self._spot_amm_completer.get_completions(document, complete_event):
+                    yield c
+
+        elif self._complete_spot_exchanges(document):
+            for c in self._spot_exchange_completer.get_completions(document, complete_event):
+                yield c
+
+        elif self._complete_derivatives(document):
+            for c in self._derivative_exchange_completer.get_completions(document, complete_event):
+                yield c
 
         elif self._complete_trading_timeframe(document):
             for c in self._trading_timeframe_completer.get_completions(document, complete_event):

--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -41,6 +41,7 @@ class HummingbotCompleter(Completer):
         self._trading_timeframe_completer = WordCompleter(["infinite", "from_date_to_date", "daily_between_times"], ignore_case=True)
         self._derivative_completer = WordCompleter(AllConnectorSettings.get_derivative_names(), ignore_case=True)
         self._derivative_exchange_completer = WordCompleter(AllConnectorSettings.get_derivative_names().difference(AllConnectorSettings.get_derivative_dex_names()), ignore_case=True)
+        self._amm_arb_connector_completer = WordCompleter(set(AllConnectorSettings.get_connector_settings().keys()).difference(AllConnectorSettings.get_derivative_names()), ignore_case=True)
         self._connect_option_completer = WordCompleter(CONNECT_OPTIONS, ignore_case=True)
         self._export_completer = WordCompleter(["keys", "trades"], ignore_case=True)
         self._balance_completer = WordCompleter(["limit", "paper"], ignore_case=True)
@@ -199,6 +200,9 @@ class HummingbotCompleter(Completer):
     def _complete_rate_oracle_source(self, document: Document):
         return all(x in self.prompt_text for x in ("source", "rate oracle"))
 
+    def _complete_amm_arb_connectors(self, document: Document):
+        return "(Exchange/AMM)" in self.prompt_text
+
     def get_completions(self, document: Document, complete_event: CompleteEvent):
         """
         Get completions for the current scope. This is the defining function for the completer
@@ -227,6 +231,10 @@ class HummingbotCompleter(Completer):
 
         elif self._complete_gateway_wallet_addresses(document):
             for c in self._gateway_wallet_address_completer.get_completions(document, complete_event):
+                yield c
+
+        elif self._complete_amm_arb_connectors(document):
+            for c in self._amm_arb_connector_completer.get_completions(document, complete_event):
                 yield c
 
         elif self._complete_spot_connectors(document):

--- a/hummingbot/strategy/amm_arb/amm_arb_config_map.py
+++ b/hummingbot/strategy/amm_arb/amm_arb_config_map.py
@@ -62,7 +62,7 @@ amm_arb_config_map = {
         default="amm_arb"),
     "connector_1": ConfigVar(
         key="connector_1",
-        prompt="Enter your first spot connector (Exchange/AMM) >>> ",
+        prompt="Enter your first connector (Exchange/AMM) >>> ",
         prompt_on_new=True,
         validator=validate_connector,
         on_validated=exchange_on_validated),
@@ -74,7 +74,7 @@ amm_arb_config_map = {
         on_validated=market_1_on_validated),
     "connector_2": ConfigVar(
         key="connector_2",
-        prompt="Enter your second spot connector (Exchange/AMM) >>> ",
+        prompt="Enter your second connector (Exchange/AMM) >>> ",
         prompt_on_new=True,
         validator=validate_connector,
         on_validated=exchange_on_validated),


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Addresses absence of gateway connectors when creating `amm-arb` strategy.

[sc-24477]


**Tests performed by the developer**:


**Tips for QA testing**:
Test that the gateway connectors now appear as part of the autocomplete when creating a `amm-arb` strategy and changing the `connector_1` and `connector_2` configs

