### PR TITLE
fix/ create_certs.sh script not creating client certs

### DIFF
--- a/gateway/setup/create_certs.sh
+++ b/gateway/setup/create_certs.sh
@@ -18,3 +18,10 @@ openssl req -new -key server_key.pem -out csr.pem -subj "/CN=localhost"
 # create certificate signed by CA
 openssl x509 -req -days 9999 -in csr.pem -CA ca_cert.pem -CAkey ca_key.pem -CAcreateserial -out server_cert.pem -sha256
 rm csr.pem
+# create client private key
+openssl genrsa -aes128 -out client_key.pem 
+# create CSR
+openssl req -new -key client_key.pem -out csr.pem -subj "/CN=localhost"
+# create certificate signed by CA
+openssl x509 -req -days 9999 -in csr.pem -CA ca_cert.pem -CAkey ca_key.pem -CAcreateserial -out client_cert.pem -sha256
+rm csr.pem


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

As brought up by @petioptrv, the `create_certs.sh` does not generate the client certs and key files that are necessary for the `curl` commands.

**Tests performed by the developer**:

**Tips for QA testing**:

Ensure that the `create_certs.sh` scripts generate the `client_key.pem` and the `client_cert.pem` file
