### PR TITLE
fix/ Hummingbot is calling `fetch_gateway_config_key_list()` before Gateway is ready

### DIFF
--- a/hummingbot/client/command/gateway_command.py
+++ b/hummingbot/client/command/gateway_command.py
@@ -32,7 +32,6 @@ from hummingbot.core.gateway import (
 from hummingbot.core.gateway.status_monitor import Status
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.gateway_config_utils import (
-    build_config_namespace_keys,
     search_configs,
     build_config_dict_display,
     build_connector_display,
@@ -357,7 +356,7 @@ class GatewayCommand:
         host = global_config_map['gateway_api_host'].value
         port = global_config_map['gateway_api_port'].value
         try:
-            config_dict = await self._fetch_gateway_configs()
+            config_dict = await self._gateway_monitor._fetch_gateway_configs()
             if key is not None:
                 config_dict = search_configs(config_dict, key)
             self.notify(f"\nGateway Configurations ({host}:{port}):")
@@ -538,18 +537,3 @@ class GatewayCommand:
         self.placeholder_mode = False
         self.app.hide_input = False
         self.app.change_prompt(prompt=">>> ")
-
-    @staticmethod
-    async def _fetch_gateway_configs() -> Dict[str, Any]:
-        return await GatewayHttpClient.get_instance().get_configuration(fail_silently=False)
-
-    async def fetch_gateway_config_key_list(self):
-        try:
-            config = await self._fetch_gateway_configs()
-            build_config_namespace_keys(self.gateway_config_keys, config)
-            self.app.input_field.completer = load_completer(self)
-        except Exception:
-            self.logger().error("Error loading gateway configs. Gateway connectors are not usable until "
-                                "it has been correctly configured. "
-                                "Use the `gateway generate-certs` or `gateway create` commands might help resolve this.",
-                                exc_info=True)

--- a/hummingbot/client/command/gateway_command.py
+++ b/hummingbot/client/command/gateway_command.py
@@ -349,6 +349,7 @@ class GatewayCommand:
         try:
             response = await GatewayHttpClient.get_instance().update_config(key, value)
             self.notify(response["message"])
+            await self._gateway_monitor.update_gateway_config_key_list()
         except Exception:
             self.notify("\nError: Gateway configuration update failed. See log file for more details.")
 
@@ -356,7 +357,7 @@ class GatewayCommand:
         host = global_config_map['gateway_api_host'].value
         port = global_config_map['gateway_api_port'].value
         try:
-            config_dict = await self._gateway_monitor._fetch_gateway_configs()
+            config_dict: Dict[str, Any] = await self._gateway_monitor._fetch_gateway_configs()
             if key is not None:
                 config_dict = search_configs(config_dict, key)
             self.notify(f"\nGateway Configurations ({host}:{port}):")

--- a/hummingbot/core/gateway/status_monitor.py
+++ b/hummingbot/core/gateway/status_monitor.py
@@ -79,7 +79,7 @@ class StatusMonitor:
                 self._current_status = Status.OFFLINE
             await asyncio.sleep(POLL_INTERVAL)
 
-    async def _fetch_gateway_configs() -> Dict[str, Any]:
+    async def _fetch_gateway_configs(self) -> Dict[str, Any]:
         return await GatewayHttpClient.get_instance().get_configuration(fail_silently=False)
 
     async def update_gateway_config_key_list(self):

--- a/hummingbot/core/gateway/status_monitor.py
+++ b/hummingbot/core/gateway/status_monitor.py
@@ -1,14 +1,20 @@
 import asyncio
-from enum import Enum
 import logging
-from typing import Optional
 
+from enum import Enum
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from hummingbot.client.settings import GATEWAY_CONNECTORS
+from hummingbot.client.ui.completer import load_completer
 from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.utils.async_utils import safe_ensure_future
-from hummingbot.client.settings import GATEWAY_CONNECTORS
+from hummingbot.core.utils.gateway_config_utils import build_config_namespace_keys
 
 POLL_INTERVAL = 2.0
 POLL_TIMEOUT = 1.0
+
+if TYPE_CHECKING:
+    from hummingbot.client.hummingbot_application import HummingbotApplication
 
 
 class Status(Enum):
@@ -27,13 +33,23 @@ class StatusMonitor:
             cls._sm_logger = logging.getLogger(__name__)
         return cls._sm_logger
 
-    def __init__(self):
+    def __init__(self, app: "HummingbotApplication"):
+        self._app = app
         self._current_status = Status.OFFLINE
         self._monitor_task = None
+        self._gateway_config_keys: List[str] = []
 
     @property
     def current_status(self) -> Status:
         return self._current_status
+
+    @property
+    def gateway_config_keys(self) -> List[str]:
+        return self._gateway_config_keys
+
+    @gateway_config_keys.setter
+    def gateway_config_keys(self, new_config: List[str]):
+        self._gateway_config_keys = new_config
 
     def start(self):
         self._monitor_task = safe_ensure_future(self._monitor_loop())
@@ -51,11 +67,29 @@ class StatusMonitor:
                         gateway_connectors = await GatewayHttpClient.get_instance().get_connectors(fail_silently=True)
                         GATEWAY_CONNECTORS.clear()
                         GATEWAY_CONNECTORS.extend([connector["name"] for connector in gateway_connectors.get("connectors", [])])
+
+                        await self.update_gateway_config_key_list()
                     self._current_status = Status.ONLINE
                 else:
                     self._current_status = Status.OFFLINE
             except asyncio.CancelledError:
                 raise
             except Exception:
+                self.logger().error("Unable to find Gateway service. Please check that Gateway service is online. ")
                 self._current_status = Status.OFFLINE
             await asyncio.sleep(POLL_INTERVAL)
+
+    async def _fetch_gateway_configs() -> Dict[str, Any]:
+        return await GatewayHttpClient.get_instance().get_configuration(fail_silently=False)
+
+    async def update_gateway_config_key_list(self):
+        try:
+            config_list: List[str] = []
+            config_dict: Dict[str, Any] = await self._fetch_gateway_configs()
+            build_config_namespace_keys(config_list, config_dict)
+
+            self.gateway_config_keys = config_list
+            self._app.app.input_field.completer = load_completer(self._app)
+        except Exception:
+            self.logger().error("Error fetching gateway configs. Please check that Gateway service is online. ",
+                                exc_info=True)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes [sc-25346]


**Tests performed by the developer**:
I chose to use the `GatewayStatusMonitor`  to determine when to fetch the gateway config.


**Tips for QA testing**:
Error message no longer appears on startup(before and after `gateway create`) when running client in Docker mode.
Ensure that Status Monitor works as intended.
All gateway commands works as intended.

