### PR TITLE
fix / gateway v2 missing cex completion

### DIFF
--- a/hummingbot/connector/gateway_EVM_AMM.py
+++ b/hummingbot/connector/gateway_EVM_AMM.py
@@ -773,9 +773,6 @@ class GatewayEVMAMM(ConnectorBase):
                         )
                     )
                     tracked_order.last_state = "FILLED"
-                    self.logger().info(f"The {tracked_order.trade_type.name} order "
-                                       f"{tracked_order.client_order_id} has completed "
-                                       f"according to order status API.")
                     event_tag: MarketEvent = (
                         MarketEvent.BuyOrderCompleted if tracked_order.trade_type is TradeType.BUY
                         else MarketEvent.SellOrderCompleted

--- a/hummingbot/strategy/amm_arb/amm_arb.py
+++ b/hummingbot/strategy/amm_arb/amm_arb.py
@@ -448,8 +448,30 @@ class AmmArbStrategy(StrategyPyBase):
     def did_complete_buy_order(self, order_completed_event: BuyOrderCompletedEvent):
         self.set_order_completed(order_id=order_completed_event.order_id)
 
+        market_info: MarketTradingPairTuple = self.order_tracker.get_market_pair_from_order_id(
+            order_completed_event.order_id
+        )
+        log_msg: str = f"Buy order completed on {market_info.market.name}: {order_completed_event.order_id}."
+        if self.is_gateway_market(market_info):
+            log_msg += f" txHash: {order_completed_event.exchange_order_id}"
+        self.log_with_clock(logging.INFO, log_msg)
+        self.notify_hb_app_with_timestamp(f"Bought {order_completed_event.base_asset_amount:.8f} "
+                                          f"{order_completed_event.base_asset}-{order_completed_event.quote_asset} "
+                                          f"on {market_info.market.name}.")
+
     def did_complete_sell_order(self, order_completed_event: SellOrderCompletedEvent):
         self.set_order_completed(order_id=order_completed_event.order_id)
+
+        market_info: MarketTradingPairTuple = self.order_tracker.get_market_pair_from_order_id(
+            order_completed_event.order_id
+        )
+        log_msg: str = f"Sell order completed on {market_info.market.name}: {order_completed_event.order_id}."
+        if self.is_gateway_market(market_info):
+            log_msg += f" txHash: {order_completed_event.exchange_order_id}"
+        self.log_with_clock(logging.INFO, log_msg)
+        self.notify_hb_app_with_timestamp(f"Sold {order_completed_event.base_asset_amount:.8f} "
+                                          f"{order_completed_event.base_asset}-{order_completed_event.quote_asset} "
+                                          f"on {market_info.market.name}.")
 
     def did_fail_order(self, order_failed_event: MarketOrderFailureEvent):
         self.set_order_completed(order_id=order_failed_event.order_id)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Added order completion messages for CEX orders, when running amm_arb.

**Tests performed by the developer**:

Tested w/ end-to-end testing methodology between Kovan and Binance US paper trade. Order completion messages are showing for both the AMM and CEX orders.

<img width="1530" alt="Screenshot 2022-03-30 175729" src="https://user-images.githubusercontent.com/304402/160955400-74a08759-40b3-431d-8624-e28301c8c3a8.png">

[ch25586]


