### PR TITLE
Better logging for trade failures due to allowed slippage

### DIFF
--- a/hummingbot/connector/gateway_EVM_AMM.py
+++ b/hummingbot/connector/gateway_EVM_AMM.py
@@ -490,9 +490,9 @@ class GatewayEVMAMM(ConnectorBase):
         error_code: Optional[int] = resp.get("errorCode")
         if error_code is not None:
             if error_code == GatewayError.swap_price_exceeds_limit_price.value:
-                self.logger().error("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
+                self.logger().info("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
             elif error_code == GatewayError.swap_price_lower_than_limit_price.value:
-                self.logger().error("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
+                self.logger().info("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
             self.logger().error(f"{resp}")
             raise Exception
 

--- a/hummingbot/connector/gateway_EVM_AMM.py
+++ b/hummingbot/connector/gateway_EVM_AMM.py
@@ -21,7 +21,7 @@ from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.connector.gateway_in_flight_order import GatewayInFlightOrder
 from hummingbot.core.utils import async_ttl_cache
 from hummingbot.core.gateway import check_transaction_exceptions
-from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
+from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient, GatewayError
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
@@ -482,6 +482,20 @@ class GatewayEVMAMM(ConnectorBase):
         safe_ensure_future(self._create_order(side, order_id, trading_pair, amount, price, **request_args))
         return order_id
 
+    def handle_gateway_api_error(self, resp: Dict[str, Any]):
+        """
+        If the API returns an error code, interpret the code, log a useful
+        message to the user, then raise an exception.
+        """
+        error_code: Optional[int] = resp.get("errorCode")
+        if error_code is not None:
+            if error_code == GatewayError.swap_price_exceeds_limit_price.value:
+                self.logger().error("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
+            elif error_code == GatewayError.swap_price_lower_than_limit_price.value:
+                self.logger().error("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
+            self.logger().error(f"{resp}")
+            raise Exception
+
     async def _create_order(
             self,
             trade_type: TradeType,
@@ -523,6 +537,7 @@ class GatewayEVMAMM(ConnectorBase):
                 self._nonce,
                 **request_args
             )
+            self.handle_gateway_api_error(order_result)
             transaction_hash: str = order_result.get("txHash")
             nonce: int = order_result.get("nonce")
             gas_price: Decimal = Decimal(order_result.get("gasPrice"))

--- a/hummingbot/core/gateway/gateway_http_client.py
+++ b/hummingbot/core/gateway/gateway_http_client.py
@@ -18,8 +18,22 @@ from hummingbot.logger import HummingbotLogger
 
 
 class GatewayError(Enum):
-    swap_price_exceeds_limit_price = 1008
-    swap_price_lower_than_limit_price = 1009
+    """
+    The gateway route error codes defined in /gateway/src/services/error-handler.ts
+    """
+
+    Network = 1001
+    RateLimit = 1002
+    OutOfGas = 1003
+    TransactionGasPriceTooLow = 1004
+    LoadWallet = 1005
+    TokenNotSupported = 1006
+    TradeFailed = 1007
+    SwapPriceExceedsLimitPrice = 1008
+    SwapPriceLowerThanLimitPrice = 1009
+    ServiceUnitialized = 1010
+    UnknownChainError = 1011
+    UnknownError = 1099
 
 
 class GatewayHttpClient:
@@ -89,9 +103,9 @@ class GatewayHttpClient:
         """
         error_code: Optional[int] = resp.get("errorCode")
         if error_code is not None:
-            if error_code == GatewayError.swap_price_exceeds_limit_price.value:
+            if error_code == GatewayError.SwapPriceExceedsLimitPrice.value:
                 self.logger().info("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's allowed slippage rate.")
-            elif error_code == GatewayError.swap_price_lower_than_limit_price.value:
+            elif error_code == GatewayError.SwapPriceLowerThanLimitPrice.value:
                 self.logger().info("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's allowed slippage rate.")
 
     async def api_request(

--- a/hummingbot/core/gateway/gateway_http_client.py
+++ b/hummingbot/core/gateway/gateway_http_client.py
@@ -103,10 +103,30 @@ class GatewayHttpClient:
         """
         error_code: Optional[int] = resp.get("errorCode")
         if error_code is not None:
-            if error_code == GatewayError.SwapPriceExceedsLimitPrice.value:
+            if error_code == GatewayError.Network.value:
+                self.logger().info("Gateway had a network error. Make sure it is still able to communicate with the node.")
+            elif error_code == GatewayError.RateLimit.value:
+                self.logger().info("Gateway was unable to communicate with the node because of rate limiting.")
+            elif error_code == GatewayError.OutOfGas.value:
+                self.logger().info("There was an out of gas error. Adjust the gas limit in the gateway config.")
+            elif error_code == GatewayError.TransactionGasPriceTooLow.value:
+                self.logger().info("The gas price provided by gateway was too low to create a blockchain operation. Consider increasing the gas price.")
+            elif error_code == GatewayError.LoadWallet.value:
+                self.logger().info("Gateway failed to load your wallet. Try running 'gateway connect' with the correct wallet settings.")
+            elif error_code == GatewayError.TokenNotSupported.value:
+                self.logger().info("Gateway tried to use an unsupported token.")
+            elif error_code == GatewayError.TradeFailed.value:
+                self.logger().info("The trade on gateway has failed.")
+            elif error_code == GatewayError.ServiceUnitialized.value:
+                self.logger().info("Some values was uninitialized. Please contact dev@hummingbot.io ")
+            elif error_code == GatewayError.SwapPriceExceedsLimitPrice.value:
                 self.logger().info("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's allowed slippage rate.")
             elif error_code == GatewayError.SwapPriceLowerThanLimitPrice.value:
                 self.logger().info("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's allowed slippage rate.")
+            elif error_code == GatewayError.UnknownChainError.value:
+                self.logger().info("An unknown chain error has occurred on gateway. Make sure your gateway settings are correct.")
+            elif error_code == GatewayError.UnknownError.value:
+                self.logger().info("An unknown error has occurred on gateway. Please send your logs to dev@hummingbot.io")
 
     async def api_request(
             self,

--- a/hummingbot/core/gateway/gateway_http_client.py
+++ b/hummingbot/core/gateway/gateway_http_client.py
@@ -3,6 +3,7 @@ import logging
 import ssl
 
 from decimal import Decimal
+from enum import Enum
 from typing import Optional, Any, Dict, List, Union
 
 from hummingbot.client.config.global_config_map import global_config_map
@@ -14,6 +15,11 @@ from hummingbot.core.gateway import (
     restart_gateway
 )
 from hummingbot.logger import HummingbotLogger
+
+
+class GatewayError(Enum):
+    swap_price_exceeds_limit_price = 1008
+    swap_price_lower_than_limit_price = 1009
 
 
 class GatewayHttpClient:

--- a/hummingbot/core/gateway/gateway_http_client.py
+++ b/hummingbot/core/gateway/gateway_http_client.py
@@ -90,9 +90,9 @@ class GatewayHttpClient:
         error_code: Optional[int] = resp.get("errorCode")
         if error_code is not None:
             if error_code == GatewayError.swap_price_exceeds_limit_price.value:
-                self.logger().info("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
+                self.logger().info("The swap price is greater than your limit buy price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's allowed slippage rate.")
             elif error_code == GatewayError.swap_price_lower_than_limit_price.value:
-                self.logger().info("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's slippage rate.")
+                self.logger().info("The swap price is lower than your limit sell price. The market may be too volatile or your slippage rate is too low. Try adjusting the strategy's allowed slippage rate.")
 
     async def api_request(
             self,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Currently if a gateway connector trade fails because allowed slippage is violated, the user has to read the logs. The solution is to include a message in the console that either a buy or sell slippage limit was violated and suggest that either the market is volatile or their allowed slippage may be too restrictive.


**Tests performed by the developer**:

1. Set amm_arb uniswap kovan allowed slippage to zero.
2. Set gateway uniswap kovan allowed slippage to zero.
3. Set profitability to -100 to force trades
4. Run strategy and see messaging.
<img width="852" alt="Screenshot 2022-04-04 at 12 36 07" src="https://user-images.githubusercontent.com/83538970/161528508-d40c7822-7a35-4806-8bc4-ba716c31bb3f.png">
.

5. Set amm_arb uniswap kovan allowed slippage to 2.0.
6. See succesful trade.




**Tips for QA testing**:

1. Create an amm_arb strategy with a DEX, set allowedSlippage to 0.
2. `gateway config uniswap.versions.2.allowedSlippage 0` or `gateway config pangolin.allowedSlippage 0`.
3. Set profitability low to force trades.
4. You should see a message about the allowed slippage rate in the hummingbot console.
