### PR TITLE
Extend wait time for exchange_order_ids retreived from gateway

### DIFF
--- a/hummingbot/connector/gateway_EVM_AMM.py
+++ b/hummingbot/connector/gateway_EVM_AMM.py
@@ -308,8 +308,8 @@ class GatewayEVMAMM(ConnectorBase):
             **request_args
         )
 
-        transaction_hash = resp.get("approval").get("hash")
-        nonce = resp.get("nonce")
+        transaction_hash: Optional[str] = resp.get("approval").get("hash")
+        nonce: Optional[int] = resp.get("nonce")
         if transaction_hash is not None and nonce is not None:
             self.start_tracking_order(order_id, transaction_hash, token_symbol)
             tracked_order = self._in_flight_orders.get(order_id)

--- a/hummingbot/connector/gateway_EVM_AMM.py
+++ b/hummingbot/connector/gateway_EVM_AMM.py
@@ -307,19 +307,19 @@ class GatewayEVMAMM(ConnectorBase):
             self._nonce,
             **request_args
         )
-        self.start_tracking_order(order_id, None, token_symbol)
 
-        if "hash" in resp.get("approval", {}).keys():
-            hash = resp["approval"]["hash"]
+        transaction_hash = resp.get("approval").get("hash")
+        nonce = resp.get("nonce")
+        if transaction_hash is not None and nonce is not None:
+            self.start_tracking_order(order_id, transaction_hash, token_symbol)
             tracked_order = self._in_flight_orders.get(order_id)
-            tracked_order.update_exchange_order_id(hash)
-            tracked_order.nonce = resp["nonce"]
+            tracked_order.nonce = nonce
             self.logger().info(
                 f"Maximum {token_symbol} approval for {self.connector_name} contract sent, hash: {hash}."
             )
             return tracked_order
         else:
-            self.stop_tracking_order(order_id)
+            self.logger().info(f"Missing data from approval result. Incomplete return result for ({resp.keys()})")
             self.logger().info(f"Approval for {token_symbol} on {self.connector_name} failed.")
             return None
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Clean up logic for creating DEX approval orders.
- Extend wait time for `get_exchange_order_id` in gateway_in_flight_order.

**Tests performed by the developer**:
Tested uniswap kovan with WETH-MKR and it works as expected.

<img width="1705" alt="Screenshot 2022-04-06 at 11 43 15" src="https://user-images.githubusercontent.com/83538970/161947215-51524b12-b8d9-403d-a2b7-36e4a22fbbf5.png">



**Tips for QA testing**:
This seems to be an issue with speed so if a QA member has a slower connection, have them test it.

