### PR TITLE
feat/ add arbitrum as new ethereum network

### DIFF
--- a/gateway/src/chains/ethereum/erc20_tokens_arbitrum_one.json
+++ b/gateway/src/chains/ethereum/erc20_tokens_arbitrum_one.json
@@ -1,0 +1,1997 @@
+{
+  "name": "arbitrum",
+  "tokens": [
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/4454/thumb/0xbtc.png?1561603765",
+      "chainId": 42161,
+      "address": "0x7cb16cb78ea464aD35c8a50ABF95dff3c9e09d5d",
+      "name": "0xBitcoin Token",
+      "symbol": "0xBTC",
+      "decimals": 8,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0x03b95f1C84Af0607afd5dD87ca1FDE7572aa827F",
+      "name": "Agave",
+      "symbol": "AGVE",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0b006e475620af076915257c6a9e40635abdbbad",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0b006e475620af076915257c6a9e40635abdbbad",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14719/thumb/sbEW5W8.png?1617939648",
+      "chainId": 42161,
+      "address": "0x0e15258734300290a651FdBAe8dEb039a8E7a2FA",
+      "name": "Alchemy",
+      "symbol": "ALCH",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0000a1c00009a619684135b824ba02f7fbf3a572",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0000a1c00009a619684135b824ba02f7fbf3a572",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14379/thumb/uaLoLU8c_400x400_%281%29.png?1627873106",
+      "chainId": 42161,
+      "address": "0x9b3fa2A7C3EB36d048A5d38d81E7fAFC6bc47B25",
+      "name": "Aluna",
+      "symbol": "ALN",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x8185bc4757572da2a610f887561c32298f1a5748",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x8185bc4757572da2a610f887561c32298f1a5748",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/2165/thumb/Auc_Discord_Avatar1.png?1618983355",
+      "chainId": 42161,
+      "address": "0xea986d33eF8a20A96120ecc44dBdD49830192043",
+      "name": "Auctus Token",
+      "symbol": "AUC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xc12d099be31567add4e4e4d0d45691c3f58f5663",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xc12d099be31567add4e4e4d0d45691c3f58f5663",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13246/thumb/BAC.png?1613231642",
+      "chainId": 42161,
+      "address": "0x6F67043201C903bbCBC129750CB3b328Dd56a0a5",
+      "name": "BAC",
+      "symbol": "BAC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x3449fc1cd036255ba1eb19d65ff4ba2b8903a69a",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x3449fc1cd036255ba1eb19d65ff4ba2b8903a69a",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/badger_32.png",
+      "chainId": 42161,
+      "address": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E",
+      "name": "Badger",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/balancer-bal-logo.png",
+      "chainId": 42161,
+      "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
+      "name": "Balancer",
+      "symbol": "BAL",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xba100000625a3754423978a60c9317c58a424e3d",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0xBbFbde08Bf1BE235a3Fa97d6A27fFfA19Ac4a8a8",
+      "name": "BarkCoin",
+      "symbol": "BARK",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x5bd7ef7113a32b56127ac32272609c42c97849ff",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x5bd7ef7113a32b56127ac32272609c42c97849ff",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/blanktoken_32.png",
+      "chainId": 42161,
+      "address": "0xA5eC9d64b64b8B9E94FEaA7538c084b38117E7Ba",
+      "name": "GoBlank Token",
+      "symbol": "BLANK",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x41a3dba3d677e573636ba691a70ff2d606c29666",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x41a3dba3d677e573636ba691a70ff2d606c29666",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/barnbridge-bond-logo.png",
+      "chainId": 42161,
+      "address": "0x0D81E50bC677fa67341c44D7eaA9228DEE64A4e1",
+      "name": "BarnBridge Governance Token",
+      "symbol": "BOND",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/boostcoin_32.png",
+      "chainId": 42161,
+      "address": "0xd44e8F8768D4ed25119921a53802D8758A5b20dD",
+      "name": "Boost",
+      "symbol": "BOOST",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x4e0fca55a6c3a94720ded91153a27f60e26b9aa8",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x4e0fca55a6c3a94720ded91153a27f60e26b9aa8",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/btu_32.png",
+      "chainId": 42161,
+      "address": "0xBA9a5Dd807c9F072850bE15a52dF3408BA25Fd18",
+      "name": "BTU Protocol",
+      "symbol": "BTU",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xb683d83a532e2cb7dfa5275eed3698436371cc9f",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xb683d83a532e2cb7dfa5275eed3698436371cc9f",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/11775/thumb/CAP.png?1594083244",
+      "chainId": 42161,
+      "address": "0x031d35296154279DC1984dCD93E392b1f946737b",
+      "name": "Cap",
+      "symbol": "CAP",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x43044f861ec040db59a7e324c40507addb673142",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x43044f861ec040db59a7e324c40507addb673142",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+      "chainId": 42161,
+      "address": "0x3a8B787f78D775AECFEEa15706D4221B40F345AB",
+      "name": "CelerToken",
+      "symbol": "CELR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/cryptionnetwork_32.png",
+      "chainId": 42161,
+      "address": "0x989D099d29F62b839C8CbD41c82c6554a5515752",
+      "name": "Cryption Network Token",
+      "symbol": "CNT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x429876c4a6f89fb470e92456b8313879df98b63c",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x429876c4a6f89fb470e92456b8313879df98b63c",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/10775/thumb/COMP.png?1592625425",
+      "chainId": 42161,
+      "address": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+      "name": "Compound",
+      "symbol": "COMP",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/coti-coti-logo.png",
+      "chainId": 42161,
+      "address": "0x6FE14d3CC2f7bDdffBa5CdB3BBE7467dd81ea101",
+      "name": "COTI Token",
+      "symbol": "COTI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xddb3422497e61e13543bea06989c0789117555c5",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xddb3422497e61e13543bea06989c0789117555c5",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/cream-finance-cream-logo.png",
+      "chainId": 42161,
+      "address": "0xf4D48Ce3ee1Ac3651998971541bAdbb9A14D7234",
+      "name": "Cream",
+      "symbol": "CREAM",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x2ba592f78db6436527729929aaf6c908497cb200",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/curve-dao-token-crv-logo.png",
+      "chainId": 42161,
+      "address": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/9956/thumb/4943.png?1636636734",
+      "chainId": 42161,
+      "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "name": "Dai Stablecoin",
+      "symbol": "DAI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "originBridgeAddress": "0x467194771dae2967aef3ecbedd3bf9a310c76c65",
+            "destBridgeAddress": "0xd3b5b60020504bc3489d6949d545893982ba3011"
+          }
+        },
+        "l1Address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "l2GatewayAddress": "0x467194771dae2967aef3ecbedd3bf9a310c76c65",
+        "l1GatewayAddress": "0xd3b5b60020504bc3489d6949d545893982ba3011"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13691/thumb/thGDKHo.png?1610959947",
+      "chainId": 42161,
+      "address": "0xdeBa25AF35e4097146d7629055E0EC3C71706324",
+      "name": "DEFI Top 5 Tokens Index",
+      "symbol": "DEFI5",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xfa6de2697d59e88ed7fc4dfe5a33dac43565ea41",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xfa6de2697d59e88ed7fc4dfe5a33dac43565ea41",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14143/thumb/alpha_logo.png?1614651244",
+      "chainId": 42161,
+      "address": "0xAE6e3540E97b0b9EA8797B157B510e133afb6282",
+      "name": "DEGEN Index",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x126c121f99e1e211df2e5f8de2d96fa36647c855",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x126c121f99e1e211df2e5f8de2d96fa36647c855",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/9709/thumb/xlGxxIjI_400x400.jpg?1571006794",
+      "chainId": 42161,
+      "address": "0xaE6aab43C4f3E0cea4Ab83752C278f8dEbabA689",
+      "name": "dForce",
+      "symbol": "DF",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dfynnetwork_32.png",
+      "chainId": 42161,
+      "address": "0x1D54Aa7E322e02A0453c0F2fA21505cE7F2E9E93",
+      "name": "DFYN Token",
+      "symbol": "DFYN",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x9695e0114e12c0d3a3636fab5a18e6b737529023",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x9695e0114e12c0d3a3636fab5a18e6b737529023",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dHedge_32.png",
+      "chainId": 42161,
+      "address": "0x8038F3C971414FD1FC220bA727F2D4A0fC98cb65",
+      "name": "dHedge DAO Token",
+      "symbol": "DHT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xca1207647ff814039530d7d35df0e1dd2e91fa84",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xca1207647ff814039530d7d35df0e1dd2e91fa84",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dodo_32.png",
+      "chainId": 42161,
+      "address": "0x69Eb4FA4a2fbd498C257C57Ea8b7655a2559A581",
+      "name": "DODO bird",
+      "symbol": "DODO",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/thedogenft_32.png",
+      "chainId": 42161,
+      "address": "0x4425742F1EC8D98779690b5A3A6276Db85Ddc01A",
+      "name": "The Doge NFT",
+      "symbol": "DOG",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xbaac2b4491727d78d2b78815144570b9f2fe8899",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xbaac2b4491727d78d2b78815144570b9f2fe8899",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dopexgovernance_32.png",
+      "chainId": 42161,
+      "address": "0x6C2C06790b3E3E3c38e12Ee22F8183b37a13EE55",
+      "name": "Dopex Governance Token",
+      "symbol": "DPX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/17482/thumb/photo_2021-08-03_09-24-16.png?1627953917",
+      "chainId": 42161,
+      "address": "0xE212f5E733257ed5628a2FeBcEdBc9222e535F51",
+      "name": "Digital Standard Unit",
+      "symbol": "DSU",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x605d26fbd5be761089281d5cec2ce86eea667109",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x605d26fbd5be761089281d5cec2ce86eea667109",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dvf_32.png",
+      "chainId": 42161,
+      "address": "0xA7Aa2921618e3D63dA433829d448b58C9445A4c3",
+      "name": "DeversiFi Token",
+      "symbol": "DVF",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xdddddd4301a082e62e84e43f474f044423921918",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xdddddd4301a082e62e84e43f474f044423921918",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/11148/thumb/dxdao.png?1607999331",
+      "chainId": 42161,
+      "address": "0xC3Ae0333F0F34aa734D5493276223d95B8F9Cb37",
+      "name": "DXdao",
+      "symbol": "DXD",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/17481/thumb/photo_2021-08-03_03-26-29.png?1627953584",
+      "chainId": 42161,
+      "address": "0xCE32aA8d60807182c0003Ef9cc1976Fa10E5d312",
+      "name": "Empty Set Share",
+      "symbol": "ESS",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x24ae124c4cc33d6791f8e8b63520ed7107ac8b3e",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x24ae124c4cc33d6791f8e8b63520ed7107ac8b3e",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dforceeur_32.png",
+      "chainId": 42161,
+      "address": "0x969131D8ddC06C2Be11a13e6E7fACF22CF57d95e",
+      "name": "dForce EUR",
+      "symbol": "EUX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xb986f3a2d91d3704dc974a24fb735dcc5e3c1e70",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xb986f3a2d91d3704dc974a24fb735dcc5e3c1e70",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/11756/thumb/fluxres.png?1593748917",
+      "chainId": 42161,
+      "address": "0xF80D589b3Dbe130c270a69F1a69D050f268786Df",
+      "name": "Flux",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/zel-flux-logo.png",
+      "chainId": 42161,
+      "address": "0x2338a5d62E9A766289934e8d2e83a443e8065b83",
+      "name": "Flux Protocol",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x7645ddfeeceda57e41f92679c4acd83c56a81d14",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x7645ddfeeceda57e41f92679c4acd83c56a81d14",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/8242/thumb/for.png?1606195375",
+      "chainId": 42161,
+      "address": "0x3816e40c1eB106c8fb7c05f901cfD58C7292D051",
+      "name": "The Force Token",
+      "symbol": "FOR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x1fcdce58959f536621d76f5b7ffb955baa5a672f",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x1fcdce58959f536621d76f5b7ffb955baa5a672f",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/futureswap2_32.png",
+      "chainId": 42161,
+      "address": "0x488cc08935458403a0458e45E20c0159c8AB2c92",
+      "name": "Futureswap Token",
+      "symbol": "FST",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0e192d382a36de7011f795acc4391cd302003606",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0e192d382a36de7011f795acc4391cd302003606",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/10347/thumb/vUXKHEe.png?1601523640",
+      "chainId": 42161,
+      "address": "0xBDeF0E9ef12E689F366fe494A7A7D0dad25D9286",
+      "name": "Fuse Token",
+      "symbol": "FUSE",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0x590020B1005b8b25f1a2C82c5f743c540dcfa24d",
+      "name": "GMX",
+      "symbol": "GMX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xbc30049adc73de06d7a98a5189203aac66b2c830",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xbc30049adc73de06d7a98a5189203aac66b2c830",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/662/thumb/logo_square_simple_300px.png?1609402668",
+      "chainId": 42161,
+      "address": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1",
+      "name": "Gnosis Token",
+      "symbol": "GNO",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13875/thumb/GOVI.png?1612451531",
+      "chainId": 42161,
+      "address": "0x07E49d5dE43DDA6162Fa28D24d5935C151875283",
+      "name": "GOVI",
+      "symbol": "GOVI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xeeaa40b28a2d1b0b08f6f97bb1dd4b75316c6107",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xeeaa40b28a2d1b0b08f6f97bb1dd4b75316c6107",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+      "chainId": 42161,
+      "address": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614",
+      "name": "Graph Token",
+      "symbol": "GRT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/impermax_32.png",
+      "chainId": 42161,
+      "address": "0x9c67eE39e3C4954396b9142010653F17257dd39C",
+      "name": "Impermax",
+      "symbol": "IMX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x7b35ce522cb72e4077baeb96cb923a5529764a00",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x7b35ce522cb72e4077baeb96cb923a5529764a00",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13177/thumb/kun_logo.png?1605923919",
+      "chainId": 42161,
+      "address": "0x04cb2d263a7489f02d813eaaB9Ba1bb8466347F2",
+      "name": "QIAN governance token",
+      "symbol": "KUN",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x65d9bc970aa9b2413027fa339f7f179b3f3f2604",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x65d9bc970aa9b2413027fa339f7f179b3f3f2604",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/farmland_32.png",
+      "chainId": 42161,
+      "address": "0x3CD1833Ce959E087D0eF0Cb45ed06BffE60F23Ba",
+      "name": "Land",
+      "symbol": "LAND",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x3258cd8134b6b28e814772dd91d5ecceea512818",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x3258cd8134b6b28e814772dd91d5ecceea512818",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1547034700",
+      "chainId": 42161,
+      "address": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+      "name": "ChainLink Token",
+      "symbol": "LINK",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/loopring-lrc-logo.png",
+      "chainId": 42161,
+      "address": "0x46d0cE7de6247b0A95f67b43B589b4041BaE7fbE",
+      "name": "LoopringCoin V2",
+      "symbol": "LRC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/18623/thumb/Magic.png?1635755672",
+      "chainId": 42161,
+      "address": "0x539bdE0d7Dbd336b79148AA742883198BBF60342",
+      "name": "MAGIC",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0xAA086809EFA469631DD90D8C6cB267bAb107E958",
+      "name": "My Alpha Leaderboard",
+      "symbol": "MAL",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6619078bdd8324e01e9a8d4b3d761b050e5ecf06",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x6619078bdd8324e01e9a8d4b3d761b050e5ecf06",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+      "chainId": 42161,
+      "address": "0x99F40b01BA9C469193B360f72740E416B17Ac332",
+      "name": "MATH Token",
+      "symbol": "MATH",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/antimatter_32.png",
+      "chainId": 42161,
+      "address": "0xaaA62D9584Cbe8e4D68A43ec91BfF4fF1fAdB202",
+      "name": "Antimatter.Finance Governance Token",
+      "symbol": "MATTER",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x9b99cca871be05119b2012fd4474731dd653febe",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x9b99cca871be05119b2012fd4474731dd653febe",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/11796/thumb/mcb.png?1594355515",
+      "chainId": 42161,
+      "address": "0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42",
+      "name": "MCDEX Token",
+      "symbol": "MCB",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/maker-mkr-logo.png",
+      "chainId": 42161,
+      "address": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879",
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/11846/thumb/mStable.png?1594950533",
+      "chainId": 42161,
+      "address": "0x5298Ee77A8f9E226898403eBAC33e68a62F770A0",
+      "name": "Meta",
+      "symbol": "MTA",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13546/thumb/indexed-light.74bb5471.png?1609712728",
+      "chainId": 42161,
+      "address": "0xB965029343D55189c25a7f3e0c9394DC0F5D41b1",
+      "name": "Indexed",
+      "symbol": "NDX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x86772b1409b61c639eaac9ba0acfbb6e238e5f83",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x86772b1409b61c639eaac9ba0acfbb6e238e5f83",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd67D9F7E018B4e7613b0251BBe3Ba3988Baf7C16",
+      "name": "New era",
+      "symbol": "NEC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x1353a77abd236207d0588bcbbb52bc3087f85351",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x1353a77abd236207d0588bcbbb52bc3087f85351",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/feistydoge_32.png",
+      "chainId": 42161,
+      "address": "0xc9c2B86CD4cdbAB70cd65D22EB044574c3539F6c",
+      "name": "Feisty Doge NFT",
+      "symbol": "NFD",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xdfdb7f72c1f195c5951a234e8db9806eb0635346",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xdfdb7f72c1f195c5951a234e8db9806eb0635346",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/12594/thumb/octofi-256x256-radius-22percent.png?1610679969",
+      "chainId": 42161,
+      "address": "0x52f5d9B3a2bB89D3aEC5829A3415c21115aCD633",
+      "name": "Octo.fi",
+      "symbol": "OCTO",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x7240ac91f01233baaf8b064248e80feaa5912ba3",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x7240ac91f01233baaf8b064248e80feaa5912ba3",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14483/thumb/token_OHM_%281%29.png?1628311611",
+      "chainId": 42161,
+      "address": "0x6E6a3D8F1AfFAc703B1aEF1F43B8D2321bE40043",
+      "name": "Olympus",
+      "symbol": "OHM",
+      "decimals": 9,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x383518188c0c6d7730d91b2c03a03c837814a899",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x383518188c0c6d7730d91b2c03a03c837814a899",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13429/thumb/ovr_logo.png?1608518911",
+      "chainId": 42161,
+      "address": "0x55704A0e9E2eb59E176C5b69655DbD3DCDCFc0F0",
+      "name": "OVR",
+      "symbol": "OVR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+      "chainId": 42161,
+      "address": "0x753D224bCf9AAFaCD81558c32341416df61D3DAC",
+      "name": "Perpetual",
+      "symbol": "PERP",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/pickle_32.png",
+      "chainId": 42161,
+      "address": "0x965772e0E9c84b6f359c8597C891108DcF1c5B1A",
+      "name": "PickleToken",
+      "symbol": "PICKLE",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3642c0680329ae3e103E2B5AB29DDfed4d43CBE5",
+      "name": "Plenny",
+      "symbol": "PL2",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x3642c0680329ae3e103e2b5ab29ddfed4d43cbe5",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x3642c0680329ae3e103e2b5ab29ddfed4d43cbe5",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13962/thumb/apple-touch-icon.png?1623679482",
+      "chainId": 42161,
+      "address": "0x51fC0f6660482Ea73330E414eFd7808811a57Fa2",
+      "name": "Premia",
+      "symbol": "PREMIA",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6399c842dd2be3de30bf99bc7d1bbf6fa3650e70",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x6399c842dd2be3de30bf99bc7d1bbf6fa3650e70",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/raireflexindex_32.png",
+      "chainId": 42161,
+      "address": "0xaeF5bbcbFa438519a5ea80B4c7181B4E78d419f2",
+      "name": "Rai Reflex Index",
+      "symbol": "RAI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dopexrebate_32.png",
+      "chainId": 42161,
+      "address": "0x32Eb7902D4134bf98A28b963D26de779AF92A212",
+      "name": "Dopex Rebate Token",
+      "symbol": "RDPX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0ff5a8451a839f5f0bb3562689d9a44089738d11",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x0ff5a8451a839f5f0bb3562689d9a44089738d11",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/RariGovernanceToken_32.png",
+      "chainId": 42161,
+      "address": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794",
+      "name": "Rari Governance Token",
+      "symbol": "RGT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xd291e7a03283640fdc51b121ac401383a46cc623",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xd291e7a03283640fdc51b121ac401383a46cc623",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13709/thumb/route_token_200x200-19.png?1611057698",
+      "chainId": 42161,
+      "address": "0x5298060A95205BE6Dd4aBc21910A4bB23D6DCD8b",
+      "name": "Route",
+      "symbol": "ROUTE",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x16eccfdbb4ee1a85a33f3a9b21175cd7ae753db4",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x16eccfdbb4ee1a85a33f3a9b21175cd7ae753db4",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/12428/thumb/sake.png?1599777402",
+      "chainId": 42161,
+      "address": "0x552E4e96A0Ce6D36d161b63984848c8dAC471ea2",
+      "name": "SakeToken",
+      "symbol": "SAKE",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x066798d9ef0833ccc719076dab77199ecbd178b0",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x066798d9ef0833ccc719076dab77199ecbd178b0",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/13724/thumb/stakedao_logo.jpg?1611195011",
+      "chainId": 42161,
+      "address": "0x7bA4a00d54A07461D9DB2aEF539e91409943AdC9",
+      "name": "Stake DAO Token",
+      "symbol": "SDT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5575552988A3A80504bBaeB1311674fCFd40aD4B",
+      "name": "Sperax",
+      "symbol": "SPA",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x2a95fe4c7e64e09856989f9ea0b57b9ab5f770cb",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0x2a95fe4c7e64e09856989f9ea0b57b9ab5f770cb",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/spelltoken_32.png",
+      "chainId": 42161,
+      "address": "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF",
+      "name": "Spell Token",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/strips_32.png",
+      "chainId": 42161,
+      "address": "0x326c33FD1113c1F29B35B4407F3d6312a8518431",
+      "name": "Strips Token",
+      "symbol": "STRP",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x97872eafd79940c7b24f7bcc1eadb1457347adc9",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x97872eafd79940c7b24f7bcc1eadb1457347adc9",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/sumswap_32.png",
+      "chainId": 42161,
+      "address": "0x20f9628a485ebCc566622314f6e07E7Ee61fF332",
+      "name": "SUM",
+      "symbol": "SUM",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x043c308bb8a5ae96d0093444be7f56459f1340b1",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x043c308bb8a5ae96d0093444be7f56459f1340b1",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/sushiswap-sushi-logo.png",
+      "chainId": 42161,
+      "address": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A",
+      "name": "SushiToken",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/18740/thumb/swapr.jpg?1633516501",
+      "chainId": 42161,
+      "address": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
+      "name": "Swapr",
+      "symbol": "SWPR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6cacdb97e3fc8136805a9e7c342d866ab77d0957",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x6cacdb97e3fc8136805a9e7c342d866ab77d0957",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/tkdcoop_32.png",
+      "chainId": 42161,
+      "address": "0xFa51B42d4C9EA35F1758828226AaEdBeC50DD54E",
+      "name": "Taekwondo Access Credit",
+      "symbol": "TAC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xdeeb6091a5adc78fa0332bee5a38a8908b6b566e",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xdeeb6091a5adc78fa0332bee5a38a8908b6b566e",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/18271/thumb/tracer_logo.png?1631176676",
+      "chainId": 42161,
+      "address": "0xA72159FC390f0E3C6D415e658264c7c4051E9b87",
+      "name": "Tracer",
+      "symbol": "TCR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://images.prismic.io/tusd-homepage/fb4d581a-95ed-404c-b9de-7ab1365c1386_%E5%9B%BE%E5%B1%82+1.png",
+      "chainId": 42161,
+      "address": "0x4D15a3A2286D883AF0AA1B3f21367843FAc63E07",
+      "name": "TrueUSD",
+      "symbol": "TUSD",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0000000000085d4780b73119b644ae5ecd22b376",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0000000000085d4780b73119b644ae5ecd22b376",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/2707/thumb/UnibrightLogo_colorful_500x500_preview.png?1547036916",
+      "chainId": 42161,
+      "address": "0x2aD62674A64E698C24831Faf824973C360430140",
+      "name": "UniBright",
+      "symbol": "UBT",
+      "decimals": 8,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14545/thumb/unlock.jpg?1616948136",
+      "chainId": 42161,
+      "address": "0xd5d3aA404D7562d09a848F96a8a8d5D65977bF90",
+      "name": "Unlock Discount Token",
+      "symbol": "UDT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x90de74265a416e1393a450752175aed98fe11517",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x90de74265a416e1393a450752175aed98fe11517",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-uni.png?1600306604",
+      "chainId": 42161,
+      "address": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+      "name": "Uniswap",
+      "symbol": "UNI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/unitynetwork_32.png",
+      "chainId": 42161,
+      "address": "0x250F471385894fc81183a99d6fDe8CE9C5B142d6",
+      "name": "Unity Network",
+      "symbol": "UNT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x8d610e20481f4c4f3acb87bba9c46bef7795fdfe",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x8d610e20481f4c4f3acb87bba9c46bef7795fdfe",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/thumb/USD_Coin_icon.png?1547042389",
+      "chainId": 42161,
+      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "USD Coin (Arb1)",
+      "symbol": "USDC",
+      "decimals": 6,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/325/thumb/Tether-logo.png?1598003707",
+      "chainId": 42161,
+      "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Tether USD",
+      "symbol": "USDT",
+      "decimals": 6,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/dforceusd_32.png",
+      "chainId": 42161,
+      "address": "0xcd14C3A2ba27819B352aae73414A26e2b366dC50",
+      "name": "dForce USD",
+      "symbol": "USX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0a5e677a6a24b2f1a2bf4f3bffc443231d2fdec8",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0a5e677a6a24b2f1a2bf4f3bffc443231d2fdec8",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://etherscan.io/token/images/validator_32.png",
+      "chainId": 42161,
+      "address": "0x8d1c89DcF613e3e709AfE9Abecae591D0e2B64Ca",
+      "name": "Validator",
+      "symbol": "VALX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x27c4af9a860c4cadc358005f8b48140b2e434a7b",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x27c4af9a860c4cadc358005f8b48140b2e434a7b",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14381/thumb/visor_logo.png?1615782828",
+      "chainId": 42161,
+      "address": "0x995C235521820f2637303Ca1970c7c044583df44",
+      "name": "VISOR",
+      "symbol": "VISR",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xf938424f7210f31df2aee3011291b658f872e91e",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xf938424f7210f31df2aee3011291b658f872e91e",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/12880/thumb/BSensIa.png?1603261093",
+      "chainId": 42161,
+      "address": "0x2eD14d1788dfB780fD216706096AeD018514ECcd",
+      "name": "Vox.Finance",
+      "symbol": "VOX",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x12d102f06da35cc0111eb58017fd2cd28537d0e1",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x12d102f06da35cc0111eb58017fd2cd28537d0e1",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/7598/thumb/wrapped_bitcoin_wbtc.png?1548822744",
+      "chainId": 42161,
+      "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+      "name": "Wrapped BTC",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/2091/thumb/xaya_logo-1.png?1547036406",
+      "chainId": 42161,
+      "address": "0xA64eCCe74F8CdB7a940766B71f1b108BAC69851a",
+      "name": "Wrapped CHI",
+      "symbol": "WCHI",
+      "decimals": 8,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x6dc02164d75651758ac74435806093e421b64605",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x6dc02164d75651758ac74435806093e421b64605",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/2518/thumb/weth.png?1628852295",
+      "chainId": 42161,
+      "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Wrapped Ether",
+      "symbol": "WETH",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "originBridgeAddress": "0x6c411ad3e74de3e7bd422b94a27770f5b86c623b",
+            "destBridgeAddress": "0xd92023E9d9911199a6711321D1277285e6d4e2db"
+          }
+        },
+        "l1Address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "l2GatewayAddress": "0x6c411ad3e74de3e7bd422b94a27770f5b86c623b",
+        "l1GatewayAddress": "0xd92023E9d9911199a6711321D1277285e6d4e2db"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+      "chainId": 42161,
+      "address": "0xcAFcD85D8ca7Ad1e1C6F82F651fA15E33AEfD07b",
+      "name": "Wootrade Network",
+      "symbol": "WOO",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/14089/thumb/xToken.png?1614226407",
+      "chainId": 42161,
+      "address": "0xF0A5717Ec0883eE56438932b0fe4A20822735fBa",
+      "name": "xToken",
+      "symbol": "XTK",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x7f3edcdd180dbe4819bd98fee8929b5cedb3adeb",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x7f3edcdd180dbe4819bd98fee8929b5cedb3adeb",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://cryptologos.cc/logos/yearn-finance-yfi-logo.png",
+      "chainId": 42161,
+      "address": "0x82e3A8F066a6989666b031d916c43672085b1582",
+      "name": "yearn.finance",
+      "symbol": "YFI",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/4302/thumb/zippie.jpg?1547039665",
+      "chainId": 42161,
+      "address": "0x0F61B24272AF65EACF6adFe507028957698e032F",
+      "name": "Zippie",
+      "symbol": "ZIPT",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xedd7c94fd7b4971b916d15067bc454b9e1bad980",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xedd7c94fd7b4971b916d15067bc454b9e1bad980",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/15500/thumb/ibbtc.png?1621077589",
+      "chainId": 42161,
+      "address": "0x9Ab3FD50FcAe73A1AEDa959468FD0D662c881b42",
+      "name": "Interest-Bearing Bitcoin",
+      "symbol": "ibBTC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xc4e15973e6ff2a35cc804c2cf9d2a1b817a8b40f",
+            "originBridgeAddress": "0x096760f208390250649e3e8763348e783aef5562",
+            "destBridgeAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+          }
+        },
+        "l1Address": "0xc4e15973e6ff2a35cc804c2cf9d2a1b817a8b40f",
+        "l2GatewayAddress": "0x096760f208390250649e3e8763348e783aef5562",
+        "l1GatewayAddress": "0xcEe284F754E854890e311e3280b767F80797180d"
+      }
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4f947b40BEEB9D8130437781a560E5c7D089730f",
+      "name": "KAKI USDC",
+      "symbol": "kUSDC",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0xa124ff1e97e7f3e4a796f6a2d3bf5d0e2d41973d",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0xa124ff1e97e7f3e4a796f6a2d3bf5d0e2d41973d",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    },
+    {
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+      "chainId": 42161,
+      "address": "0xA970AF1a584579B618be4d69aD6F73459D112F95",
+      "name": "Synth sUSD",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "extensions": {
+        "bridgeInfo": {
+          "1": {
+            "tokenAddress": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
+            "originBridgeAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+            "destBridgeAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+          }
+        },
+        "l1Address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
+        "l2GatewayAddress": "0x09e9222e96e7b4ae2a407b98d48e330053351eee",
+        "l1GatewayAddress": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC"
+      }
+    }
+  ]
+}

--- a/gateway/src/chains/ethereum/ethereum.config.ts
+++ b/gateway/src/chains/ethereum/ethereum.config.ts
@@ -62,8 +62,9 @@ export function getEthereumConfig(
     nativeCurrencySymbol: ConfigManagerV2.getInstance().get(
       chainName + '.networks.' + network + '.nativeCurrencySymbol'
     ),
-    manualGasPrice: ConfigManagerV2.getInstance().get(
-      chainName + '.manualGasPrice'
-    ),
+    manualGasPrice:
+      ConfigManagerV2.getInstance().get(
+        chainName + '.networks.' + network + '.manualGasPrice'
+      ) ?? ConfigManagerV2.getInstance().get(chainName + '.manualGasPrice'),
   };
 }

--- a/gateway/src/services/schema/ethereum-schema.json
+++ b/gateway/src/services/schema/ethereum-schema.json
@@ -13,7 +13,8 @@
             "tokenListType": { "type": "string" },
             "tokenListSource": { "type": "string" },
             "nativeCurrencySymbol": { "type": "string" },
-            "gasPriceRefreshInterval": { "type": "number" }
+            "gasPriceRefreshInterval": { "type": "number" },
+            "manualGasPrice": { "type": "integer" }
           },
           "required": [
             "chainID",

--- a/gateway/src/templates/ethereum.yml
+++ b/gateway/src/templates/ethereum.yml
@@ -18,8 +18,15 @@ networks:
     chainID: 3
     nodeURL: https://ropsten.infura.io/v3/
     tokenListType: FILE
-    tokenListSource: src/chains/ethereum/erc20_tokens_ropsten.json  
+    tokenListSource: src/chains/ethereum/erc20_tokens_ropsten.json
     nativeCurrencySymbol: ETH
     gasPriceRefreshInterval: 60
+  arbitrumOne:
+    chainID: 42161
+    nodeURL: https://arbitrum-mainnet.infura.io/v3/
+    tokenListType: FILE
+    tokenListSource: src/chains/ethereum/erc20_tokens_arbitrum_one.json
+    nativeCurrencySymbol: ETH
+    manualGasPrice: 2
 nodeAPIKey: ''
 manualGasPrice: 110

--- a/gateway/src/templates/uniswap.yml
+++ b/gateway/src/templates/uniswap.yml
@@ -32,8 +32,11 @@ contractAddresses:
     uniswapV2RouterAddress: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
     uniswapV3RouterAddress: '0xE592427A0AEce92De3Edee1F18E0157C05861564'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
-  ropsten: 
+  ropsten:
     uniswapV2RouterAddress: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
     uniswapV3RouterAddress: '0xE592427A0AEce92De3Edee1F18E0157C05861564'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
-
+  arbitrumOne:
+    uniswapV2RouterAddress: ''
+    uniswapV3RouterAddress: '0xE592427A0AEce92De3Edee1F18E0157C05861564'
+    uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'

--- a/gateway/test/chains/ethereum/uniswap/uniswap.v3.arbitrum.test.ts
+++ b/gateway/test/chains/ethereum/uniswap/uniswap.v3.arbitrum.test.ts
@@ -8,26 +8,26 @@ import { BigNumber, Contract, Transaction, Wallet } from 'ethers';
 import { Ethereum } from '../../../../src/chains/ethereum/ethereum';
 import { UniswapV3Helper } from '../../../../src/connectors/uniswap/uniswap.v3.helper';
 
-let ethereum: Ethereum;
+let arbitrum: Ethereum;
 let uniswapV3: UniswapV3;
 let uniswapV3Helper: UniswapV3Helper;
 let wallet: Wallet;
 
 const WETH = new Token(
   3,
-  '0xd0A1E359811322d97991E03f863a0C30C2cF029C',
+  '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
   18,
   'WETH'
 );
 const DAI = new Token(
   3,
-  '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
+  '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
   18,
   'DAI'
 );
 const USDC = new Token(
   3,
-  '0x2F375e94FC336Cdec2Dc0cCB5277FE59CBf1cAe5',
+  '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
   18,
   'USDC'
 );
@@ -45,7 +45,7 @@ const TICK_PROVIDER = [
 ];
 const TX = {
   type: 2,
-  chainId: 42,
+  chainId: 42161,
   nonce: 115,
   maxPriorityFeePerGas: { toString: () => '106000000000' },
   maxFeePerGas: { toString: () => '106000000000' },
@@ -77,15 +77,15 @@ const DAI_USDC_POOL = new uniV3.Pool(
 );
 
 beforeAll(async () => {
-  ethereum = Ethereum.getInstance('kovan');
-  await ethereum.init();
+  arbitrum = Ethereum.getInstance('arbitrumOne');
+  await arbitrum.init();
   wallet = new Wallet(
     '0000000000000000000000000000000000000000000000000000000000000002', // noqa: mock
-    ethereum.provider
+    arbitrum.provider
   );
-  uniswapV3 = UniswapV3.getInstance('ethereum', 'kovan');
+  uniswapV3 = UniswapV3.getInstance('ethereum', 'arbitrumOne');
   await uniswapV3.init();
-  uniswapV3Helper = new UniswapV3Helper('kovan');
+  uniswapV3Helper = new UniswapV3Helper('arbitrumOne');
 });
 
 afterEach(() => {
@@ -262,8 +262,8 @@ describe('verify UniswapV3 Nft functions', () => {
 
     const callData = await uniswapV3.addPositionHelper(
       wallet,
-      DAI,
       WETH,
+      DAI,
       '10',
       '10',
       500,
@@ -361,8 +361,8 @@ describe('verify UniswapV3 Nft functions', () => {
 
     const addTx = await uniswapV3.addPosition(
       wallet,
-      DAI,
       WETH,
+      DAI,
       '10',
       '10',
       500,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Adds `arbitrumOne` as a new network for the `ethereum` chain and as an option for the `uniswap.v3` connector. As far as I can tell, Uniswap v2 has not been deployed onto Arbitrum One, so I just added support for the Uniswap v3 deployment.

This PR is part of my hackathon project at the ETHPortland hackathon.

**Tests performed by the developer**:

Added new unit test: `gateway/test/chains/ethereum/uniswap/uniswap.v3.arbitrum.test.ts` (adapted from the current `uniswap.v3.test.ts` file)

I ran out of time and couldn't get my local hummingbot instance to talk with my local gateway-v2 process, so I wasn't able to actually test the connector in a running hummingbot client. It's quite possible that I'm missing something, so definitely open to feedback on this PR.

**Tips for QA testing**:

The Arbitrum token list in the PR has been adapted from https://bridge.arbitrum.io/token-list-42161.json (a suggestion from `vic-en` on Discord).
