### PR TITLE
feat / add connector for dfx.finance

### DIFF
--- a/gateway/setup/generate_conf.sh
+++ b/gateway/setup/generate_conf.sh
@@ -50,6 +50,9 @@ echo "created $HOST_CONF_PATH/server.yml"
 cp "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../src/templates/uniswap.yml" "$HOST_CONF_PATH/uniswap.yml"
 echo "created $HOST_CONF_PATH/uniswap.yml"
 
+cp "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../src/templates/dfx.yml" "$HOST_CONF_PATH/dfx.yml"
+echo "created $HOST_CONF_PATH/dfx.yml"
+
 # generate the telemetry file
 echo "enabled: false" > "$HOST_CONF_PATH/telemetry.yml"  # enabled must be prompted
 echo "created $HOST_CONF_PATH/telemetry.yml"

--- a/gateway/src/app.ts
+++ b/gateway/src/app.ts
@@ -17,9 +17,6 @@ import { NetworkRoutes } from './network/network.routes';
 import { ConnectorsRoutes } from './connectors/connectors.routes';
 import { EVMRoutes } from './evm/evm.routes';
 import { AmmRoutes } from './amm/amm.routes';
-import { PangolinConfig } from './connectors/pangolin/pangolin.config';
-import { UniswapConfig } from './connectors/uniswap/uniswap.config';
-import { AvailableNetworks } from './services/config-manager-types';
 import morgan from 'morgan';
 
 const swaggerUi = require('swagger-ui-express');
@@ -48,21 +45,6 @@ gatewayApp.use('/solana', SolanaRoutes.router);
 gatewayApp.get('/', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
 });
-
-interface ConnectorsResponse {
-  uniswap: Array<AvailableNetworks>;
-  pangolin: Array<AvailableNetworks>;
-}
-
-gatewayApp.get(
-  '/connectors',
-  asyncHandler(async (_req, res: Response<ConnectorsResponse, {}>) => {
-    res.status(200).json({
-      uniswap: UniswapConfig.config.availableNetworks,
-      pangolin: PangolinConfig.config.availableNetworks,
-    });
-  })
-);
 
 interface ConfigUpdateRequest {
   configPath: string;

--- a/gateway/src/connectors/connectors.routes.ts
+++ b/gateway/src/connectors/connectors.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { asyncHandler } from '../services/error-handler';
+import { DfxConfig } from './dfx/dfx.config';
 import { PangolinConfig } from './pangolin/pangolin.config';
 import { UniswapConfig } from './uniswap/uniswap.config';
 
@@ -15,6 +16,11 @@ export namespace ConnectorsRoutes {
             name: 'uniswap',
             trading_type: UniswapConfig.config.tradingTypes('v2'),
             available_networks: UniswapConfig.config.availableNetworks,
+          },
+          {
+            name: 'dfx',
+            trading_type: DfxConfig.config.tradingTypes,
+            available_networks: DfxConfig.config.availableNetworks,
           },
           {
             name: 'pangolin',

--- a/gateway/src/connectors/dfx/DfxRouter.json
+++ b/gateway/src/connectors/dfx/DfxRouter.json
@@ -1,0 +1,102 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_factory", "type": "address" }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "factory",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_quoteCurrency",
+          "type": "address"
+        },
+        { "internalType": "address", "name": "_origin", "type": "address" },
+        { "internalType": "address", "name": "_target", "type": "address" },
+        {
+          "internalType": "uint256",
+          "name": "_originAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_minTargetAmount",
+          "type": "uint256"
+        },
+        { "internalType": "uint256", "name": "_deadline", "type": "uint256" }
+      ],
+      "name": "originSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "targetAmount_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_quoteCurrency",
+          "type": "address"
+        },
+        { "internalType": "address", "name": "_origin", "type": "address" },
+        { "internalType": "address", "name": "_target", "type": "address" },
+        {
+          "internalType": "uint256",
+          "name": "_originAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "viewOriginSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "targetAmount_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_quoteCurrency",
+          "type": "address"
+        },
+        { "internalType": "address", "name": "_origin", "type": "address" },
+        { "internalType": "address", "name": "_target", "type": "address" },
+        {
+          "internalType": "uint256",
+          "name": "_targetAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "viewTargetSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "originAmount_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/gateway/src/connectors/dfx/dfx.config.ts
+++ b/gateway/src/connectors/dfx/dfx.config.ts
@@ -1,0 +1,25 @@
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
+import { AvailableNetworks } from '../../services/config-manager-types';
+
+export namespace DfxConfig {
+  export interface NetworkConfig {
+    allowedSlippage: string;
+    gasLimit: number;
+    ttl: number;
+    routerAddress: (network: string) => string;
+    tradingTypes: Array<string>;
+    availableNetworks: Array<AvailableNetworks>;
+  }
+
+  export const config: NetworkConfig = {
+    allowedSlippage: ConfigManagerV2.getInstance().get('dfx.allowedSlippage'),
+    gasLimit: ConfigManagerV2.getInstance().get('dfx.gasLimit'),
+    ttl: ConfigManagerV2.getInstance().get('dfx.ttl'),
+    routerAddress: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `dfx.contractAddresses.${network}.routerAddress`
+      ),
+    tradingTypes: ['EVM_AMM'],
+    availableNetworks: [{ chain: 'ethereum', networks: ['mainnet'] }],
+  };
+}

--- a/gateway/src/connectors/dfx/dfx.ts
+++ b/gateway/src/connectors/dfx/dfx.ts
@@ -1,0 +1,279 @@
+import { percentRegexp } from '../../services/config-manager-v2';
+import { UniswapishPriceError } from '../../services/error-handler';
+import {
+  BigNumber,
+  Contract,
+  ContractInterface,
+  Transaction,
+  Wallet,
+} from 'ethers';
+import { DfxConfig } from './dfx.config';
+import routerAbi from './DfxRouter.json';
+import {
+  Fetcher,
+  Percent,
+  Router,
+  Token,
+  TokenAmount,
+  Trade,
+  Pair,
+} from '@uniswap/sdk';
+
+import { logger } from '../../services/logger';
+import { ExpectedTrade, Uniswapish } from '../../services/common-interfaces';
+import { Ethereum } from '../../chains/ethereum/ethereum';
+
+export class Dfx implements Uniswapish {
+  private static _instances: { [name: string]: Dfx };
+  private ethereum: Ethereum;
+  private _chain: string;
+  private _router: string;
+  private _routerAbi: ContractInterface;
+  private _gasLimit: number;
+  private _ttl: number;
+  private chainId;
+  private tokenList: Record<string, Token> = {};
+  private _ready: boolean = false;
+
+  private constructor(chain: string, network: string) {
+    this._chain = chain;
+    const config = DfxConfig.config;
+    this.ethereum = Ethereum.getInstance(network);
+    this.chainId = this.ethereum.chainId;
+    this._router = config.routerAddress(network);
+    this._ttl = config.ttl;
+    this._routerAbi = routerAbi.abi;
+    this._gasLimit = config.gasLimit;
+  }
+
+  public static getInstance(chain: string, network: string): Dfx {
+    if (Dfx._instances === undefined) {
+      Dfx._instances = {};
+    }
+    if (!(chain + network in Dfx._instances)) {
+      Dfx._instances[chain + network] = new Dfx(chain, network);
+    }
+
+    return Dfx._instances[chain + network];
+  }
+
+  /**
+   * Given a token's address, return the connector's native representation of
+   * the token.
+   *
+   * @param address Token address
+   */
+  public getTokenByAddress(address: string): Token {
+    return this.tokenList[address];
+  }
+
+  public async init() {
+    if (this._chain == 'ethereum' && !this.ethereum.ready())
+      throw new Error('Avalanche is not available');
+    for (const token of this.ethereum.storedTokenList) {
+      this.tokenList[token.address] = new Token(
+        this.chainId,
+        token.address,
+        token.decimals,
+        token.symbol,
+        token.name
+      );
+    }
+    this._ready = true;
+  }
+
+  public ready(): boolean {
+    return this._ready;
+  }
+
+  /**
+   * Router address.
+   */
+  public get router(): string {
+    return this._router;
+  }
+
+  /**
+   * Router smart contract ABI.
+   */
+  public get routerAbi(): ContractInterface {
+    return this._routerAbi;
+  }
+
+  /**
+   * Default gas limit for swap transactions.
+   */
+  public get gasLimit(): number {
+    return this._gasLimit;
+  }
+
+  /**
+   * Default time-to-live for swap transactions, in seconds.
+   */
+  public get ttl(): number {
+    return this._ttl;
+  }
+
+  getSlippagePercentage(): Percent {
+    const allowedSlippage = DfxConfig.config.allowedSlippage;
+    const nd = allowedSlippage.match(percentRegexp);
+    if (nd) return new Percent(nd[1], nd[2]);
+    throw new Error(
+      'Encountered a malformed percent string in the config for ALLOWED_SLIPPAGE.'
+    );
+  }
+
+  /**
+   * Given the amount of `baseToken` to put into a transaction, calculate the
+   * amount of `quoteToken` that can be expected from the transaction.
+   *
+   * This is typically used for calculating token sell prices.
+   *
+   * @param baseToken Token input for the transaction
+   * @param quoteToken Output from the transaction
+   * @param amount Amount of `baseToken` to put into the transaction
+   */
+  async estimateSellTrade(
+    baseToken: Token,
+    quoteToken: Token,
+    amount: BigNumber
+  ): Promise<ExpectedTrade> {
+    const nativeTokenAmount: TokenAmount = new TokenAmount(
+      baseToken,
+      amount.toString()
+    );
+    logger.info(
+      `Fetching pair data for ${baseToken.address}-${quoteToken.address}.`
+    );
+    const pair: Pair = await Fetcher.fetchPairData(
+      baseToken,
+      quoteToken,
+      this.ethereum.provider
+    );
+    const trades: Trade[] = Trade.bestTradeExactIn(
+      [pair],
+      nativeTokenAmount,
+      quoteToken,
+      { maxHops: 1 }
+    );
+    if (!trades || trades.length === 0) {
+      throw new UniswapishPriceError(
+        `priceSwapIn: no trade pair found for ${baseToken} to ${quoteToken}.`
+      );
+    }
+    logger.info(
+      `Best trade for ${baseToken.address}-${quoteToken.address}: ${trades[0]}`
+    );
+    const expectedAmount = trades[0].minimumAmountOut(
+      this.getSlippagePercentage()
+    );
+    return { trade: trades[0], expectedAmount };
+  }
+
+  /**
+   * Given the amount of `baseToken` desired to acquire from a transaction,
+   * calculate the amount of `quoteToken` needed for the transaction.
+   *
+   * This is typically used for calculating token buy prices.
+   *
+   * @param quoteToken Token input for the transaction
+   * @param baseToken Token output from the transaction
+   * @param amount Amount of `baseToken` desired from the transaction
+   */
+  async estimateBuyTrade(
+    quoteToken: Token,
+    baseToken: Token,
+    amount: BigNumber
+  ): Promise<ExpectedTrade> {
+    const nativeTokenAmount: TokenAmount = new TokenAmount(
+      baseToken,
+      amount.toString()
+    );
+    logger.info(
+      `Fetching pair data for ${quoteToken.address}-${baseToken.address}.`
+    );
+    const pair: Pair = await Fetcher.fetchPairData(
+      quoteToken,
+      baseToken,
+      this.ethereum.provider
+    );
+    const trades: Trade[] = Trade.bestTradeExactOut(
+      [pair],
+      quoteToken,
+      nativeTokenAmount,
+      { maxHops: 1 }
+    );
+    if (!trades || trades.length === 0) {
+      throw new UniswapishPriceError(
+        `priceSwapOut: no trade pair found for ${quoteToken.address} to ${baseToken.address}.`
+      );
+    }
+    logger.info(
+      `Best trade for ${quoteToken.address}-${baseToken.address}: ${trades[0]}`
+    );
+
+    const expectedAmount = trades[0].maximumAmountIn(
+      this.getSlippagePercentage()
+    );
+    return { trade: trades[0], expectedAmount };
+  }
+
+  /**
+   * Given a wallet and a Uniswap-ish trade, try to execute it on blockchain.
+   *
+   * @param wallet Wallet
+   * @param trade Expected trade
+   * @param gasPrice Base gas price, for pre-EIP1559 transactions
+   * @param DfxRouter smart contract address
+   * @param ttl How long the swap is valid before expiry, in seconds
+   * @param abi Router contract ABI
+   * @param gasLimit Gas limit
+   * @param nonce (Optional) EVM transaction nonce
+   * @param maxFeePerGas (Optional) Maximum total fee per gas you want to pay
+   * @param maxPriorityFeePerGas (Optional) Maximum tip per gas you want to pay
+   */
+  async executeTrade(
+    wallet: Wallet,
+    trade: Trade,
+    gasPrice: number,
+    DfxRouter: string,
+    ttl: number,
+    abi: ContractInterface,
+    gasLimit: number,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber
+  ): Promise<Transaction> {
+    const result = Router.swapCallParameters(trade, {
+      ttl,
+      recipient: wallet.address,
+      allowedSlippage: this.getSlippagePercentage(),
+    });
+
+    const contract = new Contract(DfxRouter, abi, wallet);
+    if (!nonce) {
+      nonce = await this.ethereum.nonceManager.getNonce(wallet.address);
+    }
+    let tx;
+    if (maxFeePerGas || maxPriorityFeePerGas) {
+      tx = await contract[result.methodName](...result.args, {
+        gasLimit: gasLimit,
+        value: result.value,
+        nonce: nonce,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      });
+    } else {
+      tx = await contract[result.methodName](...result.args, {
+        gasPrice: (gasPrice * 1e9).toFixed(0),
+        gasLimit: gasLimit.toFixed(0),
+        value: result.value,
+        nonce: nonce,
+      });
+    }
+
+    logger.info(tx);
+    await this.ethereum.nonceManager.commitNonce(wallet.address, nonce);
+    return tx;
+  }
+}

--- a/gateway/src/services/schema/dfx-schema.json
+++ b/gateway/src/services/schema/dfx-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "allowedSlippage": { "type": "string" },
+    "gasLimit": { "type": "integer" },
+    "ttl": { "type": "integer" },
+    "contractAddresses": {
+      "type": "object",
+      "patternProperties": {
+        "^\\w+$": {
+          "type": "object",
+          "properties": {
+            "routerAddress": { "type": "string" }
+          },
+          "required": ["routerAddress"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "required": ["allowedSlippage", "gasLimit", "ttl", "contractAddresses"]
+}

--- a/gateway/src/templates/dfx.yml
+++ b/gateway/src/templates/dfx.yml
@@ -1,0 +1,16 @@
+# https://github.com/dfx-finance/contracts
+
+# how much the execution price is allowed to move unfavorably from the trade
+# execution price. It uses a rational number for precision.
+allowedSlippage: '1/100'
+
+# the maximum gas allowed for a trade.
+gasLimit: 150688
+
+# how long a trade is valid in seconds. After time passes pangolin will not
+# perform the trade, but the gas will still be spent.
+ttl: 300
+
+contractAddresses:
+  mainnet:
+      routerAddress: '0x9d0950c595786AbA7c26dfDdf270D66a8b18B4FA'


### PR DESCRIPTION
This is an incomplete implementation of a new connector for [DFX](https://dfx.finance/), created for the [ETHPortland 2022](http://ethportland.com/) hackathon. I'm documenting this work-in-progress to make it easy for others to continue this work, as well as be a reference for people who want to create other connectors.

### Changes in this PR so far

- You now have the option to run `gateway connect dfx` in hummingbot.
- `dfx.yml` contains the real mainnet address of the DFX router, and `DfxRouter.json` contains its real ABI.
- Other than that, everything is placeholder code cobbled together from the Uniswap and Pangolin connectors.

### Tips for devs on setting up your local env for connector development

In the parent branch, hummingbot is set up to install & run the gateway from a Docker image. But we don't want to do that, since we want to make changes to that code. So there's no need to run `gateway create` or `gateway start`.

1. [Install hummingbot from source](https://hummingbot.org/installation/source/)
    - [Anaconda](https://www.anaconda.com/distribution/) is a dependency; I installed it on MacOS with `brew install --cask anaconda`, but it didn't work with my [fish](https://fishshell.com/) shell so I switched to zsh
1. In `conf/conf_global.yml`, change `gateway_api_port` to 5000.
1. Once you have hummingbot running, run `gateway generate-certs` from within it to create the certs that it uses to ensure secure communication between the hummingbot process and the gateway's web server. These will be created in `~/.hummingbot-gateway/hummingbot-gateway-<some hash>`.
1. From `hummingbot/gateway`, run `INFURA_API_KEY=<your key> setup/generate_conf.sh`.
1. Modify the `hummingbot/gateway/conf/ssl.yml` file that was just created so that its paths match the path from step 2.
1. From `hummingbot/gateway`, run `yarn dev` to start the gateway server and restart it when files are edited.

### DFX resources
- [List of deployed contracts](https://github.com/dfx-finance/contracts)
- [Protocol source code](https://github.com/dfx-finance/protocol)
- [Docs](https://docs.dfx.finance/)