### PR TITLE
Fix/TWAP & TWAP Plus: `has_enough_balance()` doesn't consider order amount, but a total `target_asset_amount`

### DIFF
--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -365,7 +365,7 @@ class TwapTradeStrategy(StrategyPyBase):
         self.logger().debug("Checking to see if the user has enough balance to place orders")
 
         if quantized_amount != 0:
-            if self.has_enough_balance(market_info):
+            if self.has_enough_balance(market_info, quantized_amount):
                 if self._is_buy:
                     order_id = self.buy_with_specific_market(market_info,
                                                              amount=quantized_amount,
@@ -387,19 +387,20 @@ class TwapTradeStrategy(StrategyPyBase):
         else:
             self.logger().warning("Not possible to break the order into the desired number of segments.")
 
-    def has_enough_balance(self, market_info):
+    def has_enough_balance(self, market_info, amount: Decimal):
         """
         Checks to make sure the user has the sufficient balance in order to place the specified order
 
         :param market_info: a market trading pair
+        :param amount: order amount
         :return: True if user has enough balance, False if not
         """
         market: ExchangeBase = market_info.market
         base_asset_balance = market.get_balance(market_info.base_asset)
         quote_asset_balance = market.get_balance(market_info.quote_asset)
         order_book: OrderBook = market_info.order_book
-        price = order_book.get_price_for_volume(True, float(self._quantity_remaining)).result_price
+        price = order_book.get_price_for_volume(True, float(amount)).result_price
 
-        return quote_asset_balance >= (self._quantity_remaining * Decimal(price)) \
+        return quote_asset_balance >= (amount * Decimal(price)) \
             if self._is_buy \
-            else base_asset_balance >= self._quantity_remaining
+            else base_asset_balance >= amount


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

In the TWAP and TWAP Plus strategy the method `has_enough_balance()` works with the `target_asset_amount` and not an order amount when it's supposed to check whether it's possible to place an order.

**Tests performed by the developer**:

Ran the strategy with kucoin paper and SHR-USDT.
Ran unit tests

**Tips for QA testing**:

When specifying a very big `target_asset_amount` but a "normal" order amount the strategy shouldn't thrown an exception, but should place an order.


**Tests performed by the developer**:



**Tips for QA testing**:


