### PR TITLE
(fix) fix gate_io order fills reporting which causes wrong taker orde…

### DIFF
--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -824,7 +824,7 @@ class GateIoExchange(ExchangeBase):
                 tracked_order.trade_type,
                 tracked_order.order_type,
                 Decimal(str(update_msg.get("fill_price", update_msg.get("price", "0")))),
-                tracked_order.executed_amount_base,
+                Decimal(str(update_msg.get("amount","0"))),# changed from cumulative total to current fill amount
                 AddedToCostTradeFee(flat_fees=[TokenAmount(tracked_order.fee_asset, tracked_order.fee_paid)]),
                 str(update_msg.get("update_time_ms", update_msg.get("id")))
             )


### PR DESCRIPTION
…fix gate_io order fills reporting which causes wrong taker orders in cross exchange market making

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Changed line 824 of the gate_io_exchange.py file to enable order fills update report the current fill amount rather than the cumulative quantity.


**Tests performed by the developer**:
Ran the cross exchange market making strategy with gate_io as the maker market to confirm that the issue has been resolved.
[fix_gate_io_trade_fill_PR.txt](https://github.com/CoinAlpha/hummingbot/files/8500651/fix_gate_io_trade_fill_PR.txt)



**Tips for QA testing**:


