### PR TITLE
Prevent morgan from logging '/'

### DIFF
--- a/gateway/src/app.ts
+++ b/gateway/src/app.ts
@@ -29,11 +29,18 @@ export const gatewayApp = express();
 // parse body for application/json
 gatewayApp.use(express.json());
 
-// logging middleware
-gatewayApp.use(morgan('combined'));
-
 // parse url for application/x-www-form-urlencoded
 gatewayApp.use(express.urlencoded({ extended: true }));
+
+// logging middleware
+// skip logging path '/'
+gatewayApp.use(
+  morgan('combined', {
+    skip: function (req, _res) {
+      return req.path === '/';
+    },
+  })
+);
 
 // mount sub routers
 gatewayApp.use('/network', NetworkRoutes.router);


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Prevent gateway from logging calls to the route `/`. Hummingbot calls this frequently and it creates a lot of noise in the log.

**Tests performed by the developer**:

- run gateway and try various calls via curl. Confirmed that calls were being logged except for `/`.


**Tips for QA testing**:

- run gateway and try to call various routes. Make sure nothing is logged for `/`. Make sure other routes are still logging.
