### PR TITLE
Move gasLimit to the chain config

### DIFF
--- a/gateway/src/chains/avalanche/avalanche.ts
+++ b/gateway/src/chains/avalanche/avalanche.ts
@@ -21,7 +21,8 @@ export class Avalanche extends EthereumBase implements Ethereumish {
       config.network.nodeURL,
       config.network.tokenListSource,
       config.network.tokenListType,
-      config.manualGasPrice
+      config.manualGasPrice,
+      config.gasLimit
     );
     this._chain = config.network.name;
     this._nativeTokenSymbol = config.nativeCurrencySymbol;

--- a/gateway/src/chains/ethereum/ethereum.config.ts
+++ b/gateway/src/chains/ethereum/ethereum.config.ts
@@ -21,6 +21,7 @@ export interface Config {
   nodeAPIKey: string;
   nativeCurrencySymbol: string;
   manualGasPrice: number;
+  gasLimit: number;
 }
 
 export namespace EthereumConfig {
@@ -65,5 +66,6 @@ export function getEthereumConfig(
     manualGasPrice: ConfigManagerV2.getInstance().get(
       chainName + '.manualGasPrice'
     ),
+    gasLimit: ConfigManagerV2.getInstance().get(chainName + '.gasLimit'),
   };
 }

--- a/gateway/src/chains/ethereum/ethereum.ts
+++ b/gateway/src/chains/ethereum/ethereum.ts
@@ -30,7 +30,8 @@ export class Ethereum extends EthereumBase implements Ethereumish {
       config.network.nodeURL + config.nodeAPIKey,
       config.network.tokenListSource,
       config.network.tokenListType,
-      config.manualGasPrice
+      config.manualGasPrice,
+      config.gasLimit
     );
     this._chain = network;
     this._nativeTokenSymbol = config.nativeCurrencySymbol;

--- a/gateway/src/chains/harmony/harmony.config.ts
+++ b/gateway/src/chains/harmony/harmony.config.ts
@@ -14,11 +14,8 @@ interface Config {
   autoGasPrice: boolean;
   manualGasPrice: number;
   gasPricerefreshTime: number;
+  gasLimit: number;
 }
-
-// export namespace HarmonyConfig {
-//   export const config: Config = getHarmonyConfig('harmony');
-// }
 
 export function getHarmonyConfig(
   chainName: string,
@@ -53,5 +50,6 @@ export function getHarmonyConfig(
     gasPricerefreshTime: ConfigManagerV2.getInstance().get(
       chainName + '.gasPricerefreshTime'
     ),
+    gasLimit: ConfigManagerV2.getInstance().get(chainName + '.gasLimit'),
   };
 }

--- a/gateway/src/chains/harmony/harmony.ts
+++ b/gateway/src/chains/harmony/harmony.ts
@@ -5,7 +5,6 @@ import { Contract, Transaction, Wallet } from 'ethers';
 import { EthereumBase } from '../../services/ethereum-base';
 import { getHarmonyConfig } from './harmony.config';
 import { Provider } from '@ethersproject/abstract-provider';
-// import { SushiSwapConfig } from './sushiswap/sushiswap.config';
 import { Ethereumish } from '../../services/common-interfaces';
 
 export class Harmony extends EthereumBase implements Ethereumish {
@@ -25,7 +24,8 @@ export class Harmony extends EthereumBase implements Ethereumish {
       config.network.nodeURL,
       config.network.tokenListSource,
       config.network.tokenListType,
-      config.manualGasPrice
+      config.manualGasPrice,
+      config.gasLimit
     );
     this._chain = network;
     this._nativeTokenSymbol = config.nativeCurrencySymbol;
@@ -55,11 +55,6 @@ export class Harmony extends EthereumBase implements Ethereumish {
   public static getConnectedInstances(): { [name: string]: Harmony } {
     return Harmony._instances;
   }
-
-  // public static reload(): Harmony {
-  //   Harmony._instance = new Harmony();
-  //   return Harmony._instance;
-  // }
 
   public requestCounter(msg: any): void {
     if (msg.action === 'request') this._requestCount += 1;

--- a/gateway/src/connectors/pangolin/pangolin.config.ts
+++ b/gateway/src/connectors/pangolin/pangolin.config.ts
@@ -4,7 +4,6 @@ import { AvailableNetworks } from '../../services/config-manager-types';
 export namespace PangolinConfig {
   export interface NetworkConfig {
     allowedSlippage: string;
-    gasLimit: number;
     ttl: number;
     routerAddress: (network: string) => string;
     tradingTypes: Array<string>;
@@ -15,7 +14,6 @@ export namespace PangolinConfig {
     allowedSlippage: ConfigManagerV2.getInstance().get(
       'pangolin.allowedSlippage'
     ),
-    gasLimit: ConfigManagerV2.getInstance().get('pangolin.gasLimit'),
     ttl: ConfigManagerV2.getInstance().get('pangolin.ttl'),
     routerAddress: (network: string) =>
       ConfigManagerV2.getInstance().get(

--- a/gateway/src/connectors/pangolin/pangolin.ts
+++ b/gateway/src/connectors/pangolin/pangolin.ts
@@ -42,7 +42,7 @@ export class Pangolin implements Uniswapish {
     this._router = config.routerAddress(network);
     this._ttl = config.ttl;
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = config.gasLimit;
+    this._gasLimit = this.avalanche.gasLimit;
   }
 
   public static getInstance(chain: string, network: string): Pangolin {

--- a/gateway/src/connectors/uniswap/uniswap.config.ts
+++ b/gateway/src/connectors/uniswap/uniswap.config.ts
@@ -3,7 +3,6 @@ import { AvailableNetworks } from '../../services/config-manager-types';
 export namespace UniswapConfig {
   export interface NetworkConfig {
     allowedSlippage: (version: number) => string;
-    gasLimit: (version: number) => number;
     ttl: (version: number) => number;
     uniswapV2RouterAddress: (network: string) => string;
     uniswapV3RouterAddress: (network: string) => string;
@@ -16,10 +15,6 @@ export namespace UniswapConfig {
     allowedSlippage: (version: number) =>
       ConfigManagerV2.getInstance().get(
         `uniswap.versions.v${version}.allowedSlippage`
-      ),
-    gasLimit: (version: number) =>
-      ConfigManagerV2.getInstance().get(
-        `uniswap.versions.v${version}.gasLimit`
       ),
     ttl: (version: number) =>
       ConfigManagerV2.getInstance().get(`uniswap.versions.v${version}.ttl`),

--- a/gateway/src/connectors/uniswap/uniswap.ts
+++ b/gateway/src/connectors/uniswap/uniswap.ts
@@ -46,7 +46,7 @@ export class Uniswap implements Uniswapish {
     this.chainId = this.ethereum.chainId;
     this._ttl = UniswapConfig.config.ttl(2);
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = UniswapConfig.config.gasLimit(2);
+    this._gasLimit = this.ethereum.gasLimit;
     this._router = config.uniswapV2RouterAddress(network);
   }
 

--- a/gateway/src/connectors/uniswap/uniswap.v3.ts
+++ b/gateway/src/connectors/uniswap/uniswap.v3.ts
@@ -5,7 +5,6 @@ import {
   SERVICE_UNITIALIZED_ERROR_MESSAGE,
 } from '../../services/error-handler';
 import { logger } from '../../services/logger';
-import { UniswapConfig } from './uniswap.config';
 import { Contract, ContractInterface } from '@ethersproject/contracts';
 import { Token, CurrencyAmount, TradeType } from '@uniswap/sdk-core';
 import * as uniV3 from '@uniswap/v3-sdk';
@@ -36,7 +35,7 @@ export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
   private constructor(chain: string, network: string) {
     super(network);
     this._chain = chain;
-    this._gasLimit = UniswapConfig.config.gasLimit(3);
+    this._gasLimit = this.ethereum.gasLimit;
   }
 
   public static getInstance(chain: string, network: string): UniswapV3 {

--- a/gateway/src/services/ethereum-base.ts
+++ b/gateway/src/services/ethereum-base.ts
@@ -43,6 +43,7 @@ export class EthereumBase {
   public chainId;
   public rpcUrl;
   public gasPriceConstant;
+  private _gasLimit;
   public tokenListSource: string;
   public tokenListType: TokenListType;
   public cache: NodeCache;
@@ -55,7 +56,8 @@ export class EthereumBase {
     rpcUrl: string,
     tokenListSource: string,
     tokenListType: TokenListType,
-    gasPriceConstant: number
+    gasPriceConstant: number,
+    gasLimit: number
   ) {
     this._provider = new providers.StaticJsonRpcProvider(rpcUrl);
     this.chainName = chainName;
@@ -68,6 +70,7 @@ export class EthereumBase {
     this._nonceManager.init(this.provider);
     this.cache = new NodeCache({ stdTTL: 3600 }); // set default cache ttl to 1hr
     this._txStorage = new EvmTxStorage('transactions.level');
+    this._gasLimit = gasLimit;
   }
 
   ready(): boolean {
@@ -76,6 +79,10 @@ export class EthereumBase {
 
   public get provider() {
     return this._provider;
+  }
+
+  public get gasLimit() {
+    return this._gasLimit;
   }
 
   public events() {

--- a/gateway/src/services/schema/ethereum-schema.json
+++ b/gateway/src/services/schema/ethereum-schema.json
@@ -28,7 +28,8 @@
       "additionalProperties": false
     },
     "nodeAPIKey": { "type": "string" },
-    "manualGasPrice": { "type": "integer" }
+    "manualGasPrice": { "type": "integer" },
+    "gasLimit": { "type": "integer" }
   },
   "additionalProperties": false
 }

--- a/gateway/src/services/schema/harmony-schema.json
+++ b/gateway/src/services/schema/harmony-schema.json
@@ -29,7 +29,8 @@
     "network": { "type": "string" },
     "autoGasPrice": { "type": "boolean" },
     "manualGasPrice": { "type": "integer" },
-    "gasPricerefreshTime": { "type": "integer" }
+    "gasPricerefreshTime": { "type": "integer" },
+    "gasLimit": { "type": "integer" }
   },
   "additionalProperties": false
 }

--- a/gateway/src/services/schema/pangolin-schema.json
+++ b/gateway/src/services/schema/pangolin-schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "properties": {
     "allowedSlippage": { "type": "string" },
-    "gasLimit": { "type": "integer" },
     "ttl": { "type": "integer" },
     "contractAddresses": {
       "type": "object",
@@ -21,5 +20,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["allowedSlippage", "gasLimit", "ttl", "contractAddresses"]
+  "required": ["allowedSlippage", "ttl", "contractAddresses"]
 }

--- a/gateway/src/services/schema/uniswap-schema.json
+++ b/gateway/src/services/schema/uniswap-schema.json
@@ -9,10 +9,9 @@
           "type": "object",
           "properties": {
             "allowedSlippage": { "type": "string" },
-            "gasLimit": { "type": "integer" },
             "ttl": { "type": "integer" }
           },
-          "required": ["allowedSlippage", "gasLimit", "ttl"],
+          "required": ["allowedSlippage", "ttl"],
           "additionalProperties": false
         }
       },

--- a/gateway/src/templates/avalanche.yml
+++ b/gateway/src/templates/avalanche.yml
@@ -5,13 +5,14 @@ networks:
     nodeURL: 'https://api.avax-test.network/ext/bc/C/rpc'
     tokenListType: 'FILE'
     tokenListSource: 'src/chains/avalanche/avalanche_tokens_fuji.json'
-    nativeCurrencySymbol: 'AVAX'
+    nativeCurrencySymbol: 'AVAX'    
   avalanche: 
     chainID: 43114
     nodeURL: 'https://api.avax.network/ext/bc/C/rpc'
     tokenListType: 'URL'
     tokenListSource: 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/pangolin.tokenlist.json'
     nativeCurrencySymbol: 'AVAX'
-
+    
 nodeAPIKey: '3712b320394b413fb4c42fdadcebdf54'
 manualGasPrice: 100
+gasLimit: 300000

--- a/gateway/src/templates/avalanche.yml
+++ b/gateway/src/templates/avalanche.yml
@@ -15,4 +15,4 @@ networks:
     
 nodeAPIKey: '3712b320394b413fb4c42fdadcebdf54'
 manualGasPrice: 100
-gasLimit: 300000
+gasLimit: 3000000

--- a/gateway/src/templates/ethereum.yml
+++ b/gateway/src/templates/ethereum.yml
@@ -22,4 +22,5 @@ networks:
     nativeCurrencySymbol: ETH
     gasPriceRefreshInterval: 60
 nodeAPIKey: ''
+gasLimit: 300000
 manualGasPrice: 110

--- a/gateway/src/templates/ethereum.yml
+++ b/gateway/src/templates/ethereum.yml
@@ -22,5 +22,5 @@ networks:
     nativeCurrencySymbol: ETH
     gasPriceRefreshInterval: 60
 nodeAPIKey: ''
-gasLimit: 300000
+gasLimit: 3000000
 manualGasPrice: 110

--- a/gateway/src/templates/harmony.yml
+++ b/gateway/src/templates/harmony.yml
@@ -17,3 +17,4 @@ network: 'harmony'
 autoGasPrice: true
 manualGasPrice: 30
 gasPricerefreshTime: 60
+gasLimit: 300000

--- a/gateway/src/templates/pangolin.yml
+++ b/gateway/src/templates/pangolin.yml
@@ -2,9 +2,6 @@
 # execution price. It uses a rational number for precision.
 allowedSlippage: '1/100'
 
-# the maximum gas allowed for a pangolin trade.
-gasLimit: 150688
-
 # how long a trade is valid in seconds. After time passes pangolin will not
 # perform the trade, but the gas will still be spent.
 ttl: 300

--- a/gateway/src/templates/uniswap.yml
+++ b/gateway/src/templates/uniswap.yml
@@ -4,9 +4,6 @@ versions:
     # execution price. It uses a rational number for precision.
     allowedSlippage: '2/100'
 
-    # the maximum gas allowed for a uniswap trade.
-    gasLimit: 150688
-
     # how long a trade is valid in seconds. After time passes uniswap will not
     # perform the trade, but the gas will still be sent.
     ttl: 600
@@ -15,9 +12,6 @@ versions:
     # how much the execution price is allowed to move unfavorably from the trade
     # execution price. It uses a rational number for precision.
     allowedSlippage: '2/100'
-
-    # the maximum gas allowed for a uniswap trade.
-    gasLimit: 550688
 
     # how long a trade is valid in seconds. After time passes uniswap will not
     # perform the trade, but the gas will still be sent.


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Move gasLimit from connectors to the chains


**Tests performed by the developer**:

Created a gateway docker with tag `26080` and it with hummingbot. Check that the configs have the new gasLimit. Ran amm_arb with binance paper and ethereum kovan.


**Tips for QA testing**:

Use docker tag `26080`, check ethereum and avalanche config that the default gasLimit value is `3000000`. Make sure trading on DEXs still work.
