### PR TITLE
Fix/Bybit_perpetual: randomly getting incorrect price precision in the best prices

### DIFF
--- a/hummingbot/connector/exchange_base.pyx
+++ b/hummingbot/connector/exchange_base.pyx
@@ -84,11 +84,10 @@ cdef class ExchangeBase(ConnectorBase):
             OrderBook order_book = self.c_get_order_book(trading_pair)
             object top_price
         try:
-            top_price = Decimal(order_book.c_get_price(is_buy))
+            top_price = Decimal(str(order_book.c_get_price(is_buy)))
         except EnvironmentError as e:
             self.logger().warning(f"{'Ask' if is_buy else 'Bid'} orderbook for {trading_pair} is empty.")
             return s_decimal_NaN
-
         return self.c_quantize_order_price(trading_pair, top_price)
 
     cdef ClientOrderBookQueryResult c_get_vwap_for_volume(self, str trading_pair, bint is_buy, object volume):

--- a/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making.py
+++ b/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making.py
@@ -519,7 +519,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         bid_order: LimitOrder = self.strategy.active_bids[0][1]
         ask_order: LimitOrder = self.strategy.active_asks[0][1]
         # place above top bid (at 0.95)
-        self.assertAlmostEqual(Decimal("0.9500"), bid_order.price)
+        self.assertAlmostEqual(Decimal("0.9501"), bid_order.price)
         # place below top ask (at 1.05)
         self.assertAlmostEqual(Decimal("1.049"), ask_order.price)
         self.assertAlmostEqual(Decimal("3"), round(bid_order.quantity, 4))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

In the `c_get_price()` method of the `ExchangeBase` class a conversion from float to Decimal sometimes leads to a precision error. Quantization then further amplifies the error. This then results in the observed seemingly random discrepancies between the status and the real price.

**Tests performed by the developer**:

Ran the Bybit connector with the Perpetual MM strategy, compared status with the real order book on the exchange, printed all relevant variables in the code to verify it internally.

**Tips for QA testing**:

This problem is not specific to Bybit and is not specific to the status command either, since this is a general purpose method. This problem was most likely occurring also when creating orders etc.

