### PR TITLE
Restrict possible values for gasLevel in the ethereum gas station schema

### DIFF
--- a/gateway/src/services/schema/ethereum-gas-station-schema.json
+++ b/gateway/src/services/schema/ethereum-gas-station-schema.json
@@ -5,7 +5,7 @@
     "enabled": { "type": "boolean" },
     "gasStationURL": { "type": "string" },
     "APIKey": { "type": ["string", "null"] },
-    "gasLevel": { "type": "string" }
+    "gasLevel": { "enum": ["fast", "fastest", "safeLow", "average"]}
   },
   "additionalProperties": false,
   "required": ["enabled"]


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Restrict gasLevel to fast, fastest, safeLow or average (available values from the Eth Gas Station API)

**Tests performed by the developer**:
- `gateway config ethereumGasStation.gasLevel xyz` fails with a useful error message
- `gateway config ethereumGasStation.gasLevel fast`


**Tips for QA testing**:


