### PR TITLE
Fix rate lookup for .e tokens

### DIFF
--- a/hummingbot/core/gateway/utils.py
+++ b/hummingbot/core/gateway/utils.py
@@ -1,14 +1,14 @@
 import re
-from typing import Optional, Match, Pattern, List
+from typing import List, Match, Optional, Pattern
 
 # W{TOKEN} only applies to a few special tokens. It should NOT match all W-prefixed token names like WAVE or WOW.
-CAPITAL_W_SYMBOLS_PATTERN = re.compile(r"^W(BTC|ETH|AVAX|ALBT|XRP)")
+CAPITAL_W_SYMBOLS_PATTERN = re.compile(r"^W(BTC|ETH|AVAX|ALBT|XRP)", re.IGNORECASE)
 
 # w{TOKEN} generally means a wrapped token on the Ethereum network. e.g. wNXM, wDGLD.
-SMALL_W_SYMBOLS_PATTERN = re.compile(r"^w(\w+)")
+SMALL_W_SYMBOLS_PATTERN = re.compile(r"^w(\w+)", re.IGNORECASE)
 
 # {TOKEN}.e generally means a wrapped token on the Avalanche network.
-DOT_E_SYMBOLS_PATTERN = re.compile(r"(\w+)\.e$")
+DOT_E_SYMBOLS_PATTERN = re.compile(r"(\w+)\.e$", re.IGNORECASE)
 
 
 def unwrap_token_symbol(on_chain_token_symbol: str) -> str:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

The regex was failing because it was dependent on case. I relaxed it to be ignore case. Now it works!


**Tests performed by the developer**:
Tested rate with various `.e` tokens and ran amm_arb with an `.e` on Avalanche


**Tips for QA testing**:

- `rate -t USDT.e`
- `rate -p AVAX-USDT.e`
- run amm_arb with a `.e` token on avalanche

