### PR TITLE
(fix) Removes `s` flag to `conda clean` in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64
     /bin/bash ~/miniconda.sh -b && \
     rm ~/miniconda.sh && \
     ~/miniconda3/bin/conda update -n base conda -y && \
-    ~/miniconda3/bin/conda clean -tipsy
+    ~/miniconda3/bin/conda clean -tipy
 
 # Dropping default ~/.bashrc because it will return if not running as interactive shell, thus not invoking PATH settings
 RUN :> ~/.bashrc
@@ -42,7 +42,7 @@ COPY --chown=hummingbot:hummingbot setup/environment-linux.yml setup/
 
 # ./install | create hummingbot environment
 RUN ~/miniconda3/bin/conda env create -f setup/environment-linux.yml && \
-    ~/miniconda3/bin/conda clean -tipsy && \
+    ~/miniconda3/bin/conda clean -tipy && \
     # clear pip cache
     rm -rf /home/hummingbot/.cache
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

The `-s` flag has been [deprecated](https://docs.conda.io/projects/conda/en/latest/release-notes.html#id180) from the `conda clean` command in [this PR](https://github.com/conda/conda/pull/7731). This is causing our [docker image build to fail](https://github.com/CoinAlpha/hummingbot/pull/246#issuecomment-1139688439) because it is currently using this flag. I have simply removed its use since it seems to be only linked to `conda build`, which we don't install in the container.

**Tests performed by the developer**:

I have manually tested that the image builds successfully.

**Tips for QA testing**:


