### PR TITLE
gateway create generates necessary traderjoe yml file

### DIFF
--- a/gateway/setup/generate_conf.sh
+++ b/gateway/setup/generate_conf.sh
@@ -55,6 +55,9 @@ echo "created $HOST_CONF_PATH/server.yml"
 cp "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../src/templates/uniswap.yml" "$HOST_CONF_PATH/uniswap.yml"
 echo "created $HOST_CONF_PATH/uniswap.yml"
 
+cp "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../src/templates/traderjoe.yml" "$HOST_CONF_PATH/traderjoe.yml"
+echo "created $HOST_CONF_PATH/traderjoe.yml"
+
 # generate the telemetry file
 echo "enabled: false" > "$HOST_CONF_PATH/telemetry.yml"  # enabled must be prompted
 echo "created $HOST_CONF_PATH/telemetry.yml"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
`gateway create` on `development` will fail because the bash script does not copy traderjoe.yml. This fixes it.


**Tests performed by the developer**:



**Tips for QA testing**:

build the gateway docker, run `gateway create`, make sure it works normally
