### PR TITLE
Fix/kucoin get fees multiple pairs

### DIFF
--- a/hummingbot/connector/exchange/kucoin/kucoin_auth.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_auth.py
@@ -69,7 +69,7 @@ class KucoinAuth(AuthBase):
         path_url = f"/api{request.url.split('/api')[-1]}"
         if request.params:
             sorted_params = self.keysort(request.params)
-            query_string_components = urlencode(sorted_params)
+            query_string_components = urlencode(sorted_params, safe=',')
             path_url = f"{path_url}?{query_string_components}"
 
         if request.data is not None:

--- a/test/hummingbot/connector/derivative/coinflex_perpetual/test_coinflex_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/coinflex_perpetual/test_coinflex_perpetual_auth.py
@@ -49,7 +49,7 @@ class CoinflexPerpetualAuthUnitTests(unittest.TestCase):
         request = web_utils.CoinflexPerpetualRESTRequest(method=RESTMethod.GET, endpoint="", params=params, is_auth_required=True)
         configured_request = self.async_run_with_timeout(self.auth.rest_authenticate(request))
 
-        str_timestamp = datetime.fromtimestamp(now).isoformat()
+        str_timestamp = datetime.utcfromtimestamp(now).isoformat()
         nonce = int(now * 1e3)
 
         encoded_params = "&".join([f"{key}={value}" for key, value in full_params.items()])

--- a/test/hummingbot/connector/exchange/coinflex/test_coinflex_auth.py
+++ b/test/hummingbot/connector/exchange/coinflex/test_coinflex_auth.py
@@ -7,10 +7,11 @@ from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch
 
+from typing_extensions import Awaitable
+
 from hummingbot.connector.exchange.coinflex.coinflex_auth import CoinflexAuth
 from hummingbot.connector.exchange.coinflex.coinflex_web_utils import CoinflexRESTRequest
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from typing_extensions import Awaitable
 
 
 class CoinflexAuthTests(TestCase):
@@ -42,7 +43,7 @@ class CoinflexAuthTests(TestCase):
         request = CoinflexRESTRequest(method=RESTMethod.GET, endpoint="", params=params, is_auth_required=True)
         configured_request = self.async_run_with_timeout(auth.rest_authenticate(request))
 
-        str_timestamp = datetime.fromtimestamp(now).isoformat()
+        str_timestamp = datetime.utcfromtimestamp(now).isoformat()
         nonce = int(now * 1e3)
 
         encoded_params = "&".join([f"{key}={value}" for key, value in full_params.items()])

--- a/test/hummingbot/connector/exchange/kucoin/test_kucoin_exchange.py
+++ b/test/hummingbot/connector/exchange/kucoin/test_kucoin_exchange.py
@@ -265,6 +265,64 @@ class TestKucoinExchange(unittest.TestCase):
 
         self.assertEqual(Decimal("0.001"), fee.percent)  # default fee
 
+    @aioresponses()
+    def test_fee_request_for_multiple_pairs(self, mocked_api):
+        self.exchange = KucoinExchange(
+            self.api_key,
+            self.api_passphrase,
+            self.api_secret_key,
+            trading_pairs=[self.trading_pair, "BTC-USDT"]
+        )
+
+        KucoinAPIOrderBookDataSource._trading_pair_symbol_map = {
+            CONSTANTS.DEFAULT_DOMAIN: bidict(
+                {self.trading_pair: self.trading_pair,
+                 "BTC-USDT": "BTC-USDT"})
+        }
+
+        url = web_utils.rest_url(CONSTANTS.FEE_PATH_URL)
+        regex_url = re.compile(f"^{url}")
+        resp = {"data": [
+            {"symbol": self.trading_pair,
+             "makerFeeRate": "0.002",
+             "takerFeeRate": "0.002"},
+            {"symbol": "BTC-USDT",
+             "makerFeeRate": "0.01",
+             "takerFeeRate": "0.01"},
+        ]}
+        mocked_api.get(regex_url, body=json.dumps(resp))
+
+        self.async_run_with_timeout(self.exchange._update_trading_fees())
+
+        order_request = next(((key, value) for key, value in mocked_api.requests.items()
+                              if key[1].human_repr().startswith(url)))
+        self._validate_auth_credentials_present(order_request[1][0])
+        request_params = order_request[1][0].kwargs["params"]
+
+        self.assertEqual(f"{self.exchange_trading_pair},BTC-USDT", request_params["symbols"])
+
+        fee = self.exchange.get_fee(
+            base_currency=self.base_asset,
+            quote_currency=self.quote_asset,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("20"),
+        )
+
+        self.assertEqual(Decimal("0.002"), fee.percent)
+
+        fee = self.exchange.get_fee(
+            base_currency="BTC",
+            quote_currency="USDT",
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("20"),
+        )
+
+        self.assertEqual(Decimal("0.01"), fee.percent)
+
     @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
     def test_client_order_id_on_order(self, mocked_nonce):
         mocked_nonce.return_value = 9


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix in KucoinAuth when preparing the string to generate the signature. There was a problem processing the request parameters when any of the parameters contained a comma separated list.
The PR also includes a fix to a couple of CoinFlex unit tests that were failing.


**Tests performed by the developer**:
Added a new unit test with the same scenario from the issue.
Tested with a script that updated the fees on a Kucoin connector instance configured to use more than one trading pair.


**Tips for QA testing**:
To test the fix it is required to use a strategy that works with more than one trading pair.


Fixes https://github.com/hummingbot/hummingbot/issues/5273

[sc-27574]