### PR TITLE
fix/ local DigiFinex order book not in sync and occassional websocket disconnects

### DIFF
--- a/hummingbot/connector/exchange/digifinex/digifinex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_api_order_book_data_source.py
@@ -169,14 +169,10 @@ class DigifinexAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def _subscribe_channels(self, websocket: DigifinexWebsocket):
         try:
-            await websocket.subscribe("depth", list(map(
-                lambda pair: f"{digifinex_utils.convert_to_ws_trading_pair(pair)}",
-                self._trading_pairs
-            )))
-            await websocket.subscribe("trades", list(map(
-                lambda pair: f"{digifinex_utils.convert_to_ws_trading_pair(pair)}",
-                self._trading_pairs
-            )))
+            trading_pairs: List[str] = [digifinex_utils.convert_from_ws_trading_pair(pair)
+                                        for pair in self._trading_pairs]
+            await websocket.subscribe("depth", trading_pairs)
+            await websocket.subscribe("trades", trading_pairs)
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/hummingbot/connector/exchange/digifinex/digifinex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_api_order_book_data_source.py
@@ -2,21 +2,24 @@
 import asyncio
 import logging
 import time
-import aiohttp
 import traceback
-import pandas as pd
-import hummingbot.connector.exchange.digifinex.digifinex_constants as constants
+from typing import Any, Dict, List, Optional
 
-from typing import Optional, List, Dict, Any
+import aiohttp
+import pandas as pd
+
+import hummingbot.connector.exchange.digifinex.digifinex_constants as constants
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.logger import HummingbotLogger
+
 from . import digifinex_utils
 from .digifinex_active_order_tracker import DigifinexActiveOrderTracker
 from .digifinex_order_book import DigifinexOrderBook
 from .digifinex_websocket import DigifinexWebsocket
+
 # from .digifinex_utils import ms_timestamp_to_s
 
 
@@ -56,8 +59,9 @@ class DigifinexAPIOrderBookDataSource(OrderBookTrackerDataSource):
         async with aiohttp.ClientSession() as client:
             async with client.get(f"{constants.REST_URL}/ticker", timeout=10) as response:
                 if response.status == 200:
-                    from hummingbot.connector.exchange.digifinex.digifinex_utils import \
-                        convert_from_exchange_trading_pair
+                    from hummingbot.connector.exchange.digifinex.digifinex_utils import (
+                        convert_from_exchange_trading_pair,
+                    )
                     try:
                         data: Dict[str, Any] = await response.json()
                         return [convert_from_exchange_trading_pair(item["symbol"]) for item in data["ticker"]]
@@ -156,7 +160,7 @@ class DigifinexAPIOrderBookDataSource(OrderBookTrackerDataSource):
                     params = response["params"]
                     symbol = params[2]
                     order_book_data = params[1]
-                    timestamp: int = int(time.time())
+                    timestamp: float = time.time()
 
                     if params[0] is True:
                         orderbook_msg: OrderBookMessage = DigifinexOrderBook.snapshot_message_from_exchange(

--- a/hummingbot/connector/exchange/digifinex/digifinex_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_api_user_stream_data_source.py
@@ -55,13 +55,13 @@ class DigifinexAPIUserStreamDataSource(UserStreamTrackerDataSource):
 
                 trading_pairs: List[str] = [digifinex_utils.convert_to_ws_trading_pair(pair)
                                             for pair in self._trading_pairs]
-                currencies = list()
+                currencies = set()
                 for trade_pair in self._trading_pairs:
                     trade_pair_currencies = trade_pair.split('-')
-                    currencies.extend(trade_pair_currencies)
+                    currencies.update(trade_pair_currencies)
 
                 await self._ws.subscribe("order", trading_pairs)
-                await self._ws.subscribe("balance", currencies)
+                await self._ws.subscribe("balance", list(currencies))
 
                 async for msg in self._ws.iter_messages():
                     if msg is None or "params" not in msg or "method" not in msg:
@@ -77,4 +77,4 @@ class DigifinexAPIUserStreamDataSource(UserStreamTrackerDataSource):
                     exc_info=True
                 )
             finally:
-                await self._ws.disconnect()
+                self._ws and await self._ws.disconnect()

--- a/hummingbot/connector/exchange/digifinex/digifinex_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_api_user_stream_data_source.py
@@ -30,7 +30,6 @@ class DigifinexAPIUserStreamDataSource(UserStreamTrackerDataSource):
     def __init__(self, _global: DigifinexGlobal, trading_pairs: Optional[List[str]] = []):
         self._global: DigifinexGlobal = _global
         self._trading_pairs = trading_pairs
-        self._current_listen_key = None
         self._listen_for_user_stream_task = None
         self._ws: Optional[DigifinexWebsocket] = None
         super().__init__()
@@ -77,5 +76,5 @@ class DigifinexAPIUserStreamDataSource(UserStreamTrackerDataSource):
                     f"Unexpected error with WebSocket connection. {str(e)}",
                     exc_info=True
                 )
-                await self._sleep(5.0)
+            finally:
                 await self._ws.disconnect()

--- a/hummingbot/connector/exchange/digifinex/digifinex_auth.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_auth.py
@@ -1,12 +1,15 @@
-import hmac
-import hashlib
 import base64
+import hashlib
+import hmac
 import urllib
+from typing import Any, Dict, List
+
 import aiohttp
-from typing import List, Dict, Any
+
 # from hummingbot.connector.exchange.digifinex.digifinex_utils import get_ms_timestamp
 from hummingbot.connector.exchange.digifinex import digifinex_constants as Constants
 from hummingbot.connector.exchange.digifinex.time_patcher import TimePatcher
+
 # import time
 
 _time_patcher: TimePatcher = None
@@ -69,8 +72,8 @@ class DigifinexAuth():
         data[1] = str(nonce)
 
         data[2] = base64.b64encode(hmac.new(
-            self.secret_key.encode('latin-1'),
-            f"{nonce}".encode('latin-1'),
+            self.secret_key.encode('utf-8'),
+            f"{nonce}".encode('utf-8'),
             hashlib.sha256
         ).digest())
 

--- a/hummingbot/connector/exchange/digifinex/digifinex_constants.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_constants.py
@@ -11,6 +11,11 @@ REST_URL = f"https://{host}/v3"
 WSS_PRIVATE_URL = f"wss://{host}/ws/v1/"
 WSS_PUBLIC_URL = f"wss://{host}/ws/v1/"
 
+# Public WS Channels
+ORDER_BOOK_DEPTH_CHANNEL = "depth.update"
+ORDER_BOOK_TRADE_CHANNEL = "trades.update"
+
+
 API_REASONS = {
     0: "Success",
     10001: "Malformed request, (E.g. not using application/json for REST)",

--- a/hummingbot/connector/exchange/digifinex/digifinex_order_book_tracker.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_order_book_tracker.py
@@ -13,7 +13,6 @@ from hummingbot.connector.exchange.digifinex.digifinex_order_book import Digifin
 from hummingbot.connector.exchange.digifinex.digifinex_order_book_message import DigifinexOrderBookMessage
 from hummingbot.core.data_type.order_book_message import OrderBookMessageType
 from hummingbot.core.data_type.order_book_tracker import OrderBookTracker
-from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.logger import HummingbotLogger
 
 
@@ -109,13 +108,3 @@ class DigifinexOrderBookTracker(OrderBookTracker):
                     app_warning_msg="Unexpected error processing order book messages. Retrying after 5 seconds."
                 )
                 await asyncio.sleep(5.0)
-
-    def start(self):
-        super().start()
-        self._order_book_stream_listener_task = safe_ensure_future(
-            self._data_source.listen_for_subscriptions()
-        )
-
-    def stop(self):
-        self._order_book_stream_listener_task and self._order_book_stream_listener_task.cancel()
-        super().stop()

--- a/hummingbot/connector/exchange/digifinex/digifinex_rest_api.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_rest_api.py
@@ -1,10 +1,11 @@
-from typing import Callable, Dict, Any
-import aiohttp
 import json
 import urllib
+from typing import Any, Callable, Dict
+
+import aiohttp
+
+from hummingbot.connector.exchange.digifinex import digifinex_constants as Constants, digifinex_utils
 from hummingbot.connector.exchange.digifinex.digifinex_auth import DigifinexAuth
-from hummingbot.connector.exchange.digifinex import digifinex_constants as Constants
-from hummingbot.connector.exchange.digifinex import digifinex_utils
 
 
 class DigifinexRestApi:
@@ -29,7 +30,7 @@ class DigifinexRestApi:
         url = f"{Constants.REST_URL}/{path_url}"
         client = await self._http_client()
         if is_auth_required:
-            request_id = digifinex_utils.RequestId.generate_request_id()
+            request_id = digifinex_utils.generate_request_id()
             headers = self._auth.get_private_headers(path_url, request_id, params)
         else:
             headers = {}

--- a/hummingbot/connector/exchange/digifinex/digifinex_utils.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_utils.py
@@ -1,12 +1,11 @@
 import math
 from typing import Dict, List
 
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce, get_tracking_nonce_low_res
-from . import digifinex_constants as Constants
-
-from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.core.utils.tracking_nonce import get_tracking_nonce, get_tracking_nonce_low_res
 
+from . import digifinex_constants as Constants
 
 CENTRALIZED = True
 
@@ -45,16 +44,8 @@ def ms_timestamp_to_s(ms: int) -> int:
     return math.floor(ms / 1e3)
 
 
-# Request ID class
-class RequestId:
-    """
-    Generate request ids
-    """
-    _request_id: int = 0
-
-    @classmethod
-    def generate_request_id(cls) -> int:
-        return get_tracking_nonce()
+def generate_request_id() -> int:
+    return get_tracking_nonce()
 
 
 def convert_from_exchange_trading_pair(exchange_trading_pair: str) -> str:

--- a/hummingbot/connector/exchange/digifinex/digifinex_websocket.py
+++ b/hummingbot/connector/exchange/digifinex/digifinex_websocket.py
@@ -9,19 +9,15 @@ from typing import Any, AsyncIterable, Dict, List, Optional
 import aiohttp
 import ujson
 
-from hummingbot.connector.exchange.digifinex import digifinex_constants as CONSTANTS
+from hummingbot.connector.exchange.digifinex import digifinex_constants as CONSTANTS, digifinex_utils
 from hummingbot.connector.exchange.digifinex.digifinex_auth import DigifinexAuth
-from hummingbot.connector.exchange.digifinex.digifinex_utils import RequestId
 from hummingbot.logger import HummingbotLogger
 
 
-class DigifinexWebsocket(RequestId):
+class DigifinexWebsocket():
     MESSAGE_TIMEOUT = 30.0
     PING_TIMEOUT = 10.0
     _logger: Optional[HummingbotLogger] = None
-    disconnect_future: asyncio.Future = None
-    tasks: List[asyncio.Task] = []
-    login_msg_id: int = 0
 
     @classmethod
     def logger(cls) -> HummingbotLogger:
@@ -34,7 +30,7 @@ class DigifinexWebsocket(RequestId):
         self._isPrivate = True if self._auth is not None else False
         self._WS_URL = CONSTANTS.WSS_PRIVATE_URL if self._isPrivate else CONSTANTS.WSS_PUBLIC_URL
         self._client: aiohttp.ClientSession = aiohttp.ClientSession()
-        self._websocket: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._connection: Optional[aiohttp.ClientWebSocketResponse] = None
         self._last_recv_time: float = 0
 
     @property
@@ -44,34 +40,27 @@ class DigifinexWebsocket(RequestId):
     # connect to exchange
     async def connect(self):
         try:
-            self._websocket = await aiohttp.ClientSession().ws_connect(self._WS_URL)
+            self._connection = await self._client.ws_connect(self._WS_URL)
             if self._isPrivate:
                 await self.login()
-
-            return self._client
         except Exception as e:
             self.logger().error(f"Websocket error: '{str(e)}'", exc_info=True)
+            raise
 
     async def login(self):
-        self.login_msg_id = await self.request("server.auth", self._auth.generate_ws_signature())
-        raw_bytes = await self._websocket.receive_bytes()
-        parse_msg = self.parse_message(raw_bytes)
-        self._last_recv_time = self._time()
-        if parse_msg is None:
-            raise ConnectionError('websocket auth failed: connection closed unexpectedly')
-        if parse_msg.get('error') is not None:
-            raise ConnectionError(f'websocket auth failed: {parse_msg}')
+        await self.request("server.auth", self._auth.generate_ws_signature())
+        response: aiohttp.WSMessage = await self.receive()
+        if response is None or response.get("error") is not None:
+            raise ConnectionError("Error authenticating to websocket connection...")
 
     # disconnect from exchange
     async def disconnect(self):
-        if self._websocket is None:
+        if self._connection is None:
             return
         if self._client is None:
             return
-        await self._websocket.close()
+        await self._connection.close()
         await self._client.close()
-        for task in self.tasks:
-            task.cancel()
 
     async def ping(self):
         try:
@@ -82,7 +71,7 @@ class DigifinexWebsocket(RequestId):
             raise
 
     async def request(self, method: str, data: Optional[Any] = {}) -> int:
-        request_id = self.generate_request_id()
+        request_id = digifinex_utils.generate_request_id()
 
         payload = {
             "id": request_id,
@@ -91,18 +80,16 @@ class DigifinexWebsocket(RequestId):
         }
 
         self.logger().network(payload)
-        await self._websocket.send_str(ujson.dumps(payload))
+        await self._connection.send_str(ujson.dumps(payload))
 
         return request_id
 
     # subscribe to a method
     async def subscribe(self, category: str, channels: List[str]) -> int:
-        request_id = await self.request(category + ".subscribe", channels)
-        raw_msg: bytes = await self._websocket.receive_bytes()
-        parse_msg = self.parse_message(raw_msg)
-        if parse_msg.get('error') is not None:
-            raise ConnectionError(f'subscribe {category} {channels} failed: {parse_msg}')
-        return request_id
+        await self.request(category + ".subscribe", channels)
+        response: aiohttp.WSMessage = await self.receive()
+        if response is None or response.get("error"):
+            raise ConnectionError(f"Error subscribing to {category} {channels}...")
 
     # unsubscribe to a method
     async def unsubscribe(self, channels: List[str]) -> int:
@@ -113,25 +100,21 @@ class DigifinexWebsocket(RequestId):
     def parse_message(self, raw_bytes: bytes) -> Dict[str, Any]:
         return ujson.loads(zlib.decompress(raw_bytes))
 
+    async def receive(self) -> Dict[str, Any]:
+        ws_msg: aiohttp.WSMessage = await self._connection.receive()
+        if ws_msg.type == aiohttp.WSMsgType.CLOSED:
+            self.logger().warning("Websocket server closed the connection")
+            raise aiohttp.ClientConnectionError("Websocket server closed the connection")
+        elif ws_msg.type == aiohttp.WSMsgType.BINARY:
+            raw_msg: bytes = ws_msg.data
+            self._last_recv_time = self._time()
+            return self.parse_message(raw_msg)
+
     async def iter_messages(self) -> AsyncIterable[Any]:
         while True:
             try:
-                ws_msg: aiohttp.WSMessage = await asyncio.wait_for(self._websocket.receive(), timeout=300)
-
-                if ws_msg.type == aiohttp.WSMsgType.BINARY:
-                    raw_msg: bytes = ws_msg.data
-                    parse_msg: Dict[str, Any] = self.parse_message(raw_msg)
-                    err = parse_msg.get('error')
-                    if err is not None:
-                        raise ConnectionError(parse_msg)
-                    elif parse_msg.get('result') == 'pong':
-                        continue
-                elif ws_msg.type == aiohttp.WSMsgType.CLOSED:
-                    self.logger().warning("Websocket server closed the connection")
-                    raise aiohttp.ClientConnectionError("Websocket server closed the connection")
-
-                self._last_recv_time = self._time()
-                yield parse_msg
+                msg: aiohttp.WSMessage = await asyncio.wait_for(self.receive(), timeout=self.MESSAGE_TIMEOUT)
+                yield msg
             except asyncio.TimeoutError:
                 await self.ping()
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The issue is the result of not including the right resolution for `timestamp` values for both `SNAPSHOT` and `DIFF` order book messages. This results in some diffs being dropped by the `OrderBookTracker` 

The issue of the frequent websocket disconnects seems to occur since the APIOrderBookDataSource is handling 2 connections for orderbook diff and orderbook trade updates. Refactoring the logic to utilize 1 websocket client seems to resolve the issue.

Resolves [sc-28591] [sc-28603]

**Tests performed by the developer**:
No unit tests have been added since the Digifinex connector uses an old architecture and that this isnt a connector we supposedly maintained.


**Tips for QA testing**:
Ensure that the orderbook for liquid markets are now in sync.
The frequent ws disconnects should no longer be an issue.
