### PR TITLE
Feat/add gas estimates

### DIFF
--- a/gateway/src/connectors/pangolin/pangolin.ts
+++ b/gateway/src/connectors/pangolin/pangolin.ts
@@ -29,7 +29,7 @@ export class Pangolin implements Uniswapish {
   private _chain: string;
   private _router: string;
   private _routerAbi: ContractInterface;
-  private _gasLimit: number;
+  private _gasEstimate: number;
   private _ttl: number;
   private chainId;
   private tokenList: Record<string, Token> = {};
@@ -43,7 +43,7 @@ export class Pangolin implements Uniswapish {
     this._router = config.routerAddress(network);
     this._ttl = config.ttl;
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = this.avalanche.gasLimit;
+    this._gasEstimate = this.avalanche.gasLimit;
   }
 
   public static getInstance(chain: string, network: string): Pangolin {
@@ -103,8 +103,8 @@ export class Pangolin implements Uniswapish {
   /**
    * Default gas limit for swap transactions.
    */
-  public get gasLimit(): number {
-    return this._gasLimit;
+  public get gasEstimate(): number {
+    return this._gasEstimate;
   }
 
   /**

--- a/gateway/src/connectors/sushiswap/sushiswap.config.ts
+++ b/gateway/src/connectors/sushiswap/sushiswap.config.ts
@@ -4,7 +4,7 @@ import { AvailableNetworks } from '../../services/config-manager-types';
 export namespace SushiswapConfig {
   export interface NetworkConfig {
     allowedSlippage: string;
-    gasLimit: number;
+    gasEstimate: number;
     ttl: number;
     sushiswapRouterAddress: (network: string) => string;
     tradingTypes: Array<string>;
@@ -15,7 +15,7 @@ export namespace SushiswapConfig {
     allowedSlippage: ConfigManagerV2.getInstance().get(
       'sushiswap.allowedSlippage'
     ),
-    gasLimit: ConfigManagerV2.getInstance().get('sushiswap.gasLimit'),
+    gasEstimate: ConfigManagerV2.getInstance().get('sushiswap.gasEstimate'),
     ttl: ConfigManagerV2.getInstance().get('sushiswap.ttl'),
     sushiswapRouterAddress: (network: string) =>
       ConfigManagerV2.getInstance().get(

--- a/gateway/src/connectors/sushiswap/sushiswap.ts
+++ b/gateway/src/connectors/sushiswap/sushiswap.ts
@@ -39,7 +39,7 @@ export class Sushiswap implements Uniswapish {
   private _chain: string;
   private _router: string;
   private _routerAbi: ContractInterface;
-  private _gasLimit: number;
+  private _gasEstimate: number;
   private _ttl: number;
   private chainId;
   private tokenList: Record<string, Token> = {};
@@ -52,7 +52,7 @@ export class Sushiswap implements Uniswapish {
     this.chainId = this.ethereum.chainId;
     this._ttl = SushiswapConfig.config.ttl;
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = SushiswapConfig.config.gasLimit;
+    this._gasEstimate = SushiswapConfig.config.gasEstimate;
     this._router = config.sushiswapRouterAddress(network);
   }
 
@@ -116,8 +116,8 @@ export class Sushiswap implements Uniswapish {
   /**
    * Default gas limit for swap transactions.
    */
-  public get gasLimit(): number {
-    return this._gasLimit;
+  public get gasEstimate(): number {
+    return this._gasEstimate;
   }
 
   /**

--- a/gateway/src/connectors/traderjoe/traderjoe.config.ts
+++ b/gateway/src/connectors/traderjoe/traderjoe.config.ts
@@ -4,7 +4,7 @@ import { AvailableNetworks } from '../../services/config-manager-types';
 export namespace TraderjoeConfig {
   export interface NetworkConfig {
     allowedSlippage: string;
-    gasLimit: number;
+    gasEstimate: number;
     ttl: number;
     routerAddress: (network: string) => string;
     tradingTypes: Array<string>;
@@ -15,7 +15,7 @@ export namespace TraderjoeConfig {
     allowedSlippage: ConfigManagerV2.getInstance().get(
       'traderjoe.allowedSlippage'
     ),
-    gasLimit: ConfigManagerV2.getInstance().get('traderjoe.gasLimit'),
+    gasEstimate: ConfigManagerV2.getInstance().get('traderjoe.gasEstimate'),
     ttl: ConfigManagerV2.getInstance().get('traderjoe.ttl'),
     routerAddress: (network: string) =>
       ConfigManagerV2.getInstance().get(

--- a/gateway/src/connectors/traderjoe/traderjoe.ts
+++ b/gateway/src/connectors/traderjoe/traderjoe.ts
@@ -29,7 +29,7 @@ export class Traderjoe implements Uniswapish {
   private _chain: string;
   private _router: string;
   private _routerAbi: ContractInterface;
-  private _gasLimit: number;
+  private _gasEstimate: number;
   private _ttl: number;
   private chainId;
   private tokenList: Record<string, Token> = {};
@@ -43,7 +43,7 @@ export class Traderjoe implements Uniswapish {
     this._router = config.routerAddress(network);
     this._ttl = config.ttl;
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = config.gasLimit;
+    this._gasEstimate = config.gasEstimate;
   }
 
   public static getInstance(chain: string, network: string): Traderjoe {
@@ -103,8 +103,8 @@ export class Traderjoe implements Uniswapish {
   /**
    * Default gas limit for swap transactions.
    */
-  public get gasLimit(): number {
-    return this._gasLimit;
+  public get gasEstimate(): number {
+    return this._gasEstimate;
   }
 
   /**

--- a/gateway/src/connectors/uniswap/uniswap.config.ts
+++ b/gateway/src/connectors/uniswap/uniswap.config.ts
@@ -3,7 +3,7 @@ import { AvailableNetworks } from '../../services/config-manager-types';
 export namespace UniswapConfig {
   export interface NetworkConfig {
     allowedSlippage: string;
-    gasLimit: number;
+    gasEstimate: number;
     ttl: number;
     maximumHops: number;
     uniswapV3SmartOrderRouterAddress: (network: string) => string;
@@ -16,7 +16,7 @@ export namespace UniswapConfig {
     allowedSlippage: ConfigManagerV2.getInstance().get(
       `uniswap.allowedSlippage`
     ),
-    gasLimit: ConfigManagerV2.getInstance().get(`uniswap.gasLimit`),
+    gasEstimate: ConfigManagerV2.getInstance().get(`uniswap.gasEstimate`),
     ttl: ConfigManagerV2.getInstance().get(`uniswap.ttl`),
     maximumHops: ConfigManagerV2.getInstance().get(`uniswap.maximumHops`),
     uniswapV3SmartOrderRouterAddress: (network: string) =>

--- a/gateway/src/connectors/uniswap/uniswap.controllers.ts
+++ b/gateway/src/connectors/uniswap/uniswap.controllers.ts
@@ -172,8 +172,9 @@ export async function price(
   const tradePrice =
     req.side === 'BUY' ? trade.executionPrice.invert() : trade.executionPrice;
 
-  const gasLimit = uniswapish.gasLimit;
+  const gasLimit = ethereumish.gasLimit;
   const gasPrice = ethereumish.gasPrice;
+  const gasEstimate = uniswapish.gasEstimate;
   return {
     network: ethereumish.chain,
     timestamp: startTimestamp,
@@ -187,7 +188,7 @@ export async function price(
     gasPrice: gasPrice,
     gasPriceToken: ethereumish.nativeTokenSymbol,
     gasLimit: gasLimit,
-    gasCost: gasCostInEthString(gasPrice, gasLimit),
+    gasCost: gasCostInEthString(gasPrice, gasEstimate),
   };
 }
 
@@ -236,7 +237,8 @@ export async function trade(
   }
 
   const gasPrice: number = ethereumish.gasPrice;
-  const gasLimit: number = uniswapish.gasLimit;
+  const gasLimit: number = ethereumish.gasLimit;
+  const gasEstimate: number = uniswapish.gasEstimate;
 
   if (req.side === 'BUY') {
     const price: Fractionish =
@@ -263,7 +265,7 @@ export async function trade(
       uniswapish.router,
       uniswapish.ttl,
       uniswapish.routerAbi,
-      uniswapish.gasLimit,
+      gasLimit,
       req.nonce,
       maxFeePerGasBigNumber,
       maxPriorityFeePerGasBigNumber,
@@ -297,7 +299,7 @@ export async function trade(
       gasPrice: gasPrice,
       gasPriceToken: ethereumish.nativeTokenSymbol,
       gasLimit: gasLimit,
-      gasCost: gasCostInEthString(gasPrice, gasLimit),
+      gasCost: gasCostInEthString(gasPrice, gasEstimate),
       nonce: tx.nonce,
       txHash: tx.hash,
     };
@@ -329,7 +331,7 @@ export async function trade(
       uniswapish.router,
       uniswapish.ttl,
       uniswapish.routerAbi,
-      uniswapish.gasLimit,
+      gasLimit,
       req.nonce,
       maxFeePerGasBigNumber,
       maxPriorityFeePerGasBigNumber

--- a/gateway/src/connectors/uniswap/uniswap.controllers.ts
+++ b/gateway/src/connectors/uniswap/uniswap.controllers.ts
@@ -354,7 +354,7 @@ export async function trade(
       gasPrice: gasPrice,
       gasPriceToken: ethereumish.nativeTokenSymbol,
       gasLimit,
-      gasCost: gasCostInEthString(gasPrice, gasLimit),
+      gasCost: gasCostInEthString(gasPrice, gasEstimate),
       nonce: tx.nonce,
       txHash: tx.hash,
     };
@@ -391,7 +391,8 @@ export async function addLiquidity(
   ) as Token;
 
   const gasPrice: number = ethereumish.gasPrice;
-  const gasLimit: number = uniswapish.gasLimit;
+  const gasLimit: number = ethereumish.gasLimit;
+  const gasEstimate: number = uniswapish.gasEstimate;
 
   const invertTokenOrder: boolean = token0.address > token1.address;
 
@@ -427,7 +428,7 @@ export async function addLiquidity(
     gasPrice: gasPrice,
     gasPriceToken: ethereumish.nativeTokenSymbol,
     gasLimit,
-    gasCost: gasCostInEthString(gasPrice, gasLimit),
+    gasCost: gasCostInEthString(gasPrice, gasEstimate),
     nonce: tx.nonce,
     txHash: tx.hash,
   };
@@ -449,7 +450,8 @@ export async function removeLiquidity(
     );
 
   const gasPrice: number = ethereumish.gasPrice;
-  const gasLimit: number = uniswapish.gasLimit;
+  const gasLimit: number = ethereumish.gasLimit;
+  const gasEstimate: number = uniswapish.gasEstimate;
 
   const tx = await uniswapish.reducePosition(
     wallet,
@@ -474,7 +476,7 @@ export async function removeLiquidity(
     gasPrice: gasPrice,
     gasPriceToken: ethereumish.nativeTokenSymbol,
     gasLimit,
-    gasCost: gasCostInEthString(gasPrice, gasLimit),
+    gasCost: gasCostInEthString(gasPrice, gasEstimate),
     nonce: tx.nonce,
     txHash: tx.hash,
   };
@@ -496,7 +498,8 @@ export async function collectEarnedFees(
     );
 
   const gasPrice: number = ethereumish.gasPrice;
-  const gasLimit: number = uniswapish.gasLimit;
+  const gasLimit: number = ethereumish.gasLimit;
+  const gasEstimate: number = uniswapish.gasEstimate;
 
   const tx: Transaction = <Transaction>(
     await uniswapish.collectFees(
@@ -522,7 +525,7 @@ export async function collectEarnedFees(
     gasPrice: gasPrice,
     gasPriceToken: ethereumish.nativeTokenSymbol,
     gasLimit,
-    gasCost: gasCostInEthString(gasPrice, gasLimit),
+    gasCost: gasCostInEthString(gasPrice, gasEstimate),
     nonce: tx.nonce,
     txHash: tx.hash,
   };
@@ -614,13 +617,14 @@ export async function estimateGas(
   uniswapish: Uniswapish
 ): Promise<EstimateGasResponse> {
   const gasPrice: number = ethereumish.gasPrice;
-  const gasLimit: number = uniswapish.gasLimit;
+  const gasLimit: number = ethereumish.gasLimit;
+  const gasEstimate: number = uniswapish.gasEstimate;
   return {
     network: ethereumish.chain,
     timestamp: Date.now(),
     gasPrice,
     gasPriceToken: ethereumish.nativeTokenSymbol,
     gasLimit,
-    gasCost: gasCostInEthString(gasPrice, gasLimit),
+    gasCost: gasCostInEthString(gasPrice, gasEstimate),
   };
 }

--- a/gateway/src/connectors/uniswap/uniswap.lp.ts
+++ b/gateway/src/connectors/uniswap/uniswap.lp.ts
@@ -27,11 +27,11 @@ export type Overrides = {
 
 export class UniswapLP extends UniswapLPHelper implements UniswapLPish {
   private static _instances: { [name: string]: UniswapLP };
-  private _gasLimit: number;
+  private _gasEstimate: number;
 
   private constructor(chain: string, network: string) {
     super(chain, network);
-    this._gasLimit = UniswapConfig.config.gasLimit;
+    this._gasEstimate = UniswapConfig.config.gasEstimate;
   }
 
   public static getInstance(chain: string, network: string): UniswapLP {
@@ -48,8 +48,8 @@ export class UniswapLP extends UniswapLPHelper implements UniswapLPish {
   /**
    * Default gas limit for swap transactions.
    */
-  public get gasLimit(): number {
-    return this._gasLimit;
+  public get gasEstimate(): number {
+    return this._gasEstimate;
   }
 
   async getPosition(tokenId: number): Promise<PositionInfo> {
@@ -199,7 +199,7 @@ export class UniswapLP extends UniswapLPHelper implements UniswapLPish {
   async collectFees(
     wallet: Wallet | providers.StaticJsonRpcProvider,
     tokenId: number,
-    gasLimit: number = this.gasLimit,
+    gasLimit: number = this.gasEstimate,
     gasPrice: number = 0,
     nonce?: number,
     maxFeePerGas?: BigNumber,

--- a/gateway/src/connectors/uniswap/uniswap.ts
+++ b/gateway/src/connectors/uniswap/uniswap.ts
@@ -34,7 +34,7 @@ export class Uniswap implements Uniswapish {
   private _alphaRouter: AlphaRouter;
   private _router: string;
   private _routerAbi: ContractInterface;
-  private _gasLimit: number;
+  private _gasEstimate: number;
   private _ttl: number;
   private _maximumHops: number;
   private chainId;
@@ -53,7 +53,7 @@ export class Uniswap implements Uniswapish {
       provider: this.ethereum.provider,
     });
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = UniswapConfig.config.gasLimit;
+    this._gasEstimate = UniswapConfig.config.gasEstimate;
     this._router = config.uniswapV3SmartOrderRouterAddress(network);
   }
 
@@ -124,8 +124,8 @@ export class Uniswap implements Uniswapish {
   /**
    * Default gas limit for swap transactions.
    */
-  public get gasLimit(): number {
-    return this._gasLimit;
+  public get gasEstimate(): number {
+    return this._gasEstimate;
   }
 
   /**

--- a/gateway/src/services/common-interfaces.ts
+++ b/gateway/src/services/common-interfaces.ts
@@ -217,7 +217,7 @@ export interface UniswapLPish {
   /**
    * Default gas limit for swap transactions.
    */
-  gasLimit: number;
+  gasEstimate: number;
 
   /**
    * Default time-to-live for swap transactions, in seconds.

--- a/gateway/src/services/common-interfaces.ts
+++ b/gateway/src/services/common-interfaces.ts
@@ -99,9 +99,9 @@ export interface Uniswapish {
   abiDecoder?: any;
 
   /**
-   * Default gas limit for swap transactions.
+   * Default gas estiamte for swap transactions.
    */
-  gasLimit: number;
+  gasEstimate: number;
 
   /**
    * Default time-to-live for swap transactions, in seconds.

--- a/gateway/src/services/schema/sushiswap-schema.json
+++ b/gateway/src/services/schema/sushiswap-schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "allowedSlippage": { "type": "string" },
-    "gasLimit": { "type": "integer" },
+    "gasEstimate": { "type": "integer" },
     "ttl": { "type": "integer" },
     "contractAddresses": {
       "type": "object",
@@ -21,5 +21,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["allowedSlippage", "gasLimit", "ttl", "contractAddresses"]
+  "required": ["allowedSlippage", "gasEstimate", "ttl", "contractAddresses"]
 }

--- a/gateway/src/services/schema/traderjoe-schema.json
+++ b/gateway/src/services/schema/traderjoe-schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "allowedSlippage": { "type": "string" },
-    "gasLimit": { "type": "integer" },
+    "gasEstimate": { "type": "integer" },
     "ttl": { "type": "integer" },
     "contractAddresses": {
       "type": "object",
@@ -21,5 +21,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["allowedSlippage", "gasLimit", "ttl", "contractAddresses"]
+  "required": ["allowedSlippage", "gasEstimate", "ttl", "contractAddresses"]
 }

--- a/gateway/src/services/schema/uniswap-schema.json
+++ b/gateway/src/services/schema/uniswap-schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "allowedSlippage": { "type": "string" },
-    "gasLimit": { "type": "integer" },
+    "gasEstimate": { "type": "integer" },
     "ttl": { "type": "integer" },
     "maximumHops": { "type": "integer" },
     "contractAddresses": {
@@ -28,7 +28,7 @@
   "additionalProperties": false,
   "required": [
     "allowedSlippage",
-    "gasLimit",
+    "gasEstimate",
     "ttl",
     "maximumHops",
     "contractAddresses"

--- a/gateway/src/templates/sushiswap.yml
+++ b/gateway/src/templates/sushiswap.yml
@@ -5,7 +5,7 @@ allowedSlippage: '2/100'
 
 # the maximum gas allowed for a unsiwap trade.
 # TODO: find best values for sushi swap
-gasLimit: 150688
+gasEstimate: 150688
 
 # how long a trade is valid in seconds. After time passes sushiswap will not
 # perform the trade, but the gas will still be sent.

--- a/gateway/src/templates/traderjoe.yml
+++ b/gateway/src/templates/traderjoe.yml
@@ -3,7 +3,7 @@
 allowedSlippage: '1/100'
 
 # the maximum gas allowed for a traderjoe trade.
-gasLimit: 150688
+gasEstimate: 150688
 
 # how long a trade is valid in seconds. After time passes traderjoe will not
 # perform the trade, but the gas will still be spent.

--- a/gateway/src/templates/uniswap.yml
+++ b/gateway/src/templates/uniswap.yml
@@ -3,7 +3,7 @@
 allowedSlippage: '2/100'
 
 # the maximum gas allowed for a uniswap trade.
-gasLimit: 150688
+gasEstimate: 150688
 
 # how long a trade is valid in seconds. After time passes uniswap will not
 # perform the trade, but the gas will still be sent.

--- a/gateway/test/chains/ethereum/sushiswap/sushiswap.routes.test.ts
+++ b/gateway/test/chains/ethereum/sushiswap/sushiswap.routes.test.ts
@@ -644,7 +644,7 @@ describe('POST /amm/estimateGas', () => {
         expect(res.body.network).toEqual('kovan');
         expect(res.body.gasPrice).toEqual(100);
         expect(res.body.gasCost).toEqual(
-          gasCostInEthString(100, sushiswap.gasLimit)
+          gasCostInEthString(100, sushiswap.gasEstimate)
         );
       });
   });

--- a/gateway/test/chains/ethereum/uniswap/uniswap.lp.test.ts
+++ b/gateway/test/chains/ethereum/uniswap/uniswap.lp.test.ts
@@ -200,7 +200,7 @@ describe('verify UniswapLP Nft functions', () => {
     patchPoolState();
 
     expect(uniswapLP.ready()).toEqual(true);
-    expect(uniswapLP.gasLimit).toBeGreaterThan(0);
+    expect(uniswapLP.gasEstimate).toBeGreaterThan(0);
     expect(typeof uniswapLP.getContract('nft', ethereum.provider)).toEqual(
       'object'
     );

--- a/gateway/test/chains/ethereum/uniswap/uniswap.routes.test.ts
+++ b/gateway/test/chains/ethereum/uniswap/uniswap.routes.test.ts
@@ -662,7 +662,7 @@ describe('POST /amm/estimateGas', () => {
         expect(res.body.network).toEqual('kovan');
         expect(res.body.gasPrice).toEqual(100);
         expect(res.body.gasCost).toEqual(
-          gasCostInEthString(100, uniswap.gasLimit)
+          gasCostInEthString(100, uniswap.gasEstimate)
         );
       });
   });


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This pr introduces a gasEstimate parameter in most gateway connectors. It also refactors calculation for existing gasCost to (gasPrice * gasEstimate).
[ch27352]


**Tests performed by the developer**:
- Did curl test on price endpoint for uniswap and confirmed gasCost = gasPrice * 150688. 
Note: 105688 is the default gasEstimate for uniswap.


**Tips for QA testing**:
- Perform curl test and confirm that gasCost = gasPrice * gasEstimate.
GasEstimate defaults are in the conf files for each connectors. 

