### PR TITLE
(fix) Fixes a bug with Huobi exchange on trade event update

### DIFF
--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -632,7 +632,7 @@ cdef class HuobiExchange(ExchangeBase):
 
     async def _process_trade_event(self, trade_event: Dict[str, Any]):
         order_id = trade_event["orderId"]
-        client_order_id = trade_event["clientOrderId"]
+        client_order_id = trade_event.get("clientOrderId")
         execute_price = Decimal(trade_event["tradePrice"])
         execute_amount_diff = Decimal(trade_event["tradeVolume"])
 

--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -640,25 +640,24 @@ cdef class HuobiExchange(ExchangeBase):
 
         if tracked_order:
             updated = tracked_order.update_with_trade_update(trade_event)
-        if updated:
-            self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of order "
-                               f"{tracked_order.order_type.name}-{tracked_order.client_order_id}")
-            self.c_trigger_event(self.MARKET_ORDER_FILLED_EVENT_TAG,
-                                 OrderFilledEvent(
-                                     self._current_timestamp,
-                                     tracked_order.client_order_id,
-                                     tracked_order.trading_pair,
-                                     tracked_order.trade_type,
-                                     tracked_order.order_type,
-                                     execute_price,
-                                     execute_amount_diff,
-                                     AddedToCostTradeFee(
-                                         flat_fees=[
-                                             TokenAmount(tracked_order.fee_asset, Decimal(trade_event["transactFee"]))
-                                         ]
-                                     ),
-                                     exchange_trade_id=str(trade_event["tradeId"])
-                                 ))
+            if updated:
+                self.logger().info(f"Filled {execute_amount_diff} out of {tracked_order.amount} of order "
+                                   f"{tracked_order.order_type.name}-{tracked_order.client_order_id}")
+                fee = AddedToCostTradeFee(
+                    flat_fees=[TokenAmount(tracked_order.fee_asset, Decimal(trade_event["transactFee"]))]
+                )
+                self.c_trigger_event(self.MARKET_ORDER_FILLED_EVENT_TAG,
+                                     OrderFilledEvent(
+                                         self._current_timestamp,
+                                         tracked_order.client_order_id,
+                                         tracked_order.trading_pair,
+                                         tracked_order.trade_type,
+                                         tracked_order.order_type,
+                                         execute_price,
+                                         execute_amount_diff,
+                                         fee,
+                                         exchange_trade_id=str(trade_event["tradeId"])
+                                     ))
 
     @property
     def status_dict(self) -> Dict[str, bool]:

--- a/test/hummingbot/connector/exchange/huobi/test_huobi_exchange.py
+++ b/test/hummingbot/connector/exchange/huobi/test_huobi_exchange.py
@@ -6,14 +6,11 @@ from unittest.mock import AsyncMock, patch
 
 from hummingbot.connector.exchange.huobi import huobi_constants as CONSTANTS, huobi_utils
 from hummingbot.connector.exchange.huobi.huobi_exchange import HuobiExchange
-from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.connector.utils import get_new_client_order_id
+from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.core.event.event_logger import EventLogger
-from hummingbot.core.event.events import (
-    MarketEvent,
-    OrderFilledEvent,
-)
+from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
 
 
 class HuobiExchangeTests(TestCase):
@@ -189,6 +186,35 @@ class HuobiExchangeTests(TestCase):
             f"The LIMIT_BUY order {order.client_order_id} has completed according to order delta websocket API."
         ))
 
+        self.assertEqual(0, len(self.buy_order_completed_logger.event_log))
+
+    def test_order_fill_update_event_ignored_for_untracked_orders(self):
+        partial_fill = {
+            "eventType": "trade",
+            "symbol": "choinalphahbot",
+            "orderId": 99998888,
+            "tradePrice": "10050.0",
+            "tradeVolume": "0.1",
+            "orderSide": "buy",
+            "aggressor": True,
+            "tradeId": 1,
+            "tradeTime": 998787897878,
+            "transactFee": "10.00",
+            "feeDeduct ": "0",
+            "feeDeductType": "",
+            "feeCurrency": "usdt",
+            "accountId": 9912791,
+            "source": "spot-api",
+            "orderPrice": "10000",
+            "orderSize": "1",
+            "clientOrderId": "OID1",
+            "orderCreateTime": 998787897878,
+            "orderStatus": "partial-filled"
+        }
+
+        self.async_run_with_timeout(self.exchange._process_trade_event(partial_fill))
+
+        self.assertEqual(0, len(self.order_filled_logger.event_log))
         self.assertEqual(0, len(self.buy_order_completed_logger.event_log))
 
     def test_order_fill_event_processed_before_order_complete_event(self):

--- a/test/hummingbot/connector/exchange/huobi/test_huobi_exchange.py
+++ b/test/hummingbot/connector/exchange/huobi/test_huobi_exchange.py
@@ -207,7 +207,6 @@ class HuobiExchangeTests(TestCase):
             "source": "spot-api",
             "orderPrice": "10000",
             "orderSize": "1",
-            "clientOrderId": "OID1",
             "orderCreateTime": 998787897878,
             "orderStatus": "partial-filled"
         }


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR addresses a bug in Huobi where, on update event of an untracked order, the code will try to reference a variable that is not yet defined.

**Tests performed by the developer**:

- Unit test added to fix this issue.

**Tips for QA testing**:

- To test the fix, start a strategy using Huobi and then place an order on the exchange that will fill. Observe if the strategy fails because of this untracked order. Before doing that, please test this approach on `development`, where the strategy should currently fail.

[ch28706]