### PR TITLE
Fix/Ascendex: Fail to cancel an order due to order status not found

### DIFF
--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -925,15 +925,19 @@ class AscendExExchange(ExchangeBase):
             order_type=order_type,
         )
 
+        trading_rule = self._trading_rules[trading_pair]
+
         if not order_type.is_limit_type():
             self._update_order_after_failure(order_id, trading_pair)
             raise Exception(f"Unsupported order type: {order_type}")
         amount = self.quantize_order_amount(trading_pair, amount)
         price = self.quantize_order_price(trading_pair, price)
         side = "Buy" if trade_type == TradeType.BUY else "Sell"
-        if amount <= s_decimal_0:
+        if amount <= trading_rule.min_order_size:
             self._update_order_after_failure(order_id, trading_pair)
-            self.logger().error(f"{side} order amount {amount} is lower than or equal to the minimum order amount 0")
+            self.logger().error(
+                f"{side} order amount {amount} is lower than the minimum order size "
+                f"{trading_rule.min_order_size}.")
             return
         try:
             timestamp = ascend_ex_utils.get_ms_timestamp()

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -939,11 +939,6 @@ class AscendExExchange(ExchangeBase):
                 f"{side} order amount {amount} is lower than the minimum order size "
                 f"{trading_rule.min_order_size}.")
             return
-        if amount <= s_decimal_0:
-            self._update_order_after_failure(order_id, trading_pair)
-            self.logger().error(
-                f"{side} order amount {amount} is lower than or equal to 0.")
-            return
         try:
             timestamp = ascend_ex_utils.get_ms_timestamp()
             # Order UUID is strictly used to enable AscendEx to construct a unique(still questionable) exchange_order_id

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -933,11 +933,16 @@ class AscendExExchange(ExchangeBase):
         amount = self.quantize_order_amount(trading_pair, amount)
         price = self.quantize_order_price(trading_pair, price)
         side = "Buy" if trade_type == TradeType.BUY else "Sell"
-        if amount <= trading_rule.min_order_size:
+        if amount < trading_rule.min_order_size:
             self._update_order_after_failure(order_id, trading_pair)
             self.logger().error(
                 f"{side} order amount {amount} is lower than the minimum order size "
                 f"{trading_rule.min_order_size}.")
+            return
+        if amount <= s_decimal_0:
+            self._update_order_after_failure(order_id, trading_pair)
+            self.logger().error(
+                f"{side} order amount {amount} is lower than or equal to 0.")
             return
         try:
             timestamp = ascend_ex_utils.get_ms_timestamp()

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -994,11 +994,13 @@ class AscendExExchange(ExchangeBase):
                 self.logger().exception(f"The request to create the order {order_id} failed")
                 self._update_order_after_failure(order_id, trading_pair)
         except asyncio.CancelledError:
+            self._update_order_after_failure(order_id, trading_pair)
             raise
         except Exception:
             msg = (f"Error submitting {trade_type.name} {order_type.name} order to AscendEx for "
                    f"{amount} {trading_pair} {price}.")
             self.logger().exception(msg)
+            self._update_order_after_failure(order_id, trading_pair)
 
     async def _trading_rules_polling_loop(self):
         """

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
@@ -1487,11 +1487,13 @@ class TestAscendExExchange(unittest.TestCase):
         self.assertTrue(
             self._is_logged(
                 "ERROR",
-                "Buy order amount 0 is lower than or equal to the minimum order amount 0"
+                "Buy order amount 0 is lower than the minimum order size 0."
             )
         )
 
     def test_create_order_unsupported_order(self):
+        self._simulate_trading_rules_initialized()
+
         is_exception = False
         exception_msg = ""
 

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
@@ -1474,25 +1474,22 @@ class TestAscendExExchange(unittest.TestCase):
 
         mock_price.return_value = Decimal(98.7)
 
-        is_exception = False
-        exception_msg = ""
-
-        try:
-            self.async_run_with_timeout(self.exchange._create_order(
-                trade_type=TradeType.BUY,
-                order_id="testOrderId1",
-                trading_pair=self.trading_pair,
-                amount=Decimal(0),
-                order_type=OrderType.LIMIT,
-                price=Decimal(99),
-            ))
-        except ValueError as e:
-            is_exception = True
-            exception_msg = str(e)
+        self.async_run_with_timeout(self.exchange._create_order(
+            trade_type=TradeType.BUY,
+            order_id="testOrderId1",
+            trading_pair=self.trading_pair,
+            amount=Decimal(0),
+            order_type=OrderType.LIMIT,
+            price=Decimal(99),
+        ))
 
         self.assertNotIn("testOrderId1", self.exchange.in_flight_orders)
-        self.assertTrue(is_exception)
-        self.assertEqual("Order amount must be greater than zero.", exception_msg)
+        self.assertTrue(
+            self._is_logged(
+                "ERROR",
+                "Buy order amount 0 is lower than or equal to the minimum order amount 0"
+            )
+        )
 
     def test_create_order_unsupported_order(self):
         is_exception = False

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
@@ -112,6 +112,7 @@ class TestAscendExExchange(unittest.TestCase):
                 commission_reserve_rate=Decimal("0.002"),
             ),
         }
+        self.exchange._trading_rules[self.trading_pair].min_order_size = Decimal(str(0.01))
 
     def _create_exception_and_unlock_test_with_event(self, exception):
         self.resume_test_event.set()
@@ -1487,7 +1488,7 @@ class TestAscendExExchange(unittest.TestCase):
         self.assertTrue(
             self._is_logged(
                 "ERROR",
-                "Buy order amount 0 is lower than the minimum order size 0."
+                "Buy order amount 0 is lower than the minimum order size 0.01."
             )
         )
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

If an `create_order()` request results in a failure, the connector should emit an order update to remove it from the In Flight Order Tracker.

**Tests performed by the developer**:

Ran unit tests
I wasn't able to reproduce the problem, but this should fix it.
