### PR TITLE
(fix) `hummingbot_quickstart.py` blocked by confirmation prompt

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -42,7 +42,7 @@ class UIStartListener(EventListener):
         hb: HummingbotApplication = self.hummingbot_app
         if hb.strategy_config_map is not None:
             write_config_to_yml(hb.strategy_config_map, hb.strategy_file_name, hb.client_config_map)
-            hb.start(self._hb_ref.client_config_map.log_level)
+            hb.start(hb.client_config_map.log_level)
 
 
 async def main_async(client_config_map: ClientConfigAdapter):

--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import asyncio
-from typing import Coroutine, List
+from typing import Coroutine, List, Optional
 from weakref import ReferenceType, ref
 
 import path_util  # noqa: F401
@@ -27,9 +27,10 @@ from hummingbot.core.utils.async_utils import safe_gather
 
 
 class UIStartListener(EventListener):
-    def __init__(self, hummingbot_app: HummingbotApplication):
+    def __init__(self, hummingbot_app: HummingbotApplication, is_quickstart: Optional[bool] = False):
         super().__init__()
         self._hb_ref: ReferenceType = ref(hummingbot_app)
+        self._is_quickstart = is_quickstart
 
     def __call__(self, _):
         asyncio.create_task(self.ui_start_handler())
@@ -42,7 +43,8 @@ class UIStartListener(EventListener):
         hb: HummingbotApplication = self.hummingbot_app
         if hb.strategy_config_map is not None:
             write_config_to_yml(hb.strategy_config_map, hb.strategy_file_name, hb.client_config_map)
-            hb.start(hb.client_config_map.log_level)
+            hb.start(log_level=hb.client_config_map.log_level,
+                     is_quickstart=self._is_quickstart)
 
 
 async def main_async(client_config_map: ClientConfigAdapter):

--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -75,7 +75,7 @@ def autofix_permissions(user_group_spec: str):
 
 async def quick_start(args: argparse.Namespace, secrets_manager: BaseSecretsManager):
     config_file_name = args.config_file_name
-    client_config = load_client_config_map_from_file()
+    client_config_map = load_client_config_map_from_file()
 
     if args.auto_set_permissions is not None:
         autofix_permissions(args.auto_set_permissions)
@@ -86,12 +86,12 @@ async def quick_start(args: argparse.Namespace, secrets_manager: BaseSecretsMana
 
     await Security.wait_til_decryption_done()
     await create_yml_files_legacy()
-    init_logging("hummingbot_logs.yml", client_config)
+    init_logging("hummingbot_logs.yml", client_config_map)
     await read_system_configs_from_yml()
 
-    AllConnectorSettings.initialize_paper_trade_settings(client_config.paper_trade.paper_trade_exchanges)
+    AllConnectorSettings.initialize_paper_trade_settings(client_config_map.paper_trade.paper_trade_exchanges)
 
-    hb = HummingbotApplication.main_application(is_quickstart=True)
+    hb = HummingbotApplication.main_application(client_config_map=client_config_map, is_quickstart=True)
     # Todo: validate strategy and config_file_name before assinging
 
     strategy_config = None
@@ -116,8 +116,8 @@ async def quick_start(args: argparse.Namespace, secrets_manager: BaseSecretsMana
     start_listener: UIStartListener = UIStartListener(hb)
     hb.app.add_listener(HummingbotUIEvent.Start, start_listener)
 
-    tasks: List[Coroutine] = [hb.run(), start_existing_gateway_container(client_config)]
-    if client_config.debug_console:
+    tasks: List[Coroutine] = [hb.run(), start_existing_gateway_container(client_config_map)]
+    if client_config_map.debug_console:
         management_port: int = detect_available_port(8211)
         tasks.append(start_management_console(locals(), host="localhost", port=management_port))
 

--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -91,7 +91,7 @@ async def quick_start(args: argparse.Namespace, secrets_manager: BaseSecretsMana
 
     AllConnectorSettings.initialize_paper_trade_settings(client_config.paper_trade.paper_trade_exchanges)
 
-    hb = HummingbotApplication.main_application()
+    hb = HummingbotApplication.main_application(is_quickstart=True)
     # Todo: validate strategy and config_file_name before assinging
 
     strategy_config = None

--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -91,7 +91,7 @@ async def quick_start(args: argparse.Namespace, secrets_manager: BaseSecretsMana
 
     AllConnectorSettings.initialize_paper_trade_settings(client_config_map.paper_trade.paper_trade_exchanges)
 
-    hb = HummingbotApplication.main_application(client_config_map=client_config_map, is_quickstart=True)
+    hb = HummingbotApplication.main_application(client_config_map=client_config_map)
     # Todo: validate strategy and config_file_name before assinging
 
     strategy_config = None
@@ -113,7 +113,7 @@ async def quick_start(args: argparse.Namespace, secrets_manager: BaseSecretsMana
 
     # The listener needs to have a named variable for keeping reference, since the event listener system
     # uses weak references to remove unneeded listeners.
-    start_listener: UIStartListener = UIStartListener(hb)
+    start_listener: UIStartListener = UIStartListener(hb, is_quickstart=True)
     hb.app.add_listener(HummingbotUIEvent.Start, start_listener)
 
     tasks: List[Coroutine] = [hb.run(), start_existing_gateway_container(client_config_map)]

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -142,20 +142,21 @@ class StartCommand(GatewayChainApiManager):
                     wallet_df: pd.DataFrame = pd.DataFrame(data=data, columns=["", f"{connector} configuration"])
                     self.notify(wallet_df.to_string(index=False))
 
-                    self.app.clear_input()
-                    self.placeholder_mode = True
-                    use_configuration = await self.app.prompt(prompt="Do you want to continue? (Yes/No) >>> ")
-                    self.placeholder_mode = False
-                    self.app.change_prompt(prompt=">>> ")
+                    if not self._is_quickstart:
+                        self.app.clear_input()
+                        self.placeholder_mode = True
+                        use_configuration = await self.app.prompt(prompt="Do you want to continue? (Yes/No) >>> ")
+                        self.placeholder_mode = False
+                        self.app.change_prompt(prompt=">>> ")
 
-                    if use_configuration in ["N", "n", "No", "no"]:
-                        self._in_start_check = False
-                        return
+                        if use_configuration in ["N", "n", "No", "no"]:
+                            self._in_start_check = False
+                            return
 
-                    if use_configuration not in ["Y", "y", "Yes", "yes"]:
-                        self.notify("Invalid input. Please execute the `start` command again.")
-                        self._in_start_check = False
-                        return
+                        if use_configuration not in ["Y", "y", "Yes", "yes"]:
+                            self.notify("Invalid input. Please execute the `start` command again.")
+                            self._in_start_check = False
+                            return
 
             # Display custom warning message for specific connectors
             elif warning_msg is not None:

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -46,16 +46,18 @@ class StartCommand(GatewayChainApiManager):
     def start(self,  # type: HummingbotApplication
               log_level: Optional[str] = None,
               restore: Optional[bool] = False,
-              script: Optional[str] = None):
+              script: Optional[str] = None,
+              is_quickstart: Optional[bool] = False):
         if threading.current_thread() != threading.main_thread():
             self.ev_loop.call_soon_threadsafe(self.start, log_level, restore)
             return
-        safe_ensure_future(self.start_check(log_level, restore, script), loop=self.ev_loop)
+        safe_ensure_future(self.start_check(log_level, restore, script, is_quickstart), loop=self.ev_loop)
 
     async def start_check(self,  # type: HummingbotApplication
                           log_level: Optional[str] = None,
                           restore: Optional[bool] = False,
-                          strategy_file_name: Optional[str] = None):
+                          strategy_file_name: Optional[str] = None,
+                          is_quickstart: Optional[bool] = False):
         if self._in_start_check or (self.strategy_task is not None and not self.strategy_task.done()):
             self.notify('The bot is already running - please run "stop" first')
             return
@@ -142,7 +144,7 @@ class StartCommand(GatewayChainApiManager):
                     wallet_df: pd.DataFrame = pd.DataFrame(data=data, columns=["", f"{connector} configuration"])
                     self.notify(wallet_df.to_string(index=False))
 
-                    if not self._is_quickstart:
+                    if not is_quickstart:
                         self.app.clear_input()
                         self.placeholder_mode = True
                         use_configuration = await self.app.prompt(prompt="Do you want to continue? (Yes/No) >>> ")

--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -60,16 +60,15 @@ class HummingbotApplication(*commands):
         return s_logger
 
     @classmethod
-    def main_application(cls, client_config_map: Optional[ClientConfigAdapter] = None, is_quickstart: bool = False) -> "HummingbotApplication":
+    def main_application(cls, client_config_map: Optional[ClientConfigAdapter] = None) -> "HummingbotApplication":
         if cls._main_app is None:
-            cls._main_app = HummingbotApplication(client_config_map, is_quickstart)
+            cls._main_app = HummingbotApplication(client_config_map)
         return cls._main_app
 
-    def __init__(self, client_config_map: Optional[ClientConfigAdapter] = None, is_quickstart: bool = False):
+    def __init__(self, client_config_map: Optional[ClientConfigAdapter] = None):
         self.client_config_map: Union[ClientConfigMap, ClientConfigAdapter] = (  # type-hint enables IDE auto-complete
             client_config_map or load_client_config_map_from_file()
         )
-        self._is_quickstart = is_quickstart
         # This is to start fetching trading pairs for auto-complete
         TradingPairFetcher.get_instance(self.client_config_map)
         self.ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()

--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -60,16 +60,16 @@ class HummingbotApplication(*commands):
         return s_logger
 
     @classmethod
-    def main_application(cls, client_config_map: Optional[ClientConfigAdapter] = None) -> "HummingbotApplication":
+    def main_application(cls, client_config_map: Optional[ClientConfigAdapter] = None, is_quickstart: bool = False) -> "HummingbotApplication":
         if cls._main_app is None:
-            cls._main_app = HummingbotApplication(client_config_map)
+            cls._main_app = HummingbotApplication(client_config_map, is_quickstart)
         return cls._main_app
 
-    def __init__(self, client_config_map: Optional[ClientConfigAdapter] = None):
+    def __init__(self, client_config_map: Optional[ClientConfigAdapter] = None, is_quickstart: bool = False):
         self.client_config_map: Union[ClientConfigMap, ClientConfigAdapter] = (  # type-hint enables IDE auto-complete
             client_config_map or load_client_config_map_from_file()
         )
-
+        self._is_quickstart = is_quickstart
         # This is to start fetching trading pairs for auto-complete
         TradingPairFetcher.get_instance(self.client_config_map)
         self.ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Resolves [sc-27351]

**Tests performed by the developer**:
Add additional initialisation parameter for `HummingbotApplication` that will be used to determine if confirmation prompt is necessary


**Tips for QA testing**:
Running `hummingbot_quickstart.py` with a gateway-supported strategy would no longer be blocked by the confirmation prompt.

