### PR TITLE
Fix/The rate command fails to find a rate for lowercase tickers

### DIFF
--- a/hummingbot/client/command/rate_command.py
+++ b/hummingbot/client/command/rate_command.py
@@ -1,10 +1,9 @@
-from decimal import Decimal
 import threading
-from typing import (
-    TYPE_CHECKING,
-)
-from hummingbot.core.utils.async_utils import safe_ensure_future
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
+from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.exceptions import OracleRateUnavailable
 
 s_float_0 = float(0)
@@ -39,7 +38,6 @@ class RateCommand:
     @staticmethod
     async def oracle_rate_msg(pair: str,
                               ):
-        pair = pair.upper()
         rate = await RateOracle.rate_async(pair)
         if rate is None:
             raise OracleRateUnavailable
@@ -49,7 +47,6 @@ class RateCommand:
     async def show_token_value(self,  # type: HummingbotApplication
                                token: str
                                ):
-        token = token.upper()
         self.notify(f"Source: {RateOracle.source.name}")
         rate = await RateOracle.global_rate(token)
         if rate is None:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Removes forced conversion to uppercase from the Rate command

**Tests performed by the developer**:

Imported a XEMM strategy with the gateway capability and WETH-USDT.e as a taker pair.
The strategy was imported successfully and the conversion rate was found, unlike before.

**Tips for QA testing**:

Test the rate command in general and with the XEMM strategy
Try *.e assets on pangolin / Avalanche 
