### PR TITLE
Fix Cython compilation error in LimitOrder age methods

### DIFF
--- a/hummingbot/core/data_type/limit_order.pxd
+++ b/hummingbot/core/data_type/limit_order.pxd
@@ -6,8 +6,8 @@ from .LimitOrder cimport LimitOrder as CPPLimitOrder
 cdef class LimitOrder:
     cdef:
         CPPLimitOrder _cpp_limit_order
-    cdef long long c_age(self)
-    cdef long long c_age_til(self, long long start_timestamp)
+    cdef double c_age(self)
+    cdef double c_age_til(self, long long start_timestamp)
 
 
 cdef LimitOrder c_create_limit_order_from_cpp_limit_order(const CPPLimitOrder cpp_limit_order)

--- a/hummingbot/core/data_type/limit_order.pyx
+++ b/hummingbot/core/data_type/limit_order.pyx
@@ -39,7 +39,7 @@ cdef class LimitOrder:
             list data = []
             str order_id_txt, type_txt, spread_txt, age_txt, hang_txt
             double price, quantity
-            long long age_seconds
+            double age_seconds
             long long now_timestamp = int(time.time() * 1e6) if end_time_order_age == 0 else end_time_order_age
         sells.extend(buys)
         for order in sells:
@@ -145,7 +145,7 @@ cdef class LimitOrder:
             str retval = cpp_position.decode("utf8")
         return PositionAction(retval)
 
-    cdef long long c_age_til(self, long long end_timestamp):
+    cdef double c_age_til(self, long long end_timestamp):
         """
         Calculates and returns age of the order since it was created til end_timestamp in seconds
         :param end_timestamp: The end timestamp
@@ -159,19 +159,19 @@ cdef class LimitOrder:
         if 0 < start_timestamp < end_timestamp:
             return int(end_timestamp - start_timestamp) / 1e6
         else:
-            return -1
+            return -1.0
 
-    cdef long long c_age(self):
+    cdef double c_age(self):
         """
         Calculates and returns age of the order since it was created til now.
         """
         return self.c_age_til(int(time.time() * 1e6))
 
     def age(self) -> int:
-        return self.c_age()
+        return int(self.c_age())
 
     def age_til(self, start_timestamp: int) -> int:
-        return self.c_age_til(start_timestamp)
+        return int(self.c_age_til(start_timestamp))
 
     def order_type(self) -> OrderType:
         return OrderType.LIMIT


### PR DESCRIPTION
## Description
This PR fixes a Cython compilation error in the LimitOrder class that was preventing successful compilation of the project.

## Problem
The Cython compiler was failing with the error: Cannot convert 'double' to Python object unless type is correctly specified

This occurred in the c_age() and c_age_til() methods of the LimitOrder class, where the return type was declared as long long but the actual calculation returned a double value due to the division by 1e6.

## Solution
- Changed the return type from long long to double for both c_age() and c_age_til() methods in the .pxd file
- Updated the local variable age_seconds declaration from long long to double in the .pyx file
- Fixed the return value in c_age_til() to return -1.0 instead of -1 for type consistency
- Updated the public age() and age_til() methods to cast the double results to int before returning

## Files Changed
- hummingbot/core/data_type/limit_order.pxd
- hummingbot/core/data_type/limit_order.pyx

## Testing
The fix resolves the Cython compilation error while maintaining backward compatibility. The public interface continues to return integers as expected, but the internal calculations now properly handle the floating-point arithmetic.

## Request for Review
Please review this fix for the Cython compilation issue. The changes are minimal and focused on correcting the type declarations to match the actual return types from the calculations.